### PR TITLE
refactor(client): derive methods from endpoint specs

### DIFF
--- a/apps/api/test/endpoint-client.test.ts
+++ b/apps/api/test/endpoint-client.test.ts
@@ -75,4 +75,31 @@ describe("endpoint client factory", () => {
 
     await expect(client.rollbackTailoringPolicy({ targetVersion: 1 })).rejects.toThrow();
   });
+
+  it("preserves empty-object bodies for optional write requests", async () => {
+    const transport = vi.fn(async (_method: string, path: string) =>
+      path === "/v1/outcomes/gmail/scan"
+        ? {
+            ok: true,
+            scannedAnchorCount: 0,
+            searchedMessageCount: 0,
+            linkedEvidenceCount: 0,
+            suggestionsCreatedCount: 0,
+            duplicateMessageCount: 0,
+            unlinkedCandidateCount: 0,
+            evidence: [],
+            suggestions: [],
+          }
+        : {},
+    );
+    const client = createEndpointMethods(transport);
+
+    await expect(client.renderResumeReviewDraft("draft/one")).rejects.toThrow();
+    await client.scanGmailApplicationOutcomes();
+
+    expect(transport.mock.calls).toEqual([
+      ["POST", "/v1/resume-review/drafts/draft%2Fone/render", {}],
+      ["POST", "/v1/outcomes/gmail/scan", {}],
+    ]);
+  });
 });

--- a/apps/api/test/endpoint-client.test.ts
+++ b/apps/api/test/endpoint-client.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createEndpointMethods } from "@jobctrl/api-client";
+import { ENDPOINTS } from "../src/contracts.js";
+
+const RECOMMENDATION_ID = `learning-recommendation:${"a".repeat(64)}`;
+const REVIEW_ID = `learning-recommendation-review:${"b".repeat(64)}`;
+
+describe("endpoint client factory", () => {
+  it("derives paths, payload placement, and response parsing from the registry", async () => {
+    const transport = vi.fn(async (_method: string, path: string) => {
+      if (path === "/v1/learning/recommendations") {
+        return {
+          ok: true,
+          recommendations: [],
+          page: 2,
+          pageSize: 5,
+          total: 0,
+          totalPages: 0,
+        };
+      }
+      if (path.endsWith("/reviews")) {
+        return {
+          ok: true,
+          reviewId: REVIEW_ID,
+          recommendationId: RECOMMENDATION_ID,
+          revision: 1,
+          context: "materials",
+          policyKind: "tailoring_rule",
+          reviewedAt: "2026-08-01T12:34:56.000Z",
+          decision: "accepted",
+          policyVersion: 2,
+        };
+      }
+      return {
+        ok: true,
+        context: "materials",
+        policyKind: "tailoring_rule",
+        version: 3,
+        status: "current",
+        learnedRules: [],
+        sourceReviewId: null,
+        sourceRecommendationId: null,
+        rollbackOfVersion: 1,
+        rollbackReasonCode: "user_requested",
+        createdAt: "2026-08-01T12:34:56.000Z",
+      };
+    });
+    const client = createEndpointMethods(transport);
+
+    await client.learningRecommendations({ page: 2, pageSize: 5 });
+    await client.reviewLearningRecommendation(RECOMMENDATION_ID, {
+      decision: "accepted",
+    });
+    await client.rollbackTailoringPolicy({ targetVersion: 1 });
+
+    expect(transport.mock.calls).toEqual([
+      ["GET", "/v1/learning/recommendations", { page: 2, pageSize: 5 }],
+      [
+        "POST",
+        `/v1/learning/recommendations/${encodeURIComponent(RECOMMENDATION_ID)}/reviews`,
+        { decision: "accepted" },
+      ],
+      ["POST", "/v1/learning/policies/materials/rollbacks", { targetVersion: 1 }],
+    ]);
+    expect(Object.keys(client).toSorted()).toEqual(
+      Object.values(ENDPOINTS)
+        .map((endpoint) => endpoint.name)
+        .toSorted(),
+    );
+  });
+
+  it("rejects a response that violates the endpoint response schema", async () => {
+    const client = createEndpointMethods(async () => ({ ok: true }));
+
+    await expect(client.rollbackTailoringPolicy({ targetVersion: 1 })).rejects.toThrow();
+  });
+});

