### PR TITLE
refactor(api): register routes from endpoint specs

### DIFF
--- a/apps/api/src/endpoint-routes.ts
+++ b/apps/api/src/endpoint-routes.ts
@@ -1,0 +1,202 @@
+import type { FastifyInstance, FastifyReply } from "fastify";
+import type { ZodType } from "zod";
+
+import {
+  ENDPOINTS,
+  type EndpointDispatchContext,
+  type EndpointFailureResponse,
+  type EndpointHttpMethod,
+  type EndpointPath,
+  type EndpointPathParam,
+  type EndpointRequest,
+  type EndpointResponse,
+  type EndpointSpec,
+  type JsonRpcError,
+  type RpcMethod,
+} from "./contracts.js";
+import type { JsonRpcDispatcher } from "./json-rpc-adapter.js";
+
+type DirectEndpoint = EndpointSpec extends infer TEndpoint
+  ? TEndpoint extends EndpointSpec
+    ? Exclude<TEndpoint["dispatch"], undefined> extends never
+      ? TEndpoint
+      : never
+    : never
+  : never;
+
+export type DirectEndpointHandlers = {
+  [TEndpoint in DirectEndpoint as TEndpoint["name"]]: (
+    input: {
+      readonly request: EndpointRequest<TEndpoint>;
+      readonly pathParam: EndpointPathParam<TEndpoint>;
+    },
+    reply: FastifyReply,
+  ) => EndpointResponse<TEndpoint> | unknown | Promise<EndpointResponse<TEndpoint> | unknown>;
+};
+
+export type EndpointRequestParser = <T>(
+  reply: { code: (statusCode: number) => unknown },
+  schema: ZodType<T>,
+  body: unknown,
+) => T | null;
+
+export interface RegisterEndpointRoutesDependencies {
+  readonly dispatcher: JsonRpcDispatcher;
+  readonly dispatchContext: EndpointDispatchContext;
+  readonly handlers: DirectEndpointHandlers;
+  readonly parseBody: EndpointRequestParser;
+}
+
+interface RuntimeDispatch {
+  readonly rpcMethod: RpcMethod;
+  readonly params: (
+    input: { readonly request: unknown; readonly pathParam: unknown },
+    context: EndpointDispatchContext,
+  ) => unknown;
+  readonly paramsSchema: ZodType;
+  readonly result: ZodType;
+  readonly response: (input: {
+    readonly request: unknown;
+    readonly pathParam: unknown;
+    readonly result: unknown;
+  }) => unknown | null;
+  readonly error: (failure:
+    | { readonly kind: "transport" }
+    | { readonly kind: "rpc"; readonly error: JsonRpcError }
+    | { readonly kind: "invalid_result" }) => EndpointFailureResponse;
+}
+
+interface RuntimeEndpoint {
+  readonly name: string;
+  readonly method: EndpointHttpMethod;
+  readonly path: string | EndpointPath<unknown, string>;
+  readonly request: ZodType;
+  readonly response: ZodType;
+  readonly dispatch?: RuntimeDispatch;
+}
+
+export function registerEndpointRoutes(
+  app: FastifyInstance,
+  dependencies: RegisterEndpointRoutesDependencies,
+): void {
+  for (const endpoint of Object.values(ENDPOINTS) as unknown as RuntimeEndpoint[]) {
+    app.route({
+      method: endpoint.method,
+      url: typeof endpoint.path === "string" ? endpoint.path : endpoint.path.route,
+      handler: async (request, reply) => {
+        const parsedRequest = dependencies.parseBody(
+          reply,
+          endpoint.request,
+          endpoint.method === "GET" ? request.query : (request.body ?? {}),
+        );
+        if (parsedRequest === null) {
+          return undefined;
+        }
+
+        const parsedPathParam = parsePathParam(endpoint, request.params, reply);
+        if (!parsedPathParam.ok) {
+          return parsedPathParam.response;
+        }
+        const pathParam = parsedPathParam.value;
+
+        if (!endpoint.dispatch) {
+          const handler = dependencies.handlers[
+            endpoint.name as keyof DirectEndpointHandlers
+          ] as (
+            input: { readonly request: unknown; readonly pathParam: unknown },
+            reply: FastifyReply,
+          ) => unknown | Promise<unknown>;
+          const response = await handler(
+            { request: parsedRequest, pathParam },
+            reply,
+          );
+          return isFailurePayload(response)
+            ? response
+            : endpoint.response.parse(response);
+        }
+
+        const dispatch = endpoint.dispatch;
+        let rpcResponse;
+        try {
+          const params = dispatch.paramsSchema.parse(
+            dispatch.params(
+              { request: parsedRequest, pathParam },
+              dependencies.dispatchContext,
+            ),
+          ) as Record<string, unknown>;
+          rpcResponse = await dependencies.dispatcher.call(dispatch.rpcMethod, params);
+        } catch {
+          return endpointFailure(reply, dispatch.error({ kind: "transport" }));
+        }
+        if (rpcResponse.error) {
+          return endpointFailure(
+            reply,
+            dispatch.error({ kind: "rpc", error: rpcResponse.error }),
+          );
+        }
+
+        const result = dispatch.result.safeParse(rpcResponse.result);
+        if (!result.success) {
+          return endpointFailure(reply, dispatch.error({ kind: "invalid_result" }));
+        }
+        const response = dispatch.response({
+          request: parsedRequest,
+          pathParam,
+          result: result.data,
+        });
+        const parsedResponse = endpoint.response.safeParse(response);
+        if (response === null || !parsedResponse.success) {
+          return endpointFailure(reply, dispatch.error({ kind: "invalid_result" }));
+        }
+        return parsedResponse.data;
+      },
+    });
+  }
+}
+
+function parsePathParam(
+  endpoint: RuntimeEndpoint,
+  requestParams: unknown,
+  reply: FastifyReply,
+): { readonly ok: true; readonly value: unknown } | { readonly ok: false; readonly response: unknown } {
+  if (typeof endpoint.path === "string") {
+    return { ok: true, value: undefined };
+  }
+  const params = isRecord(requestParams) ? requestParams : {};
+  const rawParam = params[endpoint.path.paramName];
+  const parsed = endpoint.path.paramSchema.safeParse(
+    decodeRouteParam(typeof rawParam === "string" ? rawParam : ""),
+  );
+  if (parsed.success) {
+    return { ok: true, value: parsed.data };
+  }
+  return {
+    ok: false,
+    response: endpointFailure(reply, endpoint.path.invalid),
+  };
+}
+
+function endpointFailure(reply: FastifyReply, failure: EndpointFailureResponse) {
+  void reply.code(failure.status);
+  return {
+    ok: false as const,
+    error: failure.error,
+    ...(failure.message === undefined ? {} : { message: failure.message }),
+  };
+}
+
+function decodeRouteParam(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function isFailurePayload(value: unknown): boolean {
+  return isRecord(value) && value.ok === false;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/api/src/endpoint-routes.ts
+++ b/apps/api/src/endpoint-routes.ts
@@ -110,9 +110,12 @@ export function registerEndpointRoutes(
             { request: parsedRequest, pathParam },
             reply,
           );
-          return isFailurePayload(response)
-            ? response
-            : endpoint.response.parse(response);
+          const parsedResponse = endpoint.response.safeParse(response);
+          return parsedResponse.success
+            ? parsedResponse.data
+            : isFailurePayload(response)
+              ? response
+              : endpoint.response.parse(response);
         }
 
         const dispatch = endpoint.dispatch;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -48,9 +48,6 @@ import {
   JobListQuerySchema,
   LearningRecommendationEvidenceListQuerySchema,
   LearningRecommendationIdSchema,
-  LearningRecommendationListQuerySchema,
-  LearningRecommendationReviewRequestSchema,
-  LearningRecommendationReviewResponseSchema,
   TailoringPolicyRevisionListQuerySchema,
   JsonRpcErrorCodes,
   JsonRpcRequestSchema,
@@ -74,8 +71,6 @@ import {
   RunJobStageRequestSchema,
   RoleMatchFeedbackDecisionSchema,
   RetailorJobRequestSchema,
-  ReviewLearningRecommendationResultSchema,
-  RollbackTailoringPolicyResultSchema,
   RpcMethods,
   ResumeTemplateDefaultSelectionRequestSchema,
   ResumeTemplateVersionSaveRequestSchema,
@@ -85,8 +80,6 @@ import {
   ResumeReviewDraftRenderRequestSchema,
   ResumeReviewDraftRevisionSaveRequestSchema,
   TailoringFeedbackSignalReviewRequestSchema,
-  TailoringPolicyRollbackRequestSchema,
-  TailoringPolicyRollbackResponseSchema,
   RunPipelineStagesRequestSchema,
   SettingsUpdateRequestSchema,
   type ExtensionCapabilityTokenResponse,
@@ -192,6 +185,7 @@ import {
   writeDiscoverySettings,
 } from "./discovery-controls.js";
 import { registerEventStreamRoute } from "./event-stream.js";
+import { registerEndpointRoutes } from "./endpoint-routes.js";
 import {
   assertLiveApplicationMayDispatch,
   recordRepeatApplicationOverride,
@@ -640,14 +634,21 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     withDb(reply, options.dbPath, (db) => listScoringKeywords(db)),
   );
 
-  app.get("/v1/learning/recommendations", async (request, reply) =>
-    withDb(reply, options.dbPath, (db) =>
-      listLearningRecommendations(
-        db,
-        LearningRecommendationListQuerySchema.parse(request.query),
-      ),
-    ),
-  );
+  registerEndpointRoutes(app, {
+    dispatcher: providerDispatcher,
+    dispatchContext: {
+      tenantId: "local",
+      appDir,
+      dbPath: options.dbPath,
+    },
+    handlers: {
+      learningRecommendations: ({ request }, reply) =>
+        withDb(reply, options.dbPath, (db) =>
+          listLearningRecommendations(db, request!),
+        ),
+    },
+    parseBody,
+  });
 
   app.get("/v1/learning/policies/materials", async (request, reply) =>
     withDb(reply, options.dbPath, (db) =>
@@ -657,52 +658,6 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       ),
     ),
   );
-
-  app.post("/v1/learning/policies/materials/rollbacks", async (request, reply) => {
-    const body = parseBody(reply, TailoringPolicyRollbackRequestSchema, request.body ?? {});
-    if (!body) {
-      return undefined;
-    }
-
-    let response;
-    try {
-      response = await providerDispatcher.call(RpcMethods.RollbackTailoringPolicy, {
-        tenantId: "local",
-        targetVersion: body.targetVersion,
-        expectedAppDir: appDir,
-        expectedDbPath: options.dbPath,
-      });
-    } catch {
-      return tailoringPolicyRollbackFailure(reply, 503);
-    }
-    if (response.error) {
-      return tailoringPolicyRollbackFailure(
-        reply,
-        response.error.code === JsonRpcErrorCodes.InvalidParams ? 409 : 502,
-      );
-    }
-
-    const parsedResult = RollbackTailoringPolicyResultSchema.safeParse(response.result);
-    if (
-      !parsedResult.success ||
-      parsedResult.data.rollbackOfVersion !== body.targetVersion
-    ) {
-      return tailoringPolicyRollbackFailure(reply, 502);
-    }
-    return TailoringPolicyRollbackResponseSchema.parse({
-      ok: true,
-      context: parsedResult.data.context,
-      policyKind: parsedResult.data.policyKind,
-      version: parsedResult.data.policyVersion,
-      status: "current",
-      learnedRules: parsedResult.data.learnedRules,
-      sourceReviewId: null,
-      sourceRecommendationId: null,
-      rollbackOfVersion: parsedResult.data.rollbackOfVersion,
-      rollbackReasonCode: parsedResult.data.rollbackReasonCode,
-      createdAt: parsedResult.data.rolledBackAt,
-    });
-  });
 
   app.get<{ Params: { recommendationId: string } }>(
     "/v1/learning/recommendations/:recommendationId/evidence",
@@ -726,54 +681,6 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         }
         return response;
       });
-    },
-  );
-
-  app.post<{ Params: { recommendationId: string } }>(
-    "/v1/learning/recommendations/:recommendationId/reviews",
-    async (request, reply) => {
-      const parsedRecommendationId = LearningRecommendationIdSchema.safeParse(
-        decodeRouteParam(request.params.recommendationId),
-      );
-      if (!parsedRecommendationId.success) {
-        void reply.code(400);
-        return { ok: false, error: "invalid_learning_recommendation_id" };
-      }
-      const body = parseBody(reply, LearningRecommendationReviewRequestSchema, request.body ?? {});
-      if (!body) {
-        return undefined;
-      }
-
-      let response;
-      try {
-        response = await providerDispatcher.call(RpcMethods.ReviewLearningRecommendation, {
-          tenantId: "local",
-          recommendationId: parsedRecommendationId.data,
-          decision: body.decision,
-          expectedAppDir: appDir,
-          expectedDbPath: options.dbPath,
-        });
-      } catch {
-        return learningRecommendationReviewFailure(reply, 503);
-      }
-
-      if (response.error) {
-        return learningRecommendationReviewFailure(
-          reply,
-          response.error.code === JsonRpcErrorCodes.InvalidParams ? 409 : 502,
-        );
-      }
-
-      const parsedResult = ReviewLearningRecommendationResultSchema.safeParse(response.result);
-      if (
-        !parsedResult.success ||
-        parsedResult.data.recommendationId !== parsedRecommendationId.data ||
-        parsedResult.data.decision !== body.decision
-      ) {
-        return learningRecommendationReviewFailure(reply, 502);
-      }
-      const { status: _status, ...review } = parsedResult.data;
-      return LearningRecommendationReviewResponseSchema.parse({ ok: true, ...review });
     },
   );
 
