### PR TITLE
refactor(contracts): define endpoint specifications

### DIFF
--- a/packages/contracts/src/endpoint-spec.ts
+++ b/packages/contracts/src/endpoint-spec.ts
@@ -10,7 +10,9 @@ import {
 } from "./schemas.js";
 import {
   JsonRpcErrorCodes,
+  ReviewLearningRecommendationParamsSchema,
   ReviewLearningRecommendationResultSchema,
+  RollbackTailoringPolicyParamsSchema,
   RollbackTailoringPolicyResultSchema,
   RpcMethods,
   type JsonRpcError,
@@ -80,6 +82,7 @@ type AnyEndpointPath = string | EndpointPath<any, string>;
 export interface RpcEndpointDispatch<
   TRequestSchema extends AnySchema,
   TPathParam,
+  TRpcParamsSchema extends AnySchema,
   TRpcResultSchema extends AnySchema,
 > {
   readonly rpcMethod: RpcMethod;
@@ -89,7 +92,8 @@ export interface RpcEndpointDispatch<
       readonly pathParam: TPathParam;
     },
     context: EndpointDispatchContext,
-  ) => Readonly<Record<string, unknown>>;
+  ) => z.input<TRpcParamsSchema>;
+  readonly paramsSchema: TRpcParamsSchema;
   readonly result: TRpcResultSchema;
   readonly response: (input: {
     readonly request: z.output<TRequestSchema>;
@@ -290,6 +294,7 @@ export const ENDPOINTS = {
         expectedAppDir: context.appDir,
         expectedDbPath: context.dbPath,
       }),
+      paramsSchema: ReviewLearningRecommendationParamsSchema,
       result: ReviewLearningRecommendationResultSchema,
       response: ({ request, pathParam, result }) => {
         if (
@@ -305,6 +310,7 @@ export const ENDPOINTS = {
     } satisfies RpcEndpointDispatch<
       typeof LearningRecommendationReviewRequestSchema,
       string,
+      typeof ReviewLearningRecommendationParamsSchema,
       typeof ReviewLearningRecommendationResultSchema
     >,
     demo: {
@@ -326,6 +332,7 @@ export const ENDPOINTS = {
         expectedAppDir: context.appDir,
         expectedDbPath: context.dbPath,
       }),
+      paramsSchema: RollbackTailoringPolicyParamsSchema,
       result: RollbackTailoringPolicyResultSchema,
       response: ({ request, result }) =>
         result.rollbackOfVersion === request.targetVersion
@@ -347,6 +354,7 @@ export const ENDPOINTS = {
     } satisfies RpcEndpointDispatch<
       typeof TailoringPolicyRollbackRequestSchema,
       undefined,
+      typeof RollbackTailoringPolicyParamsSchema,
       typeof RollbackTailoringPolicyResultSchema
     >,
     demo: {

--- a/packages/contracts/src/endpoint-spec.ts
+++ b/packages/contracts/src/endpoint-spec.ts
@@ -1,0 +1,421 @@
+import { z } from "zod";
+
+import {
+  IsoTimestampSchema,
+  LearningPaginationQuerySchema,
+  LearningRecommendationIdSchema,
+  LearningRecommendationReviewIdSchema,
+  LearningRecommendationSummarySchema,
+  TailoringPolicyLearnedRuleSchema,
+} from "./schemas.js";
+import {
+  JsonRpcErrorCodes,
+  ReviewLearningRecommendationResultSchema,
+  RollbackTailoringPolicyResultSchema,
+  RpcMethods,
+  type JsonRpcError,
+  type RpcMethod,
+} from "./rpc.js";
+
+export const ENDPOINT_HTTP_METHODS = ["GET", "POST", "PATCH", "DELETE"] as const;
+export type EndpointHttpMethod = (typeof ENDPOINT_HTTP_METHODS)[number];
+
+export const ENDPOINT_DEMO_CAPABILITY_CLASSES = [
+  "browser_local",
+  "simulated_async",
+  "rehearsed_external",
+  "unavailable",
+] as const;
+export type EndpointDemoCapabilityClass =
+  (typeof ENDPOINT_DEMO_CAPABILITY_CLASSES)[number];
+
+export interface EndpointDemoCapability {
+  readonly class: EndpointDemoCapabilityClass;
+  readonly reason: string;
+}
+
+export interface EndpointFailureResponse {
+  readonly status: number;
+  readonly error: string;
+  readonly message?: string;
+}
+
+export type EndpointDispatchFailure =
+  | { readonly kind: "transport" }
+  | { readonly kind: "rpc"; readonly error: JsonRpcError }
+  | { readonly kind: "invalid_result" };
+
+export interface EndpointDispatchContext {
+  readonly tenantId: string;
+  readonly appDir: string;
+  readonly dbPath: string;
+}
+
+export interface EndpointPath<TParam, TParamName extends string> {
+  (param: TParam): string;
+  readonly route: string;
+  readonly paramName: TParamName;
+  readonly paramSchema: z.ZodType<TParam>;
+  readonly invalid: EndpointFailureResponse;
+}
+
+export function defineEndpointPath<const TParamName extends string, TParam>(options: {
+  readonly route: string;
+  readonly paramName: TParamName;
+  readonly paramSchema: z.ZodType<TParam>;
+  readonly invalid: EndpointFailureResponse;
+  readonly build: (param: TParam) => string;
+}): EndpointPath<TParam, TParamName> {
+  return Object.assign(options.build, {
+    route: options.route,
+    paramName: options.paramName,
+    paramSchema: options.paramSchema,
+    invalid: options.invalid,
+  });
+}
+
+type AnySchema = z.ZodType;
+type AnyEndpointPath = string | EndpointPath<any, string>;
+
+export interface RpcEndpointDispatch<
+  TRequestSchema extends AnySchema,
+  TPathParam,
+  TRpcResultSchema extends AnySchema,
+> {
+  readonly rpcMethod: RpcMethod;
+  readonly params: (
+    input: {
+      readonly request: z.output<TRequestSchema>;
+      readonly pathParam: TPathParam;
+    },
+    context: EndpointDispatchContext,
+  ) => Readonly<Record<string, unknown>>;
+  readonly result: TRpcResultSchema;
+  readonly response: (input: {
+    readonly request: z.output<TRequestSchema>;
+    readonly pathParam: TPathParam;
+    readonly result: z.output<TRpcResultSchema>;
+  }) => unknown | null;
+  readonly error: (failure: EndpointDispatchFailure) => EndpointFailureResponse;
+}
+
+export interface EndpointDefinition<
+  TName extends string,
+  TMethod extends EndpointHttpMethod,
+  TPath extends AnyEndpointPath,
+  TRequestSchema extends AnySchema,
+  TResponseSchema extends AnySchema,
+  TDispatch = undefined,
+> {
+  readonly name: TName;
+  readonly method: TMethod;
+  readonly path: TPath;
+  readonly request: TRequestSchema;
+  readonly response: TResponseSchema;
+  readonly dispatch?: TDispatch;
+  readonly demo: EndpointDemoCapability;
+}
+
+export function defineEndpoint<
+  const TName extends string,
+  const TMethod extends EndpointHttpMethod,
+  const TPath extends AnyEndpointPath,
+  TRequestSchema extends AnySchema,
+  TResponseSchema extends AnySchema,
+  const TDispatch = undefined,
+>(
+  definition: EndpointDefinition<
+    TName,
+    TMethod,
+    TPath,
+    TRequestSchema,
+    TResponseSchema,
+    TDispatch
+  >,
+): EndpointDefinition<
+  TName,
+  TMethod,
+  TPath,
+  TRequestSchema,
+  TResponseSchema,
+  TDispatch
+> {
+  return definition;
+}
+
+export const LearningRecommendationListQuerySchema = LearningPaginationQuerySchema;
+export type LearningRecommendationListQuery = z.output<
+  typeof LearningPaginationQuerySchema
+>;
+
+const LearningRecommendationsRequestSchema =
+  LearningRecommendationListQuerySchema.optional();
+
+export const LearningRecommendationListResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    recommendations: z.array(LearningRecommendationSummarySchema).max(100),
+    page: z.number().int().min(1),
+    pageSize: z.number().int().min(1).max(100),
+    total: z.number().int().nonnegative(),
+    totalPages: z.number().int().nonnegative(),
+  })
+  .strict()
+  .refine(
+    (value) => value.recommendations.length <= value.pageSize,
+    "Recommendation page exceeds its declared page size.",
+  );
+export type LearningRecommendationListResponse = z.infer<
+  typeof LearningRecommendationListResponseSchema
+>;
+
+export const LearningRecommendationReviewRequestSchema = z.discriminatedUnion("decision", [
+  z.object({ decision: z.literal("accepted") }).strict(),
+  z.object({ decision: z.literal("rejected") }).strict(),
+]);
+export type LearningRecommendationReviewRequest = z.infer<
+  typeof LearningRecommendationReviewRequestSchema
+>;
+
+const LearningRecommendationReviewResponseBaseSchema = z
+  .object({
+    ok: z.literal(true),
+    reviewId: LearningRecommendationReviewIdSchema,
+    recommendationId: LearningRecommendationIdSchema,
+    revision: z.number().int().positive(),
+    context: z.literal("materials"),
+    policyKind: z.literal("tailoring_rule"),
+    reviewedAt: IsoTimestampSchema,
+  })
+  .strict();
+
+export const LearningRecommendationReviewResponseSchema = z.discriminatedUnion("decision", [
+  LearningRecommendationReviewResponseBaseSchema.extend({
+    decision: z.literal("accepted"),
+    policyVersion: z.number().int().positive(),
+  }),
+  LearningRecommendationReviewResponseBaseSchema.extend({
+    decision: z.literal("rejected"),
+    policyVersion: z.null(),
+  }),
+]);
+export type LearningRecommendationReviewResponse = z.infer<
+  typeof LearningRecommendationReviewResponseSchema
+>;
+
+export const TailoringPolicyRollbackRequestSchema = z
+  .object({ targetVersion: z.number().int().positive() })
+  .strict();
+export type TailoringPolicyRollbackRequest = z.infer<
+  typeof TailoringPolicyRollbackRequestSchema
+>;
+
+export const TailoringPolicyRollbackResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    context: z.literal("materials"),
+    policyKind: z.literal("tailoring_rule"),
+    version: z.number().int().positive(),
+    status: z.literal("current"),
+    learnedRules: z.array(TailoringPolicyLearnedRuleSchema).max(5),
+    sourceReviewId: z.null(),
+    sourceRecommendationId: z.null(),
+    rollbackOfVersion: z.number().int().positive(),
+    rollbackReasonCode: z.literal("user_requested"),
+    createdAt: IsoTimestampSchema,
+  })
+  .strict();
+export type TailoringPolicyRollbackResponse = z.infer<
+  typeof TailoringPolicyRollbackResponseSchema
+>;
+
+const recommendationReviewPath = defineEndpointPath({
+  route: "/v1/learning/recommendations/:recommendationId/reviews",
+  paramName: "recommendationId",
+  paramSchema: LearningRecommendationIdSchema,
+  invalid: {
+    status: 400,
+    error: "invalid_learning_recommendation_id",
+  },
+  build: (recommendationId: string) =>
+    `/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/reviews`,
+});
+
+const reviewFailure = (failure: EndpointDispatchFailure): EndpointFailureResponse => ({
+  status:
+    failure.kind === "transport"
+      ? 503
+      : failure.kind === "rpc" && failure.error.code === JsonRpcErrorCodes.InvalidParams
+        ? 409
+        : 502,
+  error: "learning_recommendation_review_failed",
+  message: "The learning recommendation review could not be completed.",
+});
+
+const rollbackFailure = (failure: EndpointDispatchFailure): EndpointFailureResponse => ({
+  status:
+    failure.kind === "transport"
+      ? 503
+      : failure.kind === "rpc" && failure.error.code === JsonRpcErrorCodes.InvalidParams
+        ? 409
+        : 502,
+  error: "tailoring_policy_rollback_failed",
+  message: "The tailoring policy rollback could not be completed.",
+});
+
+export const ENDPOINTS = {
+  learningRecommendations: defineEndpoint({
+    name: "learningRecommendations",
+    method: "GET",
+    path: "/v1/learning/recommendations",
+    request: LearningRecommendationsRequestSchema,
+    response: LearningRecommendationListResponseSchema,
+    demo: {
+      class: "unavailable",
+      reason: "Learning recommendations require the local audited database.",
+    },
+  }),
+  reviewLearningRecommendation: defineEndpoint({
+    name: "reviewLearningRecommendation",
+    method: "POST",
+    path: recommendationReviewPath,
+    request: LearningRecommendationReviewRequestSchema,
+    response: LearningRecommendationReviewResponseSchema,
+    dispatch: {
+      rpcMethod: RpcMethods.ReviewLearningRecommendation,
+      params: ({ request, pathParam }, context) => ({
+        tenantId: context.tenantId,
+        recommendationId: pathParam,
+        decision: request.decision,
+        expectedAppDir: context.appDir,
+        expectedDbPath: context.dbPath,
+      }),
+      result: ReviewLearningRecommendationResultSchema,
+      response: ({ request, pathParam, result }) => {
+        if (
+          result.recommendationId !== pathParam ||
+          result.decision !== request.decision
+        ) {
+          return null;
+        }
+        const { status: _status, ...review } = result;
+        return { ok: true, ...review };
+      },
+      error: reviewFailure,
+    } satisfies RpcEndpointDispatch<
+      typeof LearningRecommendationReviewRequestSchema,
+      string,
+      typeof ReviewLearningRecommendationResultSchema
+    >,
+    demo: {
+      class: "unavailable",
+      reason: "Learning recommendation review requires the local audited database.",
+    },
+  }),
+  rollbackTailoringPolicy: defineEndpoint({
+    name: "rollbackTailoringPolicy",
+    method: "POST",
+    path: "/v1/learning/policies/materials/rollbacks",
+    request: TailoringPolicyRollbackRequestSchema,
+    response: TailoringPolicyRollbackResponseSchema,
+    dispatch: {
+      rpcMethod: RpcMethods.RollbackTailoringPolicy,
+      params: ({ request }, context) => ({
+        tenantId: context.tenantId,
+        targetVersion: request.targetVersion,
+        expectedAppDir: context.appDir,
+        expectedDbPath: context.dbPath,
+      }),
+      result: RollbackTailoringPolicyResultSchema,
+      response: ({ request, result }) =>
+        result.rollbackOfVersion === request.targetVersion
+          ? {
+              ok: true,
+              context: result.context,
+              policyKind: result.policyKind,
+              version: result.policyVersion,
+              status: "current",
+              learnedRules: result.learnedRules,
+              sourceReviewId: null,
+              sourceRecommendationId: null,
+              rollbackOfVersion: result.rollbackOfVersion,
+              rollbackReasonCode: result.rollbackReasonCode,
+              createdAt: result.rolledBackAt,
+            }
+          : null,
+      error: rollbackFailure,
+    } satisfies RpcEndpointDispatch<
+      typeof TailoringPolicyRollbackRequestSchema,
+      undefined,
+      typeof RollbackTailoringPolicyResultSchema
+    >,
+    demo: {
+      class: "unavailable",
+      reason: "Tailoring policy rollback requires the local audited database.",
+    },
+  }),
+} as const;
+
+export type EndpointRegistry = typeof ENDPOINTS;
+export type EndpointSpec = EndpointRegistry[keyof EndpointRegistry];
+
+export type EndpointByName<TName extends EndpointSpec["name"]> = Extract<
+  EndpointSpec,
+  { readonly name: TName }
+>;
+
+export type EndpointRequest<TEndpoint extends EndpointSpec> = z.output<
+  TEndpoint["request"]
+>;
+export type EndpointRequestInput<TEndpoint extends EndpointSpec> = z.input<
+  TEndpoint["request"]
+>;
+export type EndpointResponse<TEndpoint extends EndpointSpec> = z.output<
+  TEndpoint["response"]
+>;
+export type EndpointPathParam<TEndpoint extends EndpointSpec> =
+  TEndpoint["path"] extends EndpointPath<infer TParam, string> ? TParam : undefined;
+
+type EndpointPathArguments<TEndpoint extends EndpointSpec> =
+  TEndpoint["path"] extends EndpointPath<infer TParam, string>
+    ? readonly [pathParam: TParam]
+    : readonly [];
+
+type EndpointRequestArguments<TEndpoint extends EndpointSpec> =
+  undefined extends EndpointRequestInput<TEndpoint>
+    ? readonly [request?: Exclude<EndpointRequestInput<TEndpoint>, undefined>]
+    : readonly [request: EndpointRequestInput<TEndpoint>];
+
+export type EndpointClientMethod<TEndpoint extends EndpointSpec> = (
+  ...args: [
+    ...EndpointPathArguments<TEndpoint>,
+    ...EndpointRequestArguments<TEndpoint>,
+  ]
+) => Promise<EndpointResponse<TEndpoint>>;
+
+export type EndpointClientMethods = {
+  [TEndpoint in EndpointSpec as TEndpoint["name"]]: EndpointClientMethod<TEndpoint>;
+};
+
+export const ENDPOINT_SPEC_FIXTURE_SCHEMA_VERSION = 1 as const;
+
+export function endpointSpecJsonSchemaFixture() {
+  return {
+    schemaVersion: ENDPOINT_SPEC_FIXTURE_SCHEMA_VERSION,
+    endpoints: Object.fromEntries(
+      Object.values(ENDPOINTS).map((endpoint) => [
+        endpoint.name,
+        {
+          request: z.toJSONSchema(endpoint.request, {
+            io: "input",
+            unrepresentable: "any",
+          }),
+          response: z.toJSONSchema(endpoint.response, {
+            io: "input",
+            unrepresentable: "any",
+          }),
+        },
+      ]),
+    ),
+  };
+}