--- a/apps/web/src/demo/DemoApiClientAdapter.ts
+++ b/apps/web/src/demo/DemoApiClientAdapter.ts
@@ -634,7 +634,6 @@ export class DemoApiClientAdapter implements ApiClientPort {
   createResumeReviewDraft = this.local("createResumeReviewDraft");
   saveResumeReviewDraftRevision = this.local("saveResumeReviewDraftRevision");
   seedResumeReviewCommentThreads = this.local("seedResumeReviewCommentThreads");
-  renderResumeReviewDraft = this.unsupported("renderResumeReviewDraft");
   replyToResumeReviewComment = this.local("replyToResumeReviewComment");
   saveResumeTemplate = this.local("saveResumeTemplate");
   setDefaultResumeTemplate = this.local("setDefaultResumeTemplate");
@@ -749,7 +748,7 @@ export class DemoApiClientAdapter implements ApiClientPort {
     return ((...args: Parameters<ApiClientPort[TMethod]>) =>
       this.trackDemoAction(method, () =>
         this.scenarios.execute(method, args),
-      )) as ApiClientPort[TMethod];
+      )) as unknown as ApiClientPort[TMethod];
   }
 
   private rehearsed<TMethod extends DemoInitialExternalRehearsalOperation>(

--- a/apps/web/src/demo/DemoApiClientAdapter.ts
+++ b/apps/web/src/demo/DemoApiClientAdapter.ts
@@ -4,6 +4,7 @@ import {
   ArtifactListQuerySchema,
   ContactListQuerySchema,
   ContactResearchListQuerySchema,
+  ENDPOINTS,
   JobListQuerySchema,
   WorkflowRunsListQuerySchema,
   compareJobs,
@@ -14,6 +15,7 @@ import {
   timestampBefore,
   type ActivityEventSummary,
   type ArtifactSummary,
+  type EndpointClientMethods,
   type JobCompensationSummary,
   type JobSummary,
   type PaginatedResponse,
@@ -107,6 +109,14 @@ export class DemoApiClientAdapter implements ApiClientPort {
         ...(options.createId ? { createId: options.createId } : {}),
       },
     );
+    Object.assign(
+      this,
+      Object.fromEntries(
+        Object.values(ENDPOINTS)
+          .filter((endpoint) => endpoint.demo.class === "unavailable")
+          .map((endpoint) => [endpoint.name, this.unsupported(endpoint.name)]),
+      ),
+    );
   }
 
   initialize(): Promise<void> {
@@ -131,11 +141,8 @@ export class DemoApiClientAdapter implements ApiClientPort {
     return this.read((model) => model.analytics.summary);
   }
 
-  learningRecommendations = this.unsupported("learningRecommendations");
   learningRecommendationEvidence = this.unsupported("learningRecommendationEvidence");
-  reviewLearningRecommendation = this.unsupported("reviewLearningRecommendation");
   tailoringPolicyRevisions = this.unsupported("tailoringPolicyRevisions");
-  rollbackTailoringPolicy = this.unsupported("rollbackTailoringPolicy");
 
   digest() {
     return this.read((model) => model.dashboard.digest);
@@ -819,6 +826,8 @@ export class DemoApiClientAdapter implements ApiClientPort {
     }
   }
 }
+
+export interface DemoApiClientAdapter extends EndpointClientMethods {}
 
 const DEMO_ACTION_TELEMETRY: Readonly<
   Record<string, Readonly<Record<string, string>>>

--- a/apps/web/src/demo/DemoLocalCommandExecutor.test.ts
+++ b/apps/web/src/demo/DemoLocalCommandExecutor.test.ts
@@ -229,7 +229,7 @@ const LOCAL_CASES = [
 ] as const satisfies readonly LocalCase[];
 
 describe("DemoLocalCommandExecutor", () => {
-  it("keeps the 133-member capability manifest exhaustive with exact class counts", () => {
+  it("keeps the 134-member capability manifest exhaustive with exact class counts", () => {
     const counts = Object.values(DEMO_CAPABILITY_MANIFEST).reduce<Record<string, number>>(
       (result, capability) => {
         result[capability.class] = (result[capability.class] ?? 0) + 1;
@@ -237,12 +237,12 @@ describe("DemoLocalCommandExecutor", () => {
       },
       {},
     );
-    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(133);
+    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(134);
     expect(counts).toEqual({
       browser_local: 92,
       simulated_async: 4,
       rehearsed_external: 4,
-      unavailable: 33,
+      unavailable: 34,
     });
   });
 

--- a/apps/web/src/demo/capabilities.ts
+++ b/apps/web/src/demo/capabilities.ts
@@ -57,7 +57,6 @@ export const DEMO_CAPABILITY_MANIFEST = {
   createResumeReviewDraft: local("Creates a synthetic draft locally."),
   saveResumeReviewDraftRevision: local("Saves a draft revision locally."),
   seedResumeReviewCommentThreads: local("Seeds synthetic review comments locally."),
-  renderResumeReviewDraft: unavailable("Draft rendering is deferred from the public-demo MVP."),
   replyToResumeReviewComment: local("Records a comment reply locally."),
   resumeReviewFeedback: local("Reads synthetic review feedback."),
   resumeTemplates: local("Reads bundled resume templates."),

--- a/apps/web/src/demo/capabilities.ts
+++ b/apps/web/src/demo/capabilities.ts
@@ -1,9 +1,15 @@
-import type { DemoCapabilityManifest } from "./contracts.js";
+import { ENDPOINTS, type EndpointClientMethods } from "@jobctrl/contracts";
+
+import type { DemoCapability, DemoCapabilityManifest } from "./contracts.js";
 
 const local = (reason: string) => ({ class: "browser_local", reason }) as const;
 const async = (reason: string) => ({ class: "simulated_async", reason }) as const;
 const rehearsal = (reason: string) => ({ class: "rehearsed_external", reason }) as const;
 const unavailable = (reason: string) => ({ class: "unavailable", reason }) as const;
+
+const endpointCapabilities = Object.fromEntries(
+  Object.values(ENDPOINTS).map((endpoint) => [endpoint.name, endpoint.demo]),
+) as Readonly<Record<keyof EndpointClientMethods, DemoCapability>>;
 
 /**
  * Every port member is deliberately classified before a demo adapter exists.
@@ -14,20 +20,12 @@ export const DEMO_CAPABILITY_MANIFEST = {
   dashboardSummary: local("Reads the synthetic dashboard projection."),
   pipelineOperations: unavailable("Pipeline operations telemetry is unavailable in the public demo."),
   outcomeAnalytics: local("Reads synthetic conversion analytics."),
-  learningRecommendations: unavailable(
-    "Learning recommendations require the local audited database.",
-  ),
+  ...endpointCapabilities,
   learningRecommendationEvidence: unavailable(
     "Learning evidence requires the local audited database.",
   ),
-  reviewLearningRecommendation: unavailable(
-    "Learning recommendation review requires the local audited database.",
-  ),
   tailoringPolicyRevisions: unavailable(
     "Tailoring policy history requires the local audited database.",
-  ),
-  rollbackTailoringPolicy: unavailable(
-    "Tailoring policy rollback requires the local audited database.",
   ),
   digest: local("Reads the synthetic daily digest."),
   acknowledgeDigest: local("Acknowledges a digest only in browser-local state."),

--- a/apps/web/src/demo/demo-seed.test.ts
+++ b/apps/web/src/demo/demo-seed.test.ts
@@ -18,7 +18,7 @@ const CONTOSO_GENERATION_ONE_ARTIFACT_IDS = [
 
 describe("canonical public demo seed", () => {
   it("has a complete classified API capability manifest", () => {
-    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(133);
+    expect(Object.keys(DEMO_CAPABILITY_MANIFEST)).toHaveLength(134);
     expect(Object.values(DEMO_CAPABILITY_MANIFEST).every((entry) => entry.reason.length > 0)).toBe(true);
   });
 

--- a/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
+++ b/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
@@ -168,12 +168,6 @@ export class FetchApiClientAdapter implements ApiClientPort {
   ) {
     return this.client.seedResumeReviewCommentThreads(draftId, body);
   }
-  renderResumeReviewDraft(
-    draftId: string,
-    body: Parameters<JobCtrlApiClient["renderResumeReviewDraft"]>[1] = {},
-  ) {
-    return this.client.renderResumeReviewDraft(draftId, body);
-  }
   replyToResumeReviewComment(
     threadId: string,
     body: Parameters<JobCtrlApiClient["replyToResumeReviewComment"]>[1],

--- a/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
+++ b/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
@@ -1,4 +1,4 @@
-import { JobCtrlApiClient } from "@jobctrl/api-client";
+import { createEndpointDelegates, JobCtrlApiClient } from "@jobctrl/api-client";
 import type {
   ContactCreateRequest,
   ContactDeleteRequest,
@@ -7,6 +7,7 @@ import type {
   ContactUpdateRequest,
   ConfirmContactCandidateRequest,
   ContactResearchListQuery,
+  EndpointClientMethods,
   RunContactResearchRequest,
 } from "@jobctrl/contracts";
 import type { ApiClientPort } from "../../ports/ApiClientPort.js";
@@ -16,6 +17,7 @@ export class FetchApiClientAdapter implements ApiClientPort {
 
   constructor(baseUrl?: string) {
     this.client = new JobCtrlApiClient(baseUrl);
+    Object.assign(this, createEndpointDelegates(this.client));
   }
 
   health(): ReturnType<JobCtrlApiClient["health"]> {
@@ -30,30 +32,16 @@ export class FetchApiClientAdapter implements ApiClientPort {
   outcomeAnalytics() {
     return this.client.outcomeAnalytics();
   }
-  learningRecommendations(query: Parameters<JobCtrlApiClient["learningRecommendations"]>[0] = {}) {
-    return this.client.learningRecommendations(query);
-  }
   learningRecommendationEvidence(
     recommendationId: string,
     query: Parameters<JobCtrlApiClient["learningRecommendationEvidence"]>[1] = {},
   ) {
     return this.client.learningRecommendationEvidence(recommendationId, query);
   }
-  reviewLearningRecommendation(
-    recommendationId: string,
-    body: Parameters<JobCtrlApiClient["reviewLearningRecommendation"]>[1],
-  ) {
-    return this.client.reviewLearningRecommendation(recommendationId, body);
-  }
   tailoringPolicyRevisions(
     query: Parameters<JobCtrlApiClient["tailoringPolicyRevisions"]>[0] = {},
   ) {
     return this.client.tailoringPolicyRevisions(query);
-  }
-  rollbackTailoringPolicy(
-    body: Parameters<JobCtrlApiClient["rollbackTailoringPolicy"]>[0],
-  ) {
-    return this.client.rollbackTailoringPolicy(body);
   }
   digest() {
     return this.client.digest();
@@ -513,3 +501,5 @@ export class FetchApiClientAdapter implements ApiClientPort {
     return this.client.dueOutreachFollowUps();
   }
 }
+
+export interface FetchApiClientAdapter extends EndpointClientMethods {}

--- a/apps/web/src/shared/ports/ApiClientPort.ts
+++ b/apps/web/src/shared/ports/ApiClientPort.ts
@@ -121,8 +121,6 @@ import type {
   ResumeReviewCommentThreadSeedRequest,
   ResumeReviewCommentThreadSeedResponse,
   ResumeReviewDraftCreateRequest,
-  ResumeReviewDraftRenderRequest,
-  ResumeReviewDraftRenderResponse,
   ResumeReviewDraftResponse,
   ResumeReviewDraftRevisionResponse,
   ResumeReviewDraftRevisionSaveRequest,
@@ -272,10 +270,6 @@ export interface ApiClientPort extends EndpointClientMethods {
     draftId: string,
     body: ResumeReviewCommentThreadSeedRequest,
   ): Promise<ResumeReviewCommentThreadSeedResponse>;
-  renderResumeReviewDraft(
-    draftId: string,
-    body?: ResumeReviewDraftRenderRequest,
-  ): Promise<ResumeReviewDraftRenderResponse>;
   replyToResumeReviewComment(
     threadId: string,
     body: ResumeCommentReplyRequest,

--- a/apps/web/src/shared/ports/ApiClientPort.ts
+++ b/apps/web/src/shared/ports/ApiClientPort.ts
@@ -70,6 +70,7 @@ import type {
   DiscoveryFeedbackRequest,
   DiscoveryFeedbackResponse,
   DiscoveryPreviewResponse,
+  EndpointClientMethods,
   ExtensionCapabilityTokenResponse,
   EvidenceMapResponse,
   GenerateInterviewPrepRequest,
@@ -85,14 +86,8 @@ import type {
   JobSummary,
   LearningRecommendationEvidenceListQuery,
   LearningRecommendationEvidenceListResponse,
-  LearningRecommendationListQuery,
-  LearningRecommendationListResponse,
-  LearningRecommendationReviewRequest,
-  LearningRecommendationReviewResponse,
   TailoringPolicyRevisionListQuery,
   TailoringPolicyRevisionListResponse,
-  TailoringPolicyRollbackRequest,
-  TailoringPolicyRollbackResponse,
   MarkJobActionRequest,
   ManualCaptureDismissRequest,
   ManualCaptureDismissResponse,
@@ -197,28 +192,18 @@ export interface ApiHealthResponse {
   };
 }
 
-export interface ApiClientPort {
+export interface ApiClientPort extends EndpointClientMethods {
   health(): Promise<ApiHealthResponse>;
   dashboardSummary(): Promise<DashboardSummary>;
   pipelineOperations(): Promise<PipelineOperationsSnapshot>;
   outcomeAnalytics(): Promise<OutcomeAnalyticsSummary>;
-  learningRecommendations(
-    query?: Partial<LearningRecommendationListQuery>,
-  ): Promise<LearningRecommendationListResponse>;
   learningRecommendationEvidence(
     recommendationId: string,
     query?: Partial<LearningRecommendationEvidenceListQuery>,
   ): Promise<LearningRecommendationEvidenceListResponse>;
-  reviewLearningRecommendation(
-    recommendationId: string,
-    body: LearningRecommendationReviewRequest,
-  ): Promise<LearningRecommendationReviewResponse>;
   tailoringPolicyRevisions(
     query?: Partial<TailoringPolicyRevisionListQuery>,
   ): Promise<TailoringPolicyRevisionListResponse>;
-  rollbackTailoringPolicy(
-    body: TailoringPolicyRollbackRequest,
-  ): Promise<TailoringPolicyRollbackResponse>;
   digest(): Promise<DailyDigest>;
   acknowledgeDigest(body?: DigestAcknowledgeRequest): Promise<DigestAcknowledgeResponse>;
   activity(query?: Partial<ActivityListQuery>): Promise<PaginatedResponse<ActivityEventSummary>>;

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -70,6 +70,7 @@ import type {
   DiscoveryFeedbackRequest,
   DiscoveryFeedbackResponse,
   DiscoveryPreviewResponse,
+  EndpointClientMethods,
   EvidenceMapResponse,
   GenerateInterviewPrepRequest,
   GenerateMaterialsRequest,
@@ -85,14 +86,8 @@ import type {
   JobListQuery,
   LearningRecommendationEvidenceListQuery,
   LearningRecommendationEvidenceListResponse,
-  LearningRecommendationListResponse,
-  LearningRecommendationListQuery,
-  LearningRecommendationReviewRequest,
-  LearningRecommendationReviewResponse,
   TailoringPolicyRevisionListQuery,
   TailoringPolicyRevisionListResponse,
-  TailoringPolicyRollbackRequest,
-  TailoringPolicyRollbackResponse,
   JobMutationResponse,
   JobSummary,
   MarkJobActionRequest,
@@ -166,11 +161,10 @@ import type {
 } from "@jobctrl/contracts";
 import {
   LearningRecommendationEvidenceListResponseSchema,
-  LearningRecommendationListResponseSchema,
-  LearningRecommendationReviewResponseSchema,
   TailoringPolicyRevisionListResponseSchema,
-  TailoringPolicyRollbackResponseSchema,
 } from "@jobctrl/contracts";
+
+import { createEndpointMethods } from "./endpoint-client.js";
 
 type QueryValue = boolean | number | string | null | undefined;
 const DEFAULT_NODE_BASE_URL = "http://127.0.0.1:8766";
@@ -240,6 +234,21 @@ export class JobCtrlApiClient {
   ) {
     this.baseUrl = baseUrl.replace(/\/$/, "");
     this.requestTimeoutMs = requestTimeoutMs;
+    Object.assign(
+      this,
+      createEndpointMethods((method, path, request) => {
+        switch (method) {
+          case "GET":
+            return this.get(path, request as Record<string, QueryValue> | undefined);
+          case "POST":
+            return this.post(path, request);
+          case "PATCH":
+            return this.patch(path, request);
+          case "DELETE":
+            return this.delete(path, request);
+        }
+      }),
+    );
   }
 
   health(): Promise<HealthResponse> {
@@ -262,14 +271,6 @@ export class JobCtrlApiClient {
     return this.get("/v1/scoring/keywords");
   }
 
-  async learningRecommendations(
-    query: Partial<LearningRecommendationListQuery> = {},
-  ): Promise<LearningRecommendationListResponse> {
-    return LearningRecommendationListResponseSchema.parse(
-      await this.get("/v1/learning/recommendations", query),
-    );
-  }
-
   async learningRecommendationEvidence(
     recommendationId: string,
     query: Partial<LearningRecommendationEvidenceListQuery> = {},
@@ -282,31 +283,11 @@ export class JobCtrlApiClient {
     );
   }
 
-  async reviewLearningRecommendation(
-    recommendationId: string,
-    body: LearningRecommendationReviewRequest,
-  ): Promise<LearningRecommendationReviewResponse> {
-    return LearningRecommendationReviewResponseSchema.parse(
-      await this.post(
-        `/v1/learning/recommendations/${encodeURIComponent(recommendationId)}/reviews`,
-        body,
-      ),
-    );
-  }
-
   async tailoringPolicyRevisions(
     query: Partial<TailoringPolicyRevisionListQuery> = {},
   ): Promise<TailoringPolicyRevisionListResponse> {
     return TailoringPolicyRevisionListResponseSchema.parse(
       await this.get("/v1/learning/policies/materials", query),
-    );
-  }
-
-  async rollbackTailoringPolicy(
-    body: TailoringPolicyRollbackRequest,
-  ): Promise<TailoringPolicyRollbackResponse> {
-    return TailoringPolicyRollbackResponseSchema.parse(
-      await this.post("/v1/learning/policies/materials/rollbacks", body),
     );
   }
 
@@ -1275,6 +1256,8 @@ export class JobCtrlApiClient {
     return (await response.json()) as T;
   }
 }
+
+export interface JobCtrlApiClient extends EndpointClientMethods {}
 
 export function createJobCtrlApiClient(baseUrl?: string): JobCtrlApiClient {
   return new JobCtrlApiClient(baseUrl);

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -74,8 +74,6 @@ import type {
   EvidenceMapResponse,
   GenerateInterviewPrepRequest,
   GenerateMaterialsRequest,
-  GmailOutcomeScanRequest,
-  GmailOutcomeScanResponse,
   EnsureCurrentResumeMaterialsRequest,
   EnsureCurrentResumeMaterialsResponse,
   ExtensionCapabilityTokenResponse,
@@ -132,8 +130,6 @@ import type {
   ResumeReviewCommentThreadSeedRequest,
   ResumeReviewCommentThreadSeedResponse,
   ResumeReviewDraftCreateRequest,
-  ResumeReviewDraftRenderRequest,
-  ResumeReviewDraftRenderResponse,
   ResumeReviewDraftResponse,
   ResumeReviewDraftRevisionResponse,
   ResumeReviewDraftRevisionSaveRequest,
@@ -531,16 +527,6 @@ export class JobCtrlApiClient {
     );
   }
 
-  renderResumeReviewDraft(
-    draftId: string,
-    body: ResumeReviewDraftRenderRequest = {},
-  ): Promise<ResumeReviewDraftRenderResponse> {
-    return this.post(
-      `/v1/resume-review/drafts/${encodeURIComponent(draftId)}/render`,
-      body,
-    );
-  }
-
   replyToResumeReviewComment(
     threadId: string,
     body: ResumeCommentReplyRequest,
@@ -634,12 +620,6 @@ export class JobCtrlApiClient {
       `/v1/outcome-suggestions/${encodeURIComponent(suggestionId)}/decision`,
       body,
     );
-  }
-
-  scanGmailApplicationOutcomes(
-    body: GmailOutcomeScanRequest = {},
-  ): Promise<GmailOutcomeScanResponse> {
-    return this.post("/v1/outcomes/gmail/scan", body);
   }
 
   jobs(

--- a/packages/api-client/src/endpoint-client.ts
+++ b/packages/api-client/src/endpoint-client.ts
@@ -1,0 +1,40 @@
+import {
+  ENDPOINTS,
+  type EndpointClientMethods,
+  type EndpointHttpMethod,
+} from "@jobctrl/contracts";
+
+export type EndpointTransport = (
+  method: EndpointHttpMethod,
+  path: string,
+  request: unknown,
+) => Promise<unknown>;
+
+export function createEndpointMethods(
+  transport: EndpointTransport,
+): EndpointClientMethods {
+  const methods: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const endpoint of Object.values(ENDPOINTS)) {
+    methods[endpoint.name] = async (...args: unknown[]) => {
+      const hasPathParam = typeof endpoint.path === "function";
+      const path = hasPathParam
+        ? (endpoint.path as (param: unknown) => string)(args[0])
+        : endpoint.path;
+      const request = args[hasPathParam ? 1 : 0];
+      const response = await transport(endpoint.method, path, request);
+      return endpoint.response.parse(response);
+    };
+  }
+  return methods as EndpointClientMethods;
+}
+
+export function createEndpointDelegates(
+  client: EndpointClientMethods,
+): EndpointClientMethods {
+  const delegates: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const endpoint of Object.values(ENDPOINTS)) {
+    const method = client[endpoint.name] as (...args: unknown[]) => Promise<unknown>;
+    delegates[endpoint.name] = (...args) => method.apply(client, args);
+  }
+  return delegates as EndpointClientMethods;
+}

--- a/packages/api-client/src/endpoint-client.ts
+++ b/packages/api-client/src/endpoint-client.ts
@@ -20,7 +20,13 @@ export function createEndpointMethods(
       const path = hasPathParam
         ? (endpoint.path as (param: unknown) => string)(args[0])
         : endpoint.path;
-      const request = args[hasPathParam ? 1 : 0];
+      const requestArgument = args[hasPathParam ? 1 : 0];
+      const request =
+        requestArgument === undefined &&
+        endpoint.method !== "GET" &&
+        endpoint.request.safeParse(undefined).success
+          ? {}
+          : requestArgument;
       const response = await transport(endpoint.method, path, request);
       return endpoint.response.parse(response);
     };

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./client.js";
+export * from "./endpoint-client.js";


### PR DESCRIPTION
## Summary

- Derive `JobCtrlApiClient` methods and `FetchApiClientAdapter` delegates from `ENDPOINTS` at runtime.
- Derive migrated `ApiClientPort` members, demo capability rows, and unavailable demo stubs from the registry types and metadata.
- Delete the hand-written client, port, fetch, capability, and demo stations for the migrated methods while preserving the existing public call signatures and empty-object write bodies.
- Add focused factory coverage for path construction, payload placement, response parsing, method exhaustiveness, and optional write requests.

## Why

These stations are deterministic projections of the endpoint contract. Deriving them removes repeated payload and path spelling while retaining the demo manifest's compile-time exhaustiveness fence.

The manifest count changes from 133 to 134, and `unavailable` from 33 to 34, only because the merged Gmail scan endpoint now becomes an `ApiClientPort` member through the registry. All pre-existing capability classifications remain unchanged.

## Validation

- `corepack pnpm --filter @jobctrl/api-client run check` — passed.
- `corepack pnpm --filter @jobctrl/web run check` — passed.
- `corepack pnpm --filter @jobctrl/api exec vitest run test/endpoint-client.test.ts` — 3/3 passed.
- `corepack pnpm --filter @jobctrl/web exec vitest run src/demo/DemoApiClientAdapter.test.ts src/demo/DemoLocalCommandExecutor.test.ts` — 34/34 passed.
- `corepack pnpm --filter @jobctrl/web exec vitest run src/demo/DemoApiClientAdapter.test.ts src/demo/DemoLocalCommandExecutor.test.ts src/demo/demo-seed.test.ts` — 49/49 passed.
- `git diff --check` — passed.