@@ -3485,24 +3392,6 @@ function providerOperationError(
   message: string,
 ) {
   return { ok: false as const, error, message };
-}
-
-function learningRecommendationReviewFailure(reply: FastifyReply, statusCode: 409 | 502 | 503) {
-  void reply.code(statusCode);
-  return {
-    ok: false as const,
-    error: "learning_recommendation_review_failed" as const,
-    message: "The learning recommendation review could not be completed.",
-  };
-}
-
-function tailoringPolicyRollbackFailure(reply: FastifyReply, statusCode: 409 | 502 | 503) {
-  void reply.code(statusCode);
-  return {
-    ok: false as const,
-    error: "tailoring_policy_rollback_failed" as const,
-    message: "The tailoring policy rollback could not be completed.",
-  };
 }
 
 async function dispatchProviderModelCatalog(

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -42,7 +42,6 @@ import {
   DiscoveryFeedbackRequestSchema,
   GenerateMaterialsRequestSchema,
   GenerateInterviewPrepRequestSchema,
-  GmailOutcomeScanRequestSchema,
   EnsureCurrentResumeMaterialsRequestSchema,
   JobResumeTemplateAssignmentRequestSchema,
   JobListQuerySchema,
@@ -77,7 +76,6 @@ import {
   ResumeCommentReplyRequestSchema,
   ResumeReviewCommentThreadSeedRequestSchema,
   ResumeReviewDraftCreateRequestSchema,
-  ResumeReviewDraftRenderRequestSchema,
   ResumeReviewDraftRevisionSaveRequestSchema,
   TailoringFeedbackSignalReviewRequestSchema,
   RunPipelineStagesRequestSchema,
@@ -646,6 +644,49 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         withDb(reply, options.dbPath, (db) =>
           listLearningRecommendations(db, request!),
         ),
+      renderResumeReviewDraft: ({ request, pathParam: draftId }, reply) =>
+        withWritableDb(reply, options.dbPath, async (db) => {
+          const result = await renderResumeReviewDraft(
+            db,
+            draftId,
+            request,
+            resumePdfRenderer,
+          );
+          if (result.ok) {
+            refreshProjections(db);
+          }
+          return result;
+        }),
+      scanGmailApplicationOutcomes: async ({ request }, reply) => {
+        if (!databaseExists(options.dbPath)) {
+          void reply.code(503);
+          return {
+            ok: false,
+            error: "db_not_found",
+            message: `No JobCtrl database found at ${options.dbPath}`,
+          };
+        }
+        try {
+          const output = await gmailFeedbackScanner(request, {
+            appDir,
+            dbPath: options.dbPath,
+          });
+          return sanitizeGmailFeedbackScanResponse(output);
+        } catch (error) {
+          if (error instanceof GmailFeedbackScanError) {
+            void reply.code(error.statusCode);
+            return {
+              ok: false,
+              error:
+                error.statusCode === 400
+                  ? "invalid_gmail_feedback_scan"
+                  : "gmail_feedback_scan_failed",
+              message: error.message,
+            };
+          }
+          throw error;
+        }
+      },
     },
     parseBody,
   });