--- a/packages/contracts/src/endpoint-spec.ts
+++ b/packages/contracts/src/endpoint-spec.ts
@@ -1,11 +1,19 @@
 import { z } from "zod";
 
 import {
+  APPLICATION_OUTCOME_KINDS,
   IsoTimestampSchema,
   LearningPaginationQuerySchema,
   LearningRecommendationIdSchema,
   LearningRecommendationReviewIdSchema,
   LearningRecommendationSummarySchema,
+  RESUME_COMMENT_REPLY_DECISIONS,
+  RESUME_COMMENT_THREAD_STATES,
+  RESUME_REVIEW_DRAFT_STATES,
+  RESUME_REVIEW_EDIT_KINDS,
+  TAILORING_FEEDBACK_SIGNAL_KINDS,
+  TAILORING_FEEDBACK_SIGNAL_STATUSES,
+  TAILORING_FEEDBACK_SOURCE_KINDS,
   TailoringPolicyLearnedRuleSchema,
 } from "./schemas.js";
 import {
@@ -115,6 +123,8 @@ interface EndpointDefinitionBase<
   readonly path: TPath;
   readonly request: TRequestSchema;
   readonly response: TResponseSchema;
+  /** Indirect worker calls owned by an injected handler rather than this HTTP shell. */
+  readonly rpcDependencies?: readonly RpcMethod[];
   readonly demo: EndpointDemoCapability;
 }
 
@@ -251,6 +261,230 @@ export type TailoringPolicyRollbackResponse = z.infer<
   typeof TailoringPolicyRollbackResponseSchema
 >;
 
+export const ResumeReviewDraftRenderRequestSchema = z
+  .object({
+    draftRevisionId: z.string().trim().min(1).max(160).optional(),
+  })
+  .strict();
+export type ResumeReviewDraftRenderRequest = z.infer<
+  typeof ResumeReviewDraftRenderRequestSchema
+>;
+
+const ResumeLineAnchorResponseSchema = z
+  .object({
+    semanticId: z.string().nullable(),
+    lineNumber: z.number().int().nullable(),
+    pageNumber: z.number().int().nullable(),
+    textHash: z.string().nullable(),
+  })
+  .strict();
+
+const ResumeReviewEditDeltaResponseSchema = z
+  .object({
+    deltaId: z.string(),
+    revisionId: z.string(),
+    kind: z.enum(RESUME_REVIEW_EDIT_KINDS),
+    section: z.string().nullable(),
+    semanticId: z.string().nullable(),
+    lineAnchor: ResumeLineAnchorResponseSchema.nullable(),
+    beforeText: z.string(),
+    afterText: z.string(),
+    createdAt: IsoTimestampSchema,
+  })
+  .strict();
+
+const ResumeReviewDraftRevisionResponseSchema = z
+  .object({
+    revisionId: z.string(),
+    draftId: z.string(),
+    jobKey: z.string(),
+    revisionNumber: z.number().int().nonnegative(),
+    editedText: z.string(),
+    plateDocument: z.unknown().nullable(),
+    editDeltas: z.array(ResumeReviewEditDeltaResponseSchema),
+    createdAt: IsoTimestampSchema,
+  })
+  .strict();
+
+const ResumeCommentReplyResponseSchema = z
+  .object({
+    replyId: z.string(),
+    threadId: z.string(),
+    draftRevisionId: z.string().nullable(),
+    author: z.string(),
+    decision: z.enum(RESUME_COMMENT_REPLY_DECISIONS),
+    body: z.string(),
+    createdAt: IsoTimestampSchema,
+  })
+  .strict();
+
+const ResumeCommentThreadResponseSchema = z
+  .object({
+    threadId: z.string(),
+    draftId: z.string(),
+    jobKey: z.string(),
+    baseArtifactId: z.string().nullable(),
+    semanticId: z.string().nullable(),
+    lineAnchor: ResumeLineAnchorResponseSchema.nullable(),
+    sourcePinId: z.string().nullable(),
+    riskLabel: z.string().nullable(),
+    commentBody: z.string(),
+    state: z.enum(RESUME_COMMENT_THREAD_STATES),
+    anchorResolved: z.boolean(),
+    createdAt: IsoTimestampSchema,
+    updatedAt: IsoTimestampSchema,
+    replies: z.array(ResumeCommentReplyResponseSchema),
+  })
+  .strict();
+
+const TailoringFeedbackSignalResponseSchema = z
+  .object({
+    signalId: z.string(),
+    jobKey: z.string(),
+    draftId: z.string(),
+    draftRevisionId: z.string().nullable(),
+    sourceKind: z.enum(TAILORING_FEEDBACK_SOURCE_KINDS),
+    sourceId: z.string(),
+    kind: z.enum(TAILORING_FEEDBACK_SIGNAL_KINDS),
+    status: z.enum(TAILORING_FEEDBACK_SIGNAL_STATUSES),
+    summary: z.string(),
+    section: z.string().nullable(),
+    semanticId: z.string().nullable(),
+    createdAt: IsoTimestampSchema,
+    reviewedAt: IsoTimestampSchema.nullable(),
+  })
+  .strict();
+
+const ResumeReviewDraftResponseSchema = z
+  .object({
+    draftId: z.string(),
+    jobKey: z.string(),
+    baseGeneration: z.number().int().nonnegative(),
+    baseResumeTextArtifactId: z.string().nullable(),
+    baseResumePdfArtifactId: z.string().nullable(),
+    rendererFormat: z.string(),
+    state: z.enum(RESUME_REVIEW_DRAFT_STATES),
+    currentRevisionId: z.string().nullable(),
+    latestRevisionNumber: z.number().int().nonnegative(),
+    createdAt: IsoTimestampSchema,
+    updatedAt: IsoTimestampSchema,
+    latestRevision: ResumeReviewDraftRevisionResponseSchema.nullable(),
+    commentThreads: z.array(ResumeCommentThreadResponseSchema),
+    feedbackSignals: z.array(TailoringFeedbackSignalResponseSchema),
+  })
+  .strict();
+
+export const ResumeReviewDraftValidationResultSchema = z
+  .object({
+    passed: z.boolean(),
+    errors: z.array(z.string()),
+    warnings: z.array(z.string()),
+  })
+  .strict();
+export type ResumeReviewDraftValidationResult = z.infer<
+  typeof ResumeReviewDraftValidationResultSchema
+>;
+
+export const ResumeReviewRenderedArtifactSchema = z
+  .object({
+    artifactId: z.string(),
+    artifactType: z.enum(["tailored_resume", "resume_pdf"]),
+    generation: z.number().int().nonnegative(),
+    renderFormat: z.enum(["text", "html_pdf"]),
+  })
+  .strict();
+export type ResumeReviewRenderedArtifact = z.infer<
+  typeof ResumeReviewRenderedArtifactSchema
+>;
+
+export const ResumeReviewDraftRenderResponseSchema = z.discriminatedUnion("ok", [
+  z
+    .object({
+      ok: z.literal(true),
+      draft: ResumeReviewDraftResponseSchema,
+      validation: ResumeReviewDraftValidationResultSchema,
+      artifacts: z
+        .object({
+          resumeText: ResumeReviewRenderedArtifactSchema,
+          resumePdf: ResumeReviewRenderedArtifactSchema,
+        })
+        .strict(),
+      layoutBoxCount: z.number().int().nonnegative(),
+    })
+    .strict(),
+  z
+    .object({
+      ok: z.literal(false),
+      error: z.literal("resume_review_draft_invalid"),
+      draft: ResumeReviewDraftResponseSchema,
+      validation: ResumeReviewDraftValidationResultSchema,
+    })
+    .strict(),
+]);
+export type ResumeReviewDraftRenderResponse = z.infer<
+  typeof ResumeReviewDraftRenderResponseSchema
+>;
+
+export const GmailOutcomeScanRequestSchema = z
+  .object({
+    recipientEmail: z.string().trim().email().optional(),
+    limit: z.coerce.number().int().min(1).max(100).default(25),
+    maxResultsPerAnchor: z.coerce.number().int().min(1).max(20).default(5),
+    windowDays: z.coerce.number().int().min(1).max(180).default(45),
+  })
+  .strict();
+export type GmailOutcomeScanRequest = z.input<typeof GmailOutcomeScanRequestSchema>;
+
+export const GmailOutcomeScanEvidenceSummarySchema = z
+  .object({
+    evidenceId: z.string(),
+    jobKey: z.string(),
+    providerMessageId: z.string(),
+    linkConfidence: z.number(),
+  })
+  .strict();
+export type GmailOutcomeScanEvidenceSummary = z.infer<
+  typeof GmailOutcomeScanEvidenceSummarySchema
+>;
+
+export const GmailOutcomeScanSuggestionSummarySchema = z
+  .object({
+    suggestionId: z.string(),
+    evidenceId: z.string(),
+    jobKey: z.string(),
+    kind: z.enum(APPLICATION_OUTCOME_KINDS),
+    confidence: z.number(),
+  })
+  .strict();
+export type GmailOutcomeScanSuggestionSummary = z.infer<
+  typeof GmailOutcomeScanSuggestionSummarySchema
+>;
+
+export const GmailOutcomeScanResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    scannedAnchorCount: z.number(),
+    searchedMessageCount: z.number(),
+    linkedEvidenceCount: z.number(),
+    suggestionsCreatedCount: z.number(),
+    duplicateMessageCount: z.number(),
+    unlinkedCandidateCount: z.number(),
+    evidence: z.array(GmailOutcomeScanEvidenceSummarySchema),
+    suggestions: z.array(GmailOutcomeScanSuggestionSummarySchema),
+  })
+  .strict();
+export type GmailOutcomeScanResponse = z.infer<
+  typeof GmailOutcomeScanResponseSchema
+>;
+
+const RenderResumeReviewDraftRequestSchema =
+  ResumeReviewDraftRenderRequestSchema.optional().transform((request) => request ?? {});
+
+const ScanGmailApplicationOutcomesRequestSchema =
+  GmailOutcomeScanRequestSchema.optional().transform((request) =>
+    GmailOutcomeScanRequestSchema.parse(request ?? {}),
+  );
+
 const recommendationReviewPath = defineEndpointPath({
   route: "/v1/learning/recommendations/:recommendationId/reviews",
   paramName: "recommendationId",
@@ -261,6 +495,18 @@ const recommendationReviewPath = defineEndpointPath({
   },
   build: (recommendationId: string) =>
     `/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/reviews`,
+});
+
+const resumeReviewDraftRenderPath = defineEndpointPath({
+  route: "/v1/resume-review/drafts/:draftId/render",
+  paramName: "draftId",
+  paramSchema: z.string(),
+  invalid: {
+    status: 400,
+    error: "invalid_resume_review_draft_id",
+  },
+  build: (draftId: string) =>
+    `/v1/resume-review/drafts/${encodeURIComponent(draftId)}/render`,
 });
 
 const reviewFailure = (failure: EndpointDispatchFailure): EndpointFailureResponse => ({
@@ -378,6 +624,30 @@ export const ENDPOINTS = {
     demo: {
       class: "unavailable",
       reason: "Tailoring policy rollback requires the local audited database.",
+    },
+  }),
+  renderResumeReviewDraft: defineEndpoint({
+    name: "renderResumeReviewDraft",
+    method: "POST",
+    path: resumeReviewDraftRenderPath,
+    request: RenderResumeReviewDraftRequestSchema,
+    response: ResumeReviewDraftRenderResponseSchema,
+    rpcDependencies: [RpcMethods.RenderResumePdf],
+    demo: {
+      class: "unavailable",
+      reason: "Draft rendering is deferred from the public-demo MVP.",
+    },
+  }),
+  scanGmailApplicationOutcomes: defineEndpoint({
+    name: "scanGmailApplicationOutcomes",
+    method: "POST",
+    path: "/v1/outcomes/gmail/scan",
+    request: ScanGmailApplicationOutcomesRequestSchema,
+    response: GmailOutcomeScanResponseSchema,
+    rpcDependencies: [RpcMethods.GmailFeedbackScan],
+    demo: {
+      class: "unavailable",
+      reason: "Gmail outcome scanning requires the local authenticated mailbox.",
     },
   }),
 } as const;

--- a/packages/contracts/src/endpoint-spec.ts
+++ b/packages/contracts/src/endpoint-spec.ts
@@ -103,22 +103,38 @@ export interface RpcEndpointDispatch<
   readonly error: (failure: EndpointDispatchFailure) => EndpointFailureResponse;
 }
 