@@ -1246,23 +1287,6 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     },
   );
 
-  app.post<{ Params: { draftId: string } }>(
-    "/v1/resume-review/drafts/:draftId/render",
-    async (request, reply) => {
-      const body = parseBody(reply, ResumeReviewDraftRenderRequestSchema, request.body ?? {});
-      if (!body) {
-        return undefined;
-      }
-      return withWritableDb(reply, options.dbPath, async (db) => {
-        const result = await renderResumeReviewDraft(db, decodeRouteParam(request.params.draftId), body, resumePdfRenderer);
-        if (result.ok) {
-          refreshProjections(db);
-        }
-        return result;
-      });
-    },
-  );
-
   app.post<{ Params: { threadId: string } }>(
     "/v1/resume-review/comment-threads/:threadId/replies",
     async (request, reply) => {
@@ -1279,34 +1303,6 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
   app.get("/v1/outcomes", async (_request, reply) =>
     withDb(reply, options.dbPath, (db) => listApplicationOutcomes(db)),
   );
-
-  app.post("/v1/outcomes/gmail/scan", async (request, reply) => {
-    const body = parseBody(reply, GmailOutcomeScanRequestSchema, request.body ?? {});
-    if (!body) {
-      return undefined;
-    }
-    if (!databaseExists(options.dbPath)) {
-      void reply.code(503);
-      return { ok: false, error: "db_not_found", message: `No JobCtrl database found at ${options.dbPath}` };
-    }
-    try {
-      const output = await gmailFeedbackScanner(body, { appDir, dbPath: options.dbPath });
-      return sanitizeGmailFeedbackScanResponse(output);
-    } catch (error) {
-      if (error instanceof GmailFeedbackScanError) {
-        void reply.code(error.statusCode);
-        return {
-          ok: false,
-          error:
-            error.statusCode === 400
-              ? "invalid_gmail_feedback_scan"
-              : "gmail_feedback_scan_failed",
-          message: error.message,
-        };
-      }
-      throw error;
-    }
-  });
 
   app.post("/v1/jobs/bulk-delete", async (request, reply) => {
     const body = parseBody(reply, BulkJobMutationRequestSchema, request.body ?? {});

--- a/apps/api/test/rpc-contracts.test.ts
+++ b/apps/api/test/rpc-contracts.test.ts
@@ -48,6 +48,15 @@ describe("endpoint spec fixture", () => {
   it("pins every migrated request and response JSON Schema", () => {
     expect(endpointSpecJsonSchemaFixture()).toEqual(endpointSpecsFixture);
   });
+
+  it("records the indirect worker RPCs used by merged endpoint handlers", () => {
+    expect(ENDPOINTS.renderResumeReviewDraft.rpcDependencies).toEqual([
+      RpcMethods.RenderResumePdf,
+    ]);
+    expect(ENDPOINTS.scanGmailApplicationOutcomes.rpcDependencies).toEqual([
+      RpcMethods.GmailFeedbackScan,
+    ]);
+  });
 });
 
 describe("learning recommendation derivation RPC contract", () => {

--- a/apps/api/test/rpc-contracts.test.ts
+++ b/apps/api/test/rpc-contracts.test.ts
@@ -4,6 +4,9 @@
  * pair here so type drift between TS and Python surfaces in CI.
  */
 import { describe, expect, it } from "vitest";
+import endpointSpecsFixture from "../../../packages/domain-types/test/fixtures/endpoint_specs.json" with {
+  type: "json",
+};
 
 import {
   AnalyzeJobParamsSchema,
@@ -12,6 +15,8 @@ import {
   CancelRunParamsSchema,
   CancelRunResultSchema,
   DEFAULT_PIPELINE_LLM_MODEL,
+  ENDPOINTS,
+  endpointSpecJsonSchemaFixture,
   GenerateInterviewPrepRequestSchema,
   GenerateInterviewPrepParamsSchema,
   ManualCaptureImportParamsSchema,
@@ -19,10 +24,6 @@ import {
   ProviderModelCatalogResultSchema,
   RederiveLearningRecommendationsParamsSchema,
   RederiveLearningRecommendationsResultSchema,
-  ReviewLearningRecommendationParamsSchema,
-  ReviewLearningRecommendationResultSchema,
-  RollbackTailoringPolicyParamsSchema,
-  RollbackTailoringPolicyResultSchema,
   RefreshCompensationParamsSchema,
   RefreshCompensationResultSchema,
   RescoreJobParamsSchema,
@@ -37,6 +38,17 @@ import {
 } from "../src/contracts.js";
 
 const CANONICAL_JOB_ID = "11111111-1111-4111-8111-111111111111";
+const ENDPOINT_DISPATCH_CONTEXT = {
+  tenantId: "local",
+  appDir: "/tmp/jobctrl",
+  dbPath: "/tmp/jobctrl/jobctrl.db",
+} as const;
+
+describe("endpoint spec fixture", () => {
+  it("pins every migrated request and response JSON Schema", () => {
+    expect(endpointSpecJsonSchemaFixture()).toEqual(endpointSpecsFixture);
+  });
+});
 
 describe("learning recommendation derivation RPC contract", () => {
   it("registers bounded runtime-scoped request and result shapes", () => {
@@ -84,35 +96,39 @@ describe("learning recommendation derivation RPC contract", () => {
 
 describe("learning recommendation review RPC contract", () => {
   it("registers runtime-scoped review params and couples decision to policy effect", () => {
+    const endpoint = ENDPOINTS.reviewLearningRecommendation;
     const recommendationId = `learning-recommendation:${"a".repeat(64)}`;
     const reviewId = `learning-recommendation-review:${"b".repeat(64)}`;
-    expect(RpcMethods.ReviewLearningRecommendation).toBe("review_learning_recommendation");
-    expect(
-      ReviewLearningRecommendationParamsSchema.parse({
-        recommendationId,
-        decision: "accepted",
-        expectedAppDir: "/tmp/jobctrl",
-        expectedDbPath: "/tmp/jobctrl/jobctrl.db",
-      }),
-    ).toEqual({
-      tenantId: "local",
+    const request = endpoint.request.parse({ decision: "accepted" });
+    const params = endpoint.dispatch.params(
+      { request, pathParam: recommendationId },
+      ENDPOINT_DISPATCH_CONTEXT,
+    );
+    expect(endpoint.dispatch.rpcMethod).toBe("review_learning_recommendation");
+    expect(endpoint.dispatch.paramsSchema.parse(params)).toEqual(params);
+    expect(params.recommendationId).toBe(recommendationId);
+    expect(params.decision).toBe(request.decision);
+    expect(params.expectedAppDir).toBe(ENDPOINT_DISPATCH_CONTEXT.appDir);
+    expect(params.expectedDbPath).toBe(ENDPOINT_DISPATCH_CONTEXT.dbPath);
+    const acceptedResult = endpoint.dispatch.result.parse({
+      status: "succeeded",
+      reviewId,
       recommendationId,
+      revision: 1,
       decision: "accepted",
-      expectedAppDir: "/tmp/jobctrl",
-      expectedDbPath: "/tmp/jobctrl/jobctrl.db",
+      context: "materials",
+      policyKind: "tailoring_rule",
+      policyVersion: 2,
+      reviewedAt: "2026-08-01T12:34:56+00:00",
     });
     expect(
-      ReviewLearningRecommendationResultSchema.parse({
-        status: "succeeded",
-        reviewId,
-        recommendationId,
-        revision: 1,
-        decision: "accepted",
-        context: "materials",
-        policyKind: "tailoring_rule",
-        policyVersion: 2,
-        reviewedAt: "2026-08-01T12:34:56+00:00",
-      }),
+      endpoint.response.parse(
+        endpoint.dispatch.response({
+          request,
+          pathParam: recommendationId,
+          result: acceptedResult,
+        }),
+      ),
     ).toMatchObject({
       reviewId,
       recommendationId,
@@ -121,14 +137,13 @@ describe("learning recommendation review RPC contract", () => {
       reviewedAt: "2026-08-01T12:34:56.000Z",
     });
     expect(() =>
-      ReviewLearningRecommendationParamsSchema.parse({
-        recommendationId,
-        decision: "accepted",
+      endpoint.dispatch.paramsSchema.parse({
+        ...params,
         unexpected: true,
       }),
     ).toThrow();
     expect(() =>
-      ReviewLearningRecommendationResultSchema.parse({
+      endpoint.dispatch.result.parse({
         status: "succeeded",
         reviewId,
         recommendationId,
@@ -141,7 +156,7 @@ describe("learning recommendation review RPC contract", () => {
       }),
     ).toThrow();
     expect(() =>
-      ReviewLearningRecommendationResultSchema.parse({
+      endpoint.dispatch.result.parse({
         status: "succeeded",
         reviewId,
         recommendationId,
@@ -158,40 +173,45 @@ describe("learning recommendation review RPC contract", () => {
 
 describe("tailoring policy rollback RPC contract", () => {
   it("registers a runtime-scoped rollback with closed policy metadata", () => {
-    expect(RpcMethods.RollbackTailoringPolicy).toBe("rollback_tailoring_policy");
-    expect(
-      RollbackTailoringPolicyParamsSchema.parse({
-        targetVersion: 1,
-        expectedAppDir: "/tmp/jobctrl",
-        expectedDbPath: "/tmp/jobctrl/jobctrl.db",
-      }),
-    ).toEqual({
-      tenantId: "local",
-      targetVersion: 1,
-      expectedAppDir: "/tmp/jobctrl",
-      expectedDbPath: "/tmp/jobctrl/jobctrl.db",
-    });
-    expect(
-      RollbackTailoringPolicyResultSchema.parse({
-        status: "succeeded",
-        context: "materials",
-        policyKind: "tailoring_rule",
-        policyVersion: 3,
-        rollbackOfVersion: 1,
-        rollbackReasonCode: "user_requested",
-        learnedRules: [],
-        rolledBackAt: "2026-08-01T12:34:56+00:00",
-      }),
-    ).toMatchObject({
+    const endpoint = ENDPOINTS.rollbackTailoringPolicy;
+    const request = endpoint.request.parse({ targetVersion: 1 });
+    const params = endpoint.dispatch.params(
+      { request, pathParam: undefined },
+      ENDPOINT_DISPATCH_CONTEXT,
+    );
+    expect(endpoint.dispatch.rpcMethod).toBe("rollback_tailoring_policy");
+    expect(endpoint.dispatch.paramsSchema.parse(params)).toEqual(params);
+    expect(params.targetVersion).toBe(request.targetVersion);
+    expect(params.expectedAppDir).toBe(ENDPOINT_DISPATCH_CONTEXT.appDir);
+    expect(params.expectedDbPath).toBe(ENDPOINT_DISPATCH_CONTEXT.dbPath);
+    const result = endpoint.dispatch.result.parse({
+      status: "succeeded",
+      context: "materials",
+      policyKind: "tailoring_rule",
       policyVersion: 3,
       rollbackOfVersion: 1,
-      rolledBackAt: "2026-08-01T12:34:56.000Z",
+      rollbackReasonCode: "user_requested",
+      learnedRules: [],
+      rolledBackAt: "2026-08-01T12:34:56+00:00",
+    });
+    expect(
+      endpoint.response.parse(
+        endpoint.dispatch.response({
+          request,
+          pathParam: undefined,
+          result,
+        }),
+      ),
+    ).toMatchObject({
+      version: 3,
+      rollbackOfVersion: 1,
+      createdAt: "2026-08-01T12:34:56.000Z",
     });
     expect(() =>
-      RollbackTailoringPolicyParamsSchema.parse({ targetVersion: 0 }),
+      endpoint.request.parse({ targetVersion: 0 }),
     ).toThrow();
     expect(() =>
-      RollbackTailoringPolicyResultSchema.parse({
+      endpoint.dispatch.result.parse({
         status: "succeeded",
         context: "materials",
         policyKind: "tailoring_rule",


### PR DESCRIPTION
## Summary

- Add `registerEndpointRoutes(app, deps)` and derive all migrated Fastify route shells from `ENDPOINTS`.
- Route RPC endpoints through the injected dispatcher with spec-owned parameter, result, response, and error/status mappings; route direct-module endpoints through typed injected handlers.
- Delete the migrated inline routes and the hand-written learning-review and tailoring-rollback failure helpers.
- Preserve the post-#776 resume renderer and Gmail scanner injection seams while registering their HTTP shells and response validation through the same helper.
- Derive migrated RPC contract assertions from the registry and pin the two indirect worker RPC dependencies.

## Why

The server shell was another mechanical transcription of each endpoint. Central registration now owns request parsing, path decoding, dispatch selection, response validation, and failure shaping without moving domain logic out of its owning modules.

New endpoint tax, compared with the 13 files/stations measured for rollback:

- A hypothetical fourth RPC-proxied endpoint now changes 3 human-authored files: the endpoint spec, the owning domain/worker logic, and its tests. Refreshing the checked-in JSON Schema fixture makes 4 changed files in Git; none of the former client/port/fetch/demo/server-shell stations change.
- A hypothetical fourth direct-module endpoint now changes 4 human-authored files in the current composition layout: the endpoint spec, the owning domain module, the injected handler composition in `server.ts`, and its tests. With the generated fixture, that is 5 changed files; the route shell and all client/demo stations remain derived.

## Validation

- `corepack pnpm --filter @jobctrl/contracts run check` — passed.
- `corepack pnpm --filter @jobctrl/api-client run check` — passed.
- `corepack pnpm --filter @jobctrl/api run check` — passed.
- `corepack pnpm --filter @jobctrl/web run check` — passed.
- `corepack pnpm --filter @jobctrl/api exec vitest run test/rpc-contracts.test.ts` — 41/41 passed.
- `corepack pnpm --filter @jobctrl/api exec vitest run test/server.test.ts` — 233/233 passed with localhost access; this covers the unchanged 409 `InvalidParams` mappings for both write pilots.
- `corepack pnpm --filter @jobctrl/api exec vitest run test/projections.test.ts` — 41/41 passed.
- `corepack pnpm --filter @jobctrl/api exec vitest run test/resume-review-drafts.test.ts` — 16/16 passed.
- `corepack pnpm --filter @jobctrl/api exec vitest run test/application-feedback.test.ts` — 38/38 passed.
- `corepack pnpm --filter @jobctrl/api exec vitest run test/endpoint-client.test.ts` — 3/3 passed.
- `corepack pnpm --filter @jobctrl/web exec vitest run src/demo/DemoApiClientAdapter.test.ts src/demo/DemoLocalCommandExecutor.test.ts` — 34/34 passed.
- `git diff --check` — passed.
- Independent review and QA gates are intentionally left for the maintainer-side pass after publication.