-export interface EndpointDefinition<
+interface EndpointDefinitionBase<
   TName extends string,
   TMethod extends EndpointHttpMethod,
   TPath extends AnyEndpointPath,
   TRequestSchema extends AnySchema,
   TResponseSchema extends AnySchema,
-  TDispatch = undefined,
 > {
   readonly name: TName;
   readonly method: TMethod;
   readonly path: TPath;
   readonly request: TRequestSchema;
   readonly response: TResponseSchema;
-  readonly dispatch?: TDispatch;
   readonly demo: EndpointDemoCapability;
 }
+
+export type EndpointDefinition<
+  TName extends string,
+  TMethod extends EndpointHttpMethod,
+  TPath extends AnyEndpointPath,
+  TRequestSchema extends AnySchema,
+  TResponseSchema extends AnySchema,
+  TDispatch = undefined,
+> = EndpointDefinitionBase<
+  TName,
+  TMethod,
+  TPath,
+  TRequestSchema,
+  TResponseSchema
+> &
+  ([TDispatch] extends [undefined]
+    ? { readonly dispatch?: never }
+    : { readonly dispatch: TDispatch });
 
 export function defineEndpoint<
   const TName extends string,
@@ -153,7 +169,9 @@ export type LearningRecommendationListQuery = z.output<
 >;
 
 const LearningRecommendationsRequestSchema =
-  LearningRecommendationListQuerySchema.optional();
+  LearningRecommendationListQuerySchema.optional().transform(
+    (query) => query ?? LearningRecommendationListQuerySchema.parse({}),
+  );
 
 export const LearningRecommendationListResponseSchema = z
   .object({

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./schemas.js";
 export * from "./rpc.js";
+export * from "./endpoint-spec.js";
 export * from "./demo-fixture-contract.js";
 export * from "./jobs-query.js";
 

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -1243,15 +1243,6 @@ export type ResumeReviewCommentThreadSeedRequest = z.infer<
   typeof ResumeReviewCommentThreadSeedRequestSchema
 >;
 
-export const ResumeReviewDraftRenderRequestSchema = z
-  .object({
-    draftRevisionId: z.string().trim().min(1).max(160).optional(),
-  })
-  .strict();
-export type ResumeReviewDraftRenderRequest = z.infer<
-  typeof ResumeReviewDraftRenderRequestSchema
->;
-
 export const ResumeCommentReplyRequestSchema = z
   .object({
     draftRevisionId: z.string().trim().min(1).max(160).optional(),
@@ -1287,37 +1278,6 @@ export interface ResumeCommentReplyResponse {
   reply: ResumeCommentReply;
   feedbackSignal: TailoringFeedbackSignal;
 }
-
-export interface ResumeReviewDraftValidationResult {
-  passed: boolean;
-  errors: string[];
-  warnings: string[];
-}
-
-export interface ResumeReviewRenderedArtifact {
-  artifactId: string;
-  artifactType: "tailored_resume" | "resume_pdf";
-  generation: number;
-  renderFormat: "text" | "html_pdf";
-}
-
-export type ResumeReviewDraftRenderResponse =
-  | {
-      ok: true;
-      draft: ResumeReviewDraft;
-      validation: ResumeReviewDraftValidationResult;
-      artifacts: {
-        resumeText: ResumeReviewRenderedArtifact;
-        resumePdf: ResumeReviewRenderedArtifact;
-      };
-      layoutBoxCount: number;
-    }
-  | {
-      ok: false;
-      error: "resume_review_draft_invalid";
-      draft: ResumeReviewDraft;
-      validation: ResumeReviewDraftValidationResult;
-    };
 
 export interface ResumeReviewFeedbackListResponse {
   ok: true;
@@ -1474,43 +1434,6 @@ export interface ApplicationOutcomeListResponse {
 
 export interface JobApplicationOutcomeListResponse extends ApplicationOutcomeListResponse {
   jobKey: string;
-}
-
-export const GmailOutcomeScanRequestSchema = z
-  .object({
-    recipientEmail: z.string().trim().email().optional(),
-    limit: z.coerce.number().int().min(1).max(100).default(25),
-    maxResultsPerAnchor: z.coerce.number().int().min(1).max(20).default(5),
-    windowDays: z.coerce.number().int().min(1).max(180).default(45),
-  })
-  .strict();
-export type GmailOutcomeScanRequest = z.input<typeof GmailOutcomeScanRequestSchema>;
-
-export interface GmailOutcomeScanEvidenceSummary {
-  evidenceId: string;
-  jobKey: string;
-  providerMessageId: string;
-  linkConfidence: number;
-}
-
-export interface GmailOutcomeScanSuggestionSummary {
-  suggestionId: string;
-  evidenceId: string;
-  jobKey: string;
-  kind: ApplicationOutcomeKind;
-  confidence: number;
-}
-
-export interface GmailOutcomeScanResponse {
-  ok: true;
-  scannedAnchorCount: number;
-  searchedMessageCount: number;
-  linkedEvidenceCount: number;
-  suggestionsCreatedCount: number;
-  duplicateMessageCount: number;
-  unlinkedCandidateCount: number;
-  evidence: GmailOutcomeScanEvidenceSummary[];
-  suggestions: GmailOutcomeScanSuggestionSummary[];
 }
 
 export const RunPipelineStagesRequestSchema = z

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -184,7 +184,7 @@ const optionalText = z
   .transform((value) => value ?? "");
 
 const optionalNumber = z.coerce.number().int().optional().catch(undefined);
-const IsoTimestampSchema = z
+export const IsoTimestampSchema = z
   .string()
   .trim()
   .min(1)
@@ -2211,40 +2211,6 @@ export const LearningRecommendationReviewIdSchema = z
   .string()
   .regex(/^learning-recommendation-review:[a-f0-9]{64}$/);
 
-export const LearningRecommendationReviewRequestSchema = z.discriminatedUnion("decision", [
-  z.object({ decision: z.literal("accepted") }).strict(),
-  z.object({ decision: z.literal("rejected") }).strict(),
-]);
-export type LearningRecommendationReviewRequest = z.infer<
-  typeof LearningRecommendationReviewRequestSchema
->;
-
-const LearningRecommendationReviewResponseBaseSchema = z
-  .object({
-    ok: z.literal(true),
-    reviewId: LearningRecommendationReviewIdSchema,
-    recommendationId: LearningRecommendationIdSchema,
-    revision: z.number().int().positive(),
-    context: z.literal("materials"),
-    policyKind: z.literal("tailoring_rule"),
-    reviewedAt: IsoTimestampSchema,
-  })
-  .strict();
-
-export const LearningRecommendationReviewResponseSchema = z.discriminatedUnion("decision", [
-  LearningRecommendationReviewResponseBaseSchema.extend({
-    decision: z.literal("accepted"),
-    policyVersion: z.number().int().positive(),
-  }),
-  LearningRecommendationReviewResponseBaseSchema.extend({
-    decision: z.literal("rejected"),
-    policyVersion: z.null(),
-  }),
-]);
-export type LearningRecommendationReviewResponse = z.infer<
-  typeof LearningRecommendationReviewResponseSchema
->;
-
 const LearningEvidenceIdentifierSchema = z
   .string()
   .min(1)
@@ -2257,7 +2223,7 @@ const LearningEvidenceJobIdSchema = z
     /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/,
   );
 
-export const LearningRecommendationListQuerySchema = z
+export const LearningPaginationQuerySchema = z
   .object({
     page: z.coerce.number().int().min(1).default(1).catch(1),
     pageSize: z.coerce.number().int().min(1).max(100).optional().catch(undefined),
@@ -2267,11 +2233,9 @@ export const LearningRecommendationListQuerySchema = z
     page: value.page,
     pageSize: value.pageSize ?? value.page_size ?? 50,
   }));
-export type LearningRecommendationListQuery = z.infer<
-  typeof LearningRecommendationListQuerySchema
->;
+export type LearningPaginationQuery = z.infer<typeof LearningPaginationQuerySchema>;
 
-export const TailoringPolicyRevisionListQuerySchema = LearningRecommendationListQuerySchema;
+export const TailoringPolicyRevisionListQuerySchema = LearningPaginationQuerySchema;
 export type TailoringPolicyRevisionListQuery = z.infer<
   typeof TailoringPolicyRevisionListQuerySchema
 >;
@@ -2358,32 +2322,6 @@ export type TailoringPolicyRevisionListResponse = z.infer<
   typeof TailoringPolicyRevisionListResponseSchema
 >;
 
-export const TailoringPolicyRollbackRequestSchema = z
-  .object({ targetVersion: z.number().int().positive() })
-  .strict();
-export type TailoringPolicyRollbackRequest = z.infer<
-  typeof TailoringPolicyRollbackRequestSchema
->;
-
-export const TailoringPolicyRollbackResponseSchema = z
-  .object({
-    ok: z.literal(true),
-    context: z.literal("materials"),
-    policyKind: z.literal("tailoring_rule"),
-    version: z.number().int().positive(),
-    status: z.literal("current"),
-    learnedRules: z.array(TailoringPolicyLearnedRuleSchema).max(5),
-    sourceReviewId: z.null(),
-    sourceRecommendationId: z.null(),
-    rollbackOfVersion: z.number().int().positive(),
-    rollbackReasonCode: z.literal("user_requested"),
-    createdAt: IsoTimestampSchema,
-  })
-  .strict();
-export type TailoringPolicyRollbackResponse = z.infer<
-  typeof TailoringPolicyRollbackResponseSchema
->;
-
 export const LearningRecommendationSummarySchema = z
   .object({
     recommendationId: LearningRecommendationIdSchema,
@@ -2418,26 +2356,8 @@ export type LearningRecommendationSummary = z.infer<
   typeof LearningRecommendationSummarySchema
 >;
 
-export const LearningRecommendationListResponseSchema = z
-  .object({
-    ok: z.literal(true),
-    recommendations: z.array(LearningRecommendationSummarySchema).max(100),
-    page: z.number().int().min(1),
-    pageSize: z.number().int().min(1).max(100),
-    total: z.number().int().nonnegative(),
-    totalPages: z.number().int().nonnegative(),
-  })
-  .strict()
-  .refine(
-    (value) => value.recommendations.length <= value.pageSize,
-    "Recommendation page exceeds its declared page size.",
-  );
-export type LearningRecommendationListResponse = z.infer<
-  typeof LearningRecommendationListResponseSchema
->;
-
 export const LearningRecommendationEvidenceListQuerySchema =
-  LearningRecommendationListQuerySchema;
+  LearningPaginationQuerySchema;
 export type LearningRecommendationEvidenceListQuery = z.infer<
   typeof LearningRecommendationEvidenceListQuerySchema
 >;

--- a/packages/domain-types/test/fixtures/endpoint_specs.json
+++ b/packages/domain-types/test/fixtures/endpoint_specs.json
@@ -1,0 +1,528 @@
+{
+  "schemaVersion": 1,
+  "endpoints": {
+    "learningRecommendations": {
+      "request": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "page": {
+            "default": 1,
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 9007199254740991
+          },
+          "pageSize": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "page_size": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          }
+        }
+      },
+      "response": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": true
+          },
+          "recommendations": {
+            "maxItems": 100,
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "recommendationId": {
+                  "type": "string",
+                  "pattern": "^learning-recommendation:[a-f0-9]{64}$"
+                },
+                "derivationVersion": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "evaluationFixtureVersion": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "context": {
+                  "type": "string",
+                  "const": "materials"
+                },
+                "policyKind": {
+                  "type": "string",
+                  "const": "tailoring_rule"
+                },
+                "signalKind": {
+                  "type": "string",
+                  "enum": [
+                    "style_preference",
+                    "factual_correction",
+                    "claim_policy_correction",
+                    "keyword_strategy",
+                    "provenance_dispute"
+                  ]
+                },
+                "ruleKey": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 80,
+                  "pattern": "^[a-z0-9_]+$"
+                },
+                "ruleValue": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 160,
+                  "pattern": "^[a-z0-9_]+$"
+                },
+                "allowlistVersion": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "status": {
+                  "type": "string",
+                  "const": "pending"
+                },
+                "active": {
+                  "type": "boolean"
+                },
+                "observedSignalCount": {
+                  "type": "integer",
+                  "minimum": 3,
+                  "maximum": 9007199254740991
+                },
+                "observedJobCount": {
+                  "type": "integer",
+                  "minimum": 2,
+                  "maximum": 9007199254740991
+                },
+                "minimumSignalCount": {
+                  "type": "integer",
+                  "minimum": 3,
+                  "maximum": 9007199254740991
+                },
+                "minimumJobCount": {
+                  "type": "integer",
+                  "minimum": 2,
+                  "maximum": 9007199254740991
+                },
+                "confidenceLimit": {
+                  "type": "string",
+                  "const": "sample_gated_no_population_inference"
+                },
+                "supportingEvidenceCount": {
+                  "type": "integer",
+                  "minimum": 3,
+                  "maximum": 9007199254740991
+                },
+                "contradictingEvidenceCount": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "tombstoneCount": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "derivedAt": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 80,
+                  "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                }
+              },
+              "required": [
+                "recommendationId",
+                "derivationVersion",
+                "evaluationFixtureVersion",
+                "context",
+                "policyKind",
+                "signalKind",
+                "ruleKey",
+                "ruleValue",
+                "allowlistVersion",
+                "status",
+                "active",
+                "observedSignalCount",
+                "observedJobCount",
+                "minimumSignalCount",
+                "minimumJobCount",
+                "confidenceLimit",
+                "supportingEvidenceCount",
+                "contradictingEvidenceCount",
+                "tombstoneCount",
+                "derivedAt"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 9007199254740991
+          },
+          "pageSize": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          },
+          "totalPages": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": [
+          "ok",
+          "recommendations",
+          "page",
+          "pageSize",
+          "total",
+          "totalPages"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "reviewLearningRecommendation": {
+      "request": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "decision": {
+                "type": "string",
+                "const": "accepted"
+              }
+            },
+            "required": [
+              "decision"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "decision": {
+                "type": "string",
+                "const": "rejected"
+              }
+            },
+            "required": [
+              "decision"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "response": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "ok": {
+                "type": "boolean",
+                "const": true
+              },
+              "reviewId": {
+                "type": "string",
+                "pattern": "^learning-recommendation-review:[a-f0-9]{64}$"
+              },
+              "recommendationId": {
+                "type": "string",
+                "pattern": "^learning-recommendation:[a-f0-9]{64}$"
+              },
+              "revision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "context": {
+                "type": "string",
+                "const": "materials"
+              },
+              "policyKind": {
+                "type": "string",
+                "const": "tailoring_rule"
+              },
+              "reviewedAt": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 80,
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+              },
+              "decision": {
+                "type": "string",
+                "const": "accepted"
+              },
+              "policyVersion": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": [
+              "ok",
+              "reviewId",
+              "recommendationId",
+              "revision",
+              "context",
+              "policyKind",
+              "reviewedAt",
+              "decision",
+              "policyVersion"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "ok": {
+                "type": "boolean",
+                "const": true
+              },
+              "reviewId": {
+                "type": "string",
+                "pattern": "^learning-recommendation-review:[a-f0-9]{64}$"
+              },
+              "recommendationId": {
+                "type": "string",
+                "pattern": "^learning-recommendation:[a-f0-9]{64}$"
+              },
+              "revision": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "context": {
+                "type": "string",
+                "const": "materials"
+              },
+              "policyKind": {
+                "type": "string",
+                "const": "tailoring_rule"
+              },
+              "reviewedAt": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 80,
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+              },
+              "decision": {
+                "type": "string",
+                "const": "rejected"
+              },
+              "policyVersion": {
+                "type": "null"
+              }
+            },
+            "required": [
+              "ok",
+              "reviewId",
+              "recommendationId",
+              "revision",
+              "context",
+              "policyKind",
+              "reviewedAt",
+              "decision",
+              "policyVersion"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "rollbackTailoringPolicy": {
+      "request": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "targetVersion": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          }
+        },
+        "required": [
+          "targetVersion"
+        ],
+        "additionalProperties": false
+      },
+      "response": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": true
+          },
+          "context": {
+            "type": "string",
+            "const": "materials"
+          },
+          "policyKind": {
+            "type": "string",
+            "const": "tailoring_rule"
+          },
+          "version": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "status": {
+            "type": "string",
+            "const": "current"
+          },
+          "learnedRules": {
+            "maxItems": 5,
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "ruleKey": {
+                      "type": "string",
+                      "const": "style_guidance"
+                    },
+                    "ruleValue": {
+                      "type": "string",
+                      "const": "preserve_user_edit_pattern"
+                    }
+                  },
+                  "required": [
+                    "ruleKey",
+                    "ruleValue"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "ruleKey": {
+                      "type": "string",
+                      "const": "fact_handling"
+                    },
+                    "ruleValue": {
+                      "type": "string",
+                      "const": "require_source_match"
+                    }
+                  },
+                  "required": [
+                    "ruleKey",
+                    "ruleValue"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "ruleKey": {
+                      "type": "string",
+                      "const": "claim_policy"
+                    },
+                    "ruleValue": {
+                      "type": "string",
+                      "const": "omit_unsupported_claims"
+                    }
+                  },
+                  "required": [
+                    "ruleKey",
+                    "ruleValue"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "ruleKey": {
+                      "type": "string",
+                      "const": "keyword_strategy"
+                    },
+                    "ruleValue": {
+                      "type": "string",
+                      "const": "use_supported_terms_only"
+                    }
+                  },
+                  "required": [
+                    "ruleKey",
+                    "ruleValue"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "ruleKey": {
+                      "type": "string",
+                      "const": "provenance_policy"
+                    },
+                    "ruleValue": {
+                      "type": "string",
+                      "const": "require_direct_evidence"
+                    }
+                  },
+                  "required": [
+                    "ruleKey",
+                    "ruleValue"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "sourceReviewId": {
+            "type": "null"
+          },
+          "sourceRecommendationId": {
+            "type": "null"
+          },
+          "rollbackOfVersion": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+          },
+          "rollbackReasonCode": {
+            "type": "string",
+            "const": "user_requested"
+          },
+          "createdAt": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+          }
+        },
+        "required": [
+          "ok",
+          "context",
+          "policyKind",
+          "version",
+          "status",
+          "learnedRules",
+          "sourceReviewId",
+          "sourceRecommendationId",
+          "rollbackOfVersion",
+          "rollbackReasonCode",
+          "createdAt"
+        ],
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/packages/domain-types/test/fixtures/endpoint_specs.json
+++ b/packages/domain-types/test/fixtures/endpoint_specs.json
@@ -523,6 +523,1557 @@
         ],
         "additionalProperties": false
       }
+    },
+    "renderResumeReviewDraft": {
+      "request": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "draftRevisionId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 160
+          }
+        },
+        "additionalProperties": false
+      },
+      "response": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "ok": {
+                "type": "boolean",
+                "const": true
+              },
+              "draft": {
+                "type": "object",
+                "properties": {
+                  "draftId": {
+                    "type": "string"
+                  },
+                  "jobKey": {
+                    "type": "string"
+                  },
+                  "baseGeneration": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "baseResumeTextArtifactId": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "baseResumePdfArtifactId": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "rendererFormat": {
+                    "type": "string"
+                  },
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "active",
+                      "rendered",
+                      "promoted",
+                      "abandoned"
+                    ]
+                  },
+                  "currentRevisionId": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "latestRevisionNumber": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 80,
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 80,
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                  },
+                  "latestRevision": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "revisionId": {
+                            "type": "string"
+                          },
+                          "draftId": {
+                            "type": "string"
+                          },
+                          "jobKey": {
+                            "type": "string"
+                          },
+                          "revisionNumber": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9007199254740991
+                          },
+                          "editedText": {
+                            "type": "string"
+                          },
+                          "plateDocument": {
+                            "anyOf": [
+                              {},
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "editDeltas": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "deltaId": {
+                                  "type": "string"
+                                },
+                                "revisionId": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "type": "string",
+                                  "enum": [
+                                    "replace_text",
+                                    "insert_text",
+                                    "delete_text",
+                                    "structure_change"
+                                  ]
+                                },
+                                "section": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "semanticId": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "lineAnchor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "semanticId": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        },
+                                        "lineNumber": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer",
+                                              "minimum": -9007199254740991,
+                                              "maximum": 9007199254740991
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        },
+                                        "pageNumber": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer",
+                                              "minimum": -9007199254740991,
+                                              "maximum": 9007199254740991
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        },
+                                        "textHash": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "semanticId",
+                                        "lineNumber",
+                                        "pageNumber",
+                                        "textHash"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "beforeText": {
+                                  "type": "string"
+                                },
+                                "afterText": {
+                                  "type": "string"
+                                },
+                                "createdAt": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 80,
+                                  "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                                }
+                              },
+                              "required": [
+                                "deltaId",
+                                "revisionId",
+                                "kind",
+                                "section",
+                                "semanticId",
+                                "lineAnchor",
+                                "beforeText",
+                                "afterText",
+                                "createdAt"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 80,
+                            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                          }
+                        },
+                        "required": [
+                          "revisionId",
+                          "draftId",
+                          "jobKey",
+                          "revisionNumber",
+                          "editedText",
+                          "plateDocument",
+                          "editDeltas",
+                          "createdAt"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "commentThreads": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "threadId": {
+                          "type": "string"
+                        },
+                        "draftId": {
+                          "type": "string"
+                        },
+                        "jobKey": {
+                          "type": "string"
+                        },
+                        "baseArtifactId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "semanticId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "lineAnchor": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "semanticId": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "lineNumber": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer",
+                                      "minimum": -9007199254740991,
+                                      "maximum": 9007199254740991
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "pageNumber": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer",
+                                      "minimum": -9007199254740991,
+                                      "maximum": 9007199254740991
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "textHash": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "semanticId",
+                                "lineNumber",
+                                "pageNumber",
+                                "textHash"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "sourcePinId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "riskLabel": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "commentBody": {
+                          "type": "string"
+                        },
+                        "state": {
+                          "type": "string",
+                          "enum": [
+                            "open",
+                            "user_replied",
+                            "resolved",
+                            "superseded_by_edit",
+                            "residual_after_acceptance"
+                          ]
+                        },
+                        "anchorResolved": {
+                          "type": "boolean"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 80,
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 80,
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                        },
+                        "replies": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "replyId": {
+                                "type": "string"
+                              },
+                              "threadId": {
+                                "type": "string"
+                              },
+                              "draftRevisionId": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "author": {
+                                "type": "string"
+                              },
+                              "decision": {
+                                "type": "string",
+                                "enum": [
+                                  "accepted",
+                                  "rejected",
+                                  "clarified",
+                                  "rewrite_requested"
+                                ]
+                              },
+                              "body": {
+                                "type": "string"
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 80,
+                                "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                              }
+                            },
+                            "required": [
+                              "replyId",
+                              "threadId",
+                              "draftRevisionId",
+                              "author",
+                              "decision",
+                              "body",
+                              "createdAt"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "threadId",
+                        "draftId",
+                        "jobKey",
+                        "baseArtifactId",
+                        "semanticId",
+                        "lineAnchor",
+                        "sourcePinId",
+                        "riskLabel",
+                        "commentBody",
+                        "state",
+                        "anchorResolved",
+                        "createdAt",
+                        "updatedAt",
+                        "replies"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "feedbackSignals": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "signalId": {
+                          "type": "string"
+                        },
+                        "jobKey": {
+                          "type": "string"
+                        },
+                        "draftId": {
+                          "type": "string"
+                        },
+                        "draftRevisionId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "sourceKind": {
+                          "type": "string",
+                          "enum": [
+                            "edit_delta",
+                            "comment_reply"
+                          ]
+                        },
+                        "sourceId": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "style_preference",
+                            "factual_correction",
+                            "claim_policy_correction",
+                            "keyword_strategy",
+                            "provenance_dispute"
+                          ]
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "candidate",
+                            "accepted",
+                            "rejected"
+                          ]
+                        },
+                        "summary": {
+                          "type": "string"
+                        },
+                        "section": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "semanticId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 80,
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                        },
+                        "reviewedAt": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 80,
+                              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "signalId",
+                        "jobKey",
+                        "draftId",
+                        "draftRevisionId",
+                        "sourceKind",
+                        "sourceId",
+                        "kind",
+                        "status",
+                        "summary",
+                        "section",
+                        "semanticId",
+                        "createdAt",
+                        "reviewedAt"
+                      ],
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "required": [
+                  "draftId",
+                  "jobKey",
+                  "baseGeneration",
+                  "baseResumeTextArtifactId",
+                  "baseResumePdfArtifactId",
+                  "rendererFormat",
+                  "state",
+                  "currentRevisionId",
+                  "latestRevisionNumber",
+                  "createdAt",
+                  "updatedAt",
+                  "latestRevision",
+                  "commentThreads",
+                  "feedbackSignals"
+                ],
+                "additionalProperties": false
+              },
+              "validation": {
+                "type": "object",
+                "properties": {
+                  "passed": {
+                    "type": "boolean"
+                  },
+                  "errors": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "warnings": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "passed",
+                  "errors",
+                  "warnings"
+                ],
+                "additionalProperties": false
+              },
+              "artifacts": {
+                "type": "object",
+                "properties": {
+                  "resumeText": {
+                    "type": "object",
+                    "properties": {
+                      "artifactId": {
+                        "type": "string"
+                      },
+                      "artifactType": {
+                        "type": "string",
+                        "enum": [
+                          "tailored_resume",
+                          "resume_pdf"
+                        ]
+                      },
+                      "generation": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "renderFormat": {
+                        "type": "string",
+                        "enum": [
+                          "text",
+                          "html_pdf"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "artifactId",
+                      "artifactType",
+                      "generation",
+                      "renderFormat"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "resumePdf": {
+                    "type": "object",
+                    "properties": {
+                      "artifactId": {
+                        "type": "string"
+                      },
+                      "artifactType": {
+                        "type": "string",
+                        "enum": [
+                          "tailored_resume",
+                          "resume_pdf"
+                        ]
+                      },
+                      "generation": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 9007199254740991
+                      },
+                      "renderFormat": {
+                        "type": "string",
+                        "enum": [
+                          "text",
+                          "html_pdf"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "artifactId",
+                      "artifactType",
+                      "generation",
+                      "renderFormat"
+                    ],
+                    "additionalProperties": false
+                  }
+                },
+                "required": [
+                  "resumeText",
+                  "resumePdf"
+                ],
+                "additionalProperties": false
+              },
+              "layoutBoxCount": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 9007199254740991
+              }
+            },
+            "required": [
+              "ok",
+              "draft",
+              "validation",
+              "artifacts",
+              "layoutBoxCount"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "ok": {
+                "type": "boolean",
+                "const": false
+              },
+              "error": {
+                "type": "string",
+                "const": "resume_review_draft_invalid"
+              },
+              "draft": {
+                "type": "object",
+                "properties": {
+                  "draftId": {
+                    "type": "string"
+                  },
+                  "jobKey": {
+                    "type": "string"
+                  },
+                  "baseGeneration": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "baseResumeTextArtifactId": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "baseResumePdfArtifactId": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "rendererFormat": {
+                    "type": "string"
+                  },
+                  "state": {
+                    "type": "string",
+                    "enum": [
+                      "active",
+                      "rendered",
+                      "promoted",
+                      "abandoned"
+                    ]
+                  },
+                  "currentRevisionId": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "latestRevisionNumber": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 9007199254740991
+                  },
+                  "createdAt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 80,
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                  },
+                  "updatedAt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 80,
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                  },
+                  "latestRevision": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "revisionId": {
+                            "type": "string"
+                          },
+                          "draftId": {
+                            "type": "string"
+                          },
+                          "jobKey": {
+                            "type": "string"
+                          },
+                          "revisionNumber": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9007199254740991
+                          },
+                          "editedText": {
+                            "type": "string"
+                          },
+                          "plateDocument": {
+                            "anyOf": [
+                              {},
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "editDeltas": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "deltaId": {
+                                  "type": "string"
+                                },
+                                "revisionId": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "type": "string",
+                                  "enum": [
+                                    "replace_text",
+                                    "insert_text",
+                                    "delete_text",
+                                    "structure_change"
+                                  ]
+                                },
+                                "section": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "semanticId": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "lineAnchor": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "semanticId": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        },
+                                        "lineNumber": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer",
+                                              "minimum": -9007199254740991,
+                                              "maximum": 9007199254740991
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        },
+                                        "pageNumber": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer",
+                                              "minimum": -9007199254740991,
+                                              "maximum": 9007199254740991
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        },
+                                        "textHash": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "null"
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "semanticId",
+                                        "lineNumber",
+                                        "pageNumber",
+                                        "textHash"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "beforeText": {
+                                  "type": "string"
+                                },
+                                "afterText": {
+                                  "type": "string"
+                                },
+                                "createdAt": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 80,
+                                  "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                                }
+                              },
+                              "required": [
+                                "deltaId",
+                                "revisionId",
+                                "kind",
+                                "section",
+                                "semanticId",
+                                "lineAnchor",
+                                "beforeText",
+                                "afterText",
+                                "createdAt"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 80,
+                            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                          }
+                        },
+                        "required": [
+                          "revisionId",
+                          "draftId",
+                          "jobKey",
+                          "revisionNumber",
+                          "editedText",
+                          "plateDocument",
+                          "editDeltas",
+                          "createdAt"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "commentThreads": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "threadId": {
+                          "type": "string"
+                        },
+                        "draftId": {
+                          "type": "string"
+                        },
+                        "jobKey": {
+                          "type": "string"
+                        },
+                        "baseArtifactId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "semanticId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "lineAnchor": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "semanticId": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "lineNumber": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer",
+                                      "minimum": -9007199254740991,
+                                      "maximum": 9007199254740991
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "pageNumber": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer",
+                                      "minimum": -9007199254740991,
+                                      "maximum": 9007199254740991
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "textHash": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "semanticId",
+                                "lineNumber",
+                                "pageNumber",
+                                "textHash"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "sourcePinId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "riskLabel": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "commentBody": {
+                          "type": "string"
+                        },
+                        "state": {
+                          "type": "string",
+                          "enum": [
+                            "open",
+                            "user_replied",
+                            "resolved",
+                            "superseded_by_edit",
+                            "residual_after_acceptance"
+                          ]
+                        },
+                        "anchorResolved": {
+                          "type": "boolean"
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 80,
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 80,
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                        },
+                        "replies": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "replyId": {
+                                "type": "string"
+                              },
+                              "threadId": {
+                                "type": "string"
+                              },
+                              "draftRevisionId": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "author": {
+                                "type": "string"
+                              },
+                              "decision": {
+                                "type": "string",
+                                "enum": [
+                                  "accepted",
+                                  "rejected",
+                                  "clarified",
+                                  "rewrite_requested"
+                                ]
+                              },
+                              "body": {
+                                "type": "string"
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 80,
+                                "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                              }
+                            },
+                            "required": [
+                              "replyId",
+                              "threadId",
+                              "draftRevisionId",
+                              "author",
+                              "decision",
+                              "body",
+                              "createdAt"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "threadId",
+                        "draftId",
+                        "jobKey",
+                        "baseArtifactId",
+                        "semanticId",
+                        "lineAnchor",
+                        "sourcePinId",
+                        "riskLabel",
+                        "commentBody",
+                        "state",
+                        "anchorResolved",
+                        "createdAt",
+                        "updatedAt",
+                        "replies"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "feedbackSignals": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "signalId": {
+                          "type": "string"
+                        },
+                        "jobKey": {
+                          "type": "string"
+                        },
+                        "draftId": {
+                          "type": "string"
+                        },
+                        "draftRevisionId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "sourceKind": {
+                          "type": "string",
+                          "enum": [
+                            "edit_delta",
+                            "comment_reply"
+                          ]
+                        },
+                        "sourceId": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "style_preference",
+                            "factual_correction",
+                            "claim_policy_correction",
+                            "keyword_strategy",
+                            "provenance_dispute"
+                          ]
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "candidate",
+                            "accepted",
+                            "rejected"
+                          ]
+                        },
+                        "summary": {
+                          "type": "string"
+                        },
+                        "section": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "semanticId": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 80,
+                          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                        },
+                        "reviewedAt": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "minLength": 1,
+                              "maxLength": 80,
+                              "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{1,3})?Z$"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "signalId",
+                        "jobKey",
+                        "draftId",
+                        "draftRevisionId",
+                        "sourceKind",
+                        "sourceId",
+                        "kind",
+                        "status",
+                        "summary",
+                        "section",
+                        "semanticId",
+                        "createdAt",
+                        "reviewedAt"
+                      ],
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "required": [
+                  "draftId",
+                  "jobKey",
+                  "baseGeneration",
+                  "baseResumeTextArtifactId",
+                  "baseResumePdfArtifactId",
+                  "rendererFormat",
+                  "state",
+                  "currentRevisionId",
+                  "latestRevisionNumber",
+                  "createdAt",
+                  "updatedAt",
+                  "latestRevision",
+                  "commentThreads",
+                  "feedbackSignals"
+                ],
+                "additionalProperties": false
+              },
+              "validation": {
+                "type": "object",
+                "properties": {
+                  "passed": {
+                    "type": "boolean"
+                  },
+                  "errors": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "warnings": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "passed",
+                  "errors",
+                  "warnings"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "ok",
+              "error",
+              "draft",
+              "validation"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
+    "scanGmailApplicationOutcomes": {
+      "request": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "recipientEmail": {
+            "type": "string",
+            "format": "email",
+            "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+          },
+          "limit": {
+            "default": 25,
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          },
+          "maxResultsPerAnchor": {
+            "default": 5,
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 20
+          },
+          "windowDays": {
+            "default": 45,
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 180
+          }
+        },
+        "additionalProperties": false
+      },
+      "response": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": true
+          },
+          "scannedAnchorCount": {
+            "type": "number"
+          },
+          "searchedMessageCount": {
+            "type": "number"
+          },
+          "linkedEvidenceCount": {
+            "type": "number"
+          },
+          "suggestionsCreatedCount": {
+            "type": "number"
+          },
+          "duplicateMessageCount": {
+            "type": "number"
+          },
+          "unlinkedCandidateCount": {
+            "type": "number"
+          },
+          "evidence": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "evidenceId": {
+                  "type": "string"
+                },
+                "jobKey": {
+                  "type": "string"
+                },
+                "providerMessageId": {
+                  "type": "string"
+                },
+                "linkConfidence": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "evidenceId",
+                "jobKey",
+                "providerMessageId",
+                "linkConfidence"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "suggestions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "suggestionId": {
+                  "type": "string"
+                },
+                "evidenceId": {
+                  "type": "string"
+                },
+                "jobKey": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "applied_confirmation",
+                    "recruiter_reply",
+                    "interview",
+                    "assessment",
+                    "rejection",
+                    "offer",
+                    "withdrawn",
+                    "bounced",
+                    "no_response",
+                    "unknown"
+                  ]
+                },
+                "confidence": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "suggestionId",
+                "evidenceId",
+                "jobKey",
+                "kind",
+                "confidence"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "ok",
+          "scannedAnchorCount",
+          "searchedMessageCount",
+          "linkedEvidenceCount",
+          "suggestionsCreatedCount",
+          "duplicateMessageCount",
+          "unlinkedCandidateCount",
+          "evidence",
+          "suggestions"
+        ],
+        "additionalProperties": false
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `defineEndpoint(...)`, typed endpoint paths, and the runtime `ENDPOINTS` registry in `@jobctrl/contracts`.
- Register the three pilot endpoints plus the post-#776 `renderResumeReviewDraft` and `scanGmailApplicationOutcomes` endpoints because that stack is present on the base.
- Move each migrated HTTP request/response schema into its endpoint definition and emit the phase-2 JSON Schema parity fixture.
- Keep the existing raw RPC contracts in `rpc.ts`; the two post-#776 worker calls are recorded as typed indirect RPC dependencies because their HTTP handlers retain domain orchestration and injected worker seams.

## Why

The rollback endpoint demonstrated that the same method contract was being transcribed across nine mechanical TypeScript stations. A typed runtime registry gives those consumers one contract while leaving payload design, error/status policy, dispatch choice, and domain behavior explicit.

## Validation

- `corepack pnpm --filter @jobctrl/contracts run check` — passed.
- `corepack pnpm --filter @jobctrl/api-client run check` — passed against the moved exports.
- `corepack pnpm --filter @jobctrl/api run check` — passed against the moved exports.
- `corepack pnpm --filter @jobctrl/web run check` — passed against the moved exports.
- `git diff --check` — passed.
- Final base verification: `origin/main` and the bottom-branch merge base both resolve to `e8afa7a46a7bfe9640746768e62bb324565e51bd`.
