### PR TITLE
feat(discovery): expose JobStreaming provider progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,10 @@ evidence, qualifications, and the complete capability matrix.
   posting before acknowledging its provider checkpoint. If the worker stops,
   the same Discover execution resumes unfinished query/location/board units;
   accepted postings and the run-wide new-job limit survive replay, and
-  Pipelines reports how many units resumed.
+  Pipelines reports how many units resumed. JobStreaming 0.0.3 also supplies
+  cursor-free provider page progress so the active crawl can show completed
+  pages, raw listings, emitted jobs, and known continuation without guessing
+  an unavailable provider total or ETA.
 - Optionally reconcile a local Temporal Schedule for discovery; it is disabled
   by default and uses the configured cron only after you enable it.
 - Enrich postings with full descriptions, canonical posting URLs, and apply

--- a/apps/api/src/pipeline-operations.ts
+++ b/apps/api/src/pipeline-operations.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import type {
+  DiscoveryProviderProgress,
   DiscoveryExecutionSummary,
   PipelineActiveItem,
   PipelineCapacity,
@@ -1473,6 +1474,11 @@ function sourceFamilyProgress(
   if (sourceRows.length === 0 && sourcePlanRows.length === 0) return null;
   const planned = Math.max(maxDetailCount(sourcePlanRows) ?? 0, sourceRows.length);
   const counts = projectionCounts(sourceRows, planned);
+  const providerProgress = sourceRows.some(
+    (step) => step.item_key === "family:jobspy" && step.state === "running",
+  )
+    ? latestDiscoveryProviderProgress(db, tenantId, selected)
+    : null;
   return {
     planned,
     counts,
@@ -1501,6 +1507,94 @@ function sourceFamilyProgress(
       contention: sourceContention(selected, sweepCounts, globalCounts, globalRetryability, telemetry),
     }) as PipelineEta,
     asOf: generatedAt,
+    ...(providerProgress ? { providerProgress } : {}),
+  };
+}
+
+function latestDiscoveryProviderProgress(
+  db: SqliteDatabase,
+  tenantId: string,
+  selected: SelectedExecution,
+): DiscoveryProviderProgress | null {
+  const runId = nullableText(selected.row.temporal_run_id);
+  if (!runId) return null;
+  const rows = allRows<{ payload_json: string | null }>(
+    db,
+    `SELECT payload_json
+       FROM job_events
+      WHERE tenant_id = ?
+        AND job_id IS NULL
+        AND stage = 'discover'
+        AND event_type = 'StageProgress'
+        AND payload_json IS NOT NULL
+        AND json_valid(payload_json)
+        AND COALESCE(
+              json_extract(payload_json, '$.workflowId'),
+              json_extract(payload_json, '$.workflow_id')
+            ) = ?
+        AND COALESCE(
+              json_extract(payload_json, '$.discoverRunId'),
+              json_extract(payload_json, '$.discover_run_id')
+            ) = ?
+        AND (
+          json_type(payload_json, '$.progress.sourceProgress.providerProgress') = 'object'
+          OR json_type(payload_json, '$.progress.source_progress.provider_progress') = 'object'
+        )
+      ORDER BY event_id DESC
+      LIMIT 1`,
+    [tenantId, selected.row.workflow_id, runId],
+  );
+  const payload = parseRecord(rows[0]?.payload_json ?? null);
+  const progress = objectRecord(payload?.progress);
+  const sourceProgress = objectRecord(
+    progress?.sourceProgress ?? progress?.source_progress,
+  );
+  return parseDiscoveryProviderProgress(
+    sourceProgress?.providerProgress ?? sourceProgress?.provider_progress,
+  );
+}
+
+function parseDiscoveryProviderProgress(
+  value: unknown,
+): DiscoveryProviderProgress | null {
+  const progress = objectRecord(value);
+  if (!progress) return null;
+  const site = safeCode(progress.site);
+  const phase = safeCode(progress.phase);
+  const unit = safeCode(progress.unit);
+  const completedUnits = nonnegativeInteger(
+    progress.completedUnits ?? progress.completed_units,
+  );
+  const totalUnits = nullableNonnegativeInteger(
+    progress.totalUnits ?? progress.total_units,
+  );
+  const rawItemsSeen = nullableNonnegativeInteger(
+    progress.rawItemsSeen ?? progress.raw_items_seen,
+  );
+  const jobsEmitted = nonnegativeInteger(
+    progress.jobsEmitted ?? progress.jobs_emitted,
+  );
+  if (
+    !site
+    || !phase
+    || !unit
+    || completedUnits === null
+    || jobsEmitted === null
+    || (totalUnits !== null && completedUnits > totalUnits)
+    || (rawItemsSeen !== null && jobsEmitted > rawItemsSeen)
+  ) {
+    return null;
+  }
+  const hasMoreValue = progress.hasMore ?? progress.has_more;
+  return {
+    site,
+    phase,
+    unit,
+    completedUnits,
+    totalUnits,
+    rawItemsSeen,
+    jobsEmitted,
+    hasMore: typeof hasMoreValue === "boolean" ? hasMoreValue : null,
   };
 }
 
@@ -2306,6 +2400,18 @@ function nonnegative(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
 }
 
+function nonnegativeInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0
+    ? value
+    : null;
+}
+
+function nullableNonnegativeInteger(value: unknown): number | null {
+  return value === null || value === undefined
+    ? null
+    : nonnegativeInteger(value);
+}
+
 function nullableText(value: unknown): string | null {
   return typeof value === "string" && value.trim() !== "" ? value : null;
 }
@@ -2331,6 +2437,12 @@ function parseRecord(raw: string | null): Record<string, unknown> | null {
   const parsed = parseJson(raw);
   return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
     ? (parsed as Record<string, unknown>)
+    : null;
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
     : null;
 }
 

--- a/apps/api/test/pipeline-operations.test.ts
+++ b/apps/api/test/pipeline-operations.test.ts
@@ -375,6 +375,86 @@ describe("pipeline operations read model", () => {
     });
   });
 
+  it("projects exact-run JobStreaming traversal facts without provider cursors", () => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "in_progress" });
+    insertStep(fixture, {
+      stepKind: "source_planning",
+      itemKey: "plan",
+      state: "succeeded",
+      detailCount: 1,
+    });
+    insertStep(fixture, {
+      stepKind: "source_family",
+      itemKey: "family:jobspy",
+      state: "running",
+    });
+    const progressPayload = (runId: string, site: string, completedUnits: number) => ({
+      workflowId: DISCOVER_WORKFLOW_ID,
+      discoverRunId: runId,
+      progress: {
+        sourceProgress: {
+          providerProgress: {
+            site,
+            phase: "search",
+            unit: "page",
+            completedUnits,
+            totalUnits: null,
+            rawItemsSeen: 42,
+            jobsEmitted: 9,
+            hasMore: true,
+          },
+        },
+      },
+    });
+    fixture.db.prepare(
+      `INSERT INTO job_events (
+         tenant_id, job_id, identity_version, stage, event_type, level,
+         message, occurred_at, payload_json
+       ) VALUES ('local', NULL, 1, 'discover', 'StageProgress', 'info', ?, ?, ?)`,
+    ).run(
+      "current provider progress",
+      "2026-07-14T11:58:00.000Z",
+      JSON.stringify(progressPayload(DISCOVER_RUN_ID, "indeed", 3)),
+    );
+    fixture.db.prepare(
+      `INSERT INTO job_events (
+         tenant_id, job_id, identity_version, stage, event_type, level,
+         message, occurred_at, payload_json
+       ) VALUES ('local', NULL, 1, 'discover', 'StageProgress', 'info', ?, ?, ?)`,
+    ).run(
+      "newer progress from another run",
+      "2026-07-14T11:59:00.000Z",
+      JSON.stringify(progressPayload("different-temporal-run", "google", 99)),
+    );
+
+    const result = snapshot(fixture);
+
+    expect(result.sourceFamilies?.providerProgress).toEqual({
+      site: "indeed",
+      phase: "search",
+      unit: "page",
+      completedUnits: 3,
+      totalUnits: null,
+      rawItemsSeen: 42,
+      jobsEmitted: 9,
+      hasMore: true,
+    });
+    expect(JSON.stringify(result)).not.toContain("resume_state");
+    expect(JSON.stringify(result)).not.toContain("cursor");
+
+    fixture.db.prepare(
+      `UPDATE pipeline_step_projections
+          SET state = 'succeeded', finished_at = ?, duration_ms = 60000
+        WHERE tenant_id = 'local'
+          AND discover_workflow_id = ?
+          AND discover_run_id = ?
+          AND step_kind = 'source_family'
+          AND item_key = 'family:jobspy'`,
+    ).run(NOW.toISOString(), DISCOVER_WORKFLOW_ID, DISCOVER_RUN_ID);
+    expect(snapshot(fixture).sourceFamilies?.providerProgress).toBeUndefined();
+  });
+
   it("uses every bucket exactly once for the current execution stage scope", () => {
     const fixture = createFixture();
     insertExecution(fixture, { status: "in_progress" });

--- a/apps/web/src/views/pipelines/PipelinesView.fixtures.ts
+++ b/apps/web/src/views/pipelines/PipelinesView.fixtures.ts
@@ -158,6 +158,16 @@ function snapshot(overrides: Partial<PipelineOperationsSnapshot> = {}): Pipeline
       counts: counts({ eligible: 3, processing: 2, succeeded: 1 }),
       eta: etaAvailable,
       asOf: AS_OF,
+      providerProgress: {
+        site: "indeed",
+        phase: "search",
+        unit: "page",
+        completedUnits: 3,
+        totalUnits: null,
+        rawItemsSeen: 42,
+        jobsEmitted: 9,
+        hasMore: true,
+      },
     },
     reconciliation: {
       enrichment: counts({ eligible: 1, waiting: 1 }),

--- a/apps/web/src/views/pipelines/PipelinesView.test.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.test.tsx
@@ -132,6 +132,12 @@ describe("PipelinesView", () => {
     expect(
       within(crawl).getByRole("progressbar", { name: "Stage progress" }),
     ).toHaveAttribute("aria-valuenow", "33");
+    expect(
+      within(crawl).getByRole("heading", { name: "Provider traversal" }),
+    ).toBeInTheDocument();
+    expect(crawl).toHaveTextContent(
+      "Indeed · 3 pages completed; provider total unavailable · 42 raw listings seen · 9 jobs emitted · more pages available",
+    );
 
     expect(
       screen.queryByRole("region", { name: "Execution sweep ledger table" }),

--- a/apps/web/src/views/pipelines/PipelinesView.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.tsx
@@ -1,4 +1,5 @@
 import type {
+  DiscoveryProviderProgress,
   PipelineActiveItem,
   PipelineApproximateTaskQueue,
   PipelineCapacity,
@@ -87,6 +88,24 @@ const COHORT_FIELDS = [
   ["terminal", "Terminal"],
   ["remaining", "Remaining"],
 ] as const;
+
+function providerProgressLabel(progress: DiscoveryProviderProgress): string {
+  const unit = progress.completedUnits === 1
+    ? progress.unit
+    : `${progress.unit}s`;
+  const completion = progress.totalUnits === null
+    ? `${progress.completedUnits} ${unit} completed; provider total unavailable`
+    : `${progress.completedUnits}/${progress.totalUnits} ${unit} completed`;
+  const raw = progress.rawItemsSeen === null
+    ? "raw listing count unavailable"
+    : `${progress.rawItemsSeen} raw listings seen`;
+  const continuation = progress.hasMore === true
+    ? "more pages available"
+    : progress.hasMore === false
+      ? "no more pages"
+      : "continuation unknown";
+  return `${sentenceCase(progress.site)} · ${completion} · ${raw} · ${progress.jobsEmitted} jobs emitted · ${continuation}`;
+}
 
 function statusTone(status: string): StatusTagTone {
   if (["available", "completed", "fresh", "succeeded"].includes(status)) {
@@ -669,10 +688,12 @@ function StageRows({
 }
 
 function PipelineStageRow({
+  providerProgress,
   recoveryLabel,
   stage,
   trackingReady,
 }: {
+  readonly providerProgress?: DiscoveryProviderProgress;
   readonly recoveryLabel: string;
   readonly stage: PipelineOperationalStage;
   readonly trackingReady: boolean;
@@ -733,6 +754,12 @@ function PipelineStageRow({
                 <span data-typography="label">ETA</span>
                 <strong data-typography="strong-body">{etaLabel(stage.eta)}</strong>
               </div>
+            ) : null}
+            {providerProgress ? (
+              <section className="pipeline-stage-row__outcomes">
+                <h4 data-typography="component-title">Provider traversal</h4>
+                <p data-typography="body">{providerProgressLabel(providerProgress)}</p>
+              </section>
             ) : null}
             <section className="pipeline-stage-row__outcomes">
               <h4 data-typography="component-title">Exact outcomes</h4>
@@ -1104,6 +1131,13 @@ function PipelineLiveFlow({
             {currentStages.map((stage, index) => (
               <PipelineStageRow
                 key={`${stage.scope}-${stage.stage}-${index}`}
+                {...(stage.stage === "source_family"
+                  && snapshot.sourceFamilies?.providerProgress
+                  ? {
+                      providerProgress:
+                        snapshot.sourceFamilies.providerProgress,
+                    }
+                  : {})}
                 recoveryLabel="Restoring history"
                 stage={stage}
                 trackingReady

--- a/docs/api/complete-contract.md
+++ b/docs/api/complete-contract.md
@@ -387,7 +387,7 @@ schema:
 | `freshness` | Discriminated `fresh`, `stale`, `unsupported`, or `unavailable`; every arm carries `asOf` and `staleAfterSeconds`, and non-fresh arms carry a bounded reason. |
 | `execution` | `null` or exact Discover identity/status/phase/membership closure, timestamps/error code, and `currentExecution` / `sweptExistingBacklog` cohort summaries. Each cohort has `members`, `planned`, `notEligible`, `pending`, `failedPlan`, `terminal`, and `remaining`. |
 | `capacity` | Discriminated `available`, `stale`, or `unavailable`; see below. |
-| `sourceFamilies` | `null` or `{ planned, counts, eta, asOf }`. |
+| `sourceFamilies` | `null` or `{ planned, counts, eta, asOf, providerProgress? }`. The optional progress object contains `{ site, phase, unit, completedUnits, totalUnits, rawItemsSeen, jobsEmitted, hasMore }`; nullable provider facts remain `null`. |
 | `reconciliation` | `null` or `{ enrichment, preparationFanout, asOf }`, where both values use the canonical stage-count shape. |
 | `projectionCoverage` | `null` only when no execution is selected and fresh available telemetry proves zero active slots; otherwise the `ready`, `recovering`, `retrying`, or terminal `incomplete` exact-lineage checkpoint described below. |
 | `stages` | Ordered `PipelineOperationalStage[]`; each has `stage`, `label`, `scope`, `currentExecution`, `existingBacklog`, `capacity`, `eta`, and `asOf`. |
@@ -396,6 +396,14 @@ schema:
 | `activeItemsTotal` | Exact allowlisted active-detail count, or `null` when inventory cannot make an exact statement. |
 | `activeItemsTruncated` | Whether safe detail was omitted, or `null` when inventory is unavailable/stale. |
 | `overallEta` | The ETA discriminated union below. |
+
+`sourceFamilies.providerProgress` is a cursor-free observation from the latest
+JobStreaming provider event for the selected execution's exact
+`{ discoverWorkflowId, discoverRunId }`. It is projected only while that
+execution's `family:jobspy` source step is running and is omitted after the
+source step becomes terminal, so an older event cannot look current. The field
+never contains a provider cursor, checkpoint, resume token, raw provider
+payload, or other continuation state.
 
 `projectionCoverage.status = "ready"` carries `mode` (`native` or
 `reconstructed`), `decoderVersion`, `historyEventId`, verified

--- a/docs/api/operations-and-events.md
+++ b/docs/api/operations-and-events.md
@@ -118,6 +118,15 @@ calculation: unresolved current jobs or swept backlog can keep a successful
 Discover workflow in `draining`, while a closed membership with failed or
 inconsistent planning/terminal steps produces `completed_with_issues`.
 
+While the selected execution's `family:jobspy` source step is running,
+`sourceFamilies.providerProgress` may expose the latest normalized
+JobStreaming traversal observation: `site`, `phase`, `unit`, completed and
+optional total units, optional raw-items-seen count, jobs emitted, and optional
+continuation status. The API binds the event to both the exact Discover
+workflow ID and Temporal run ID, omits it when the source step is terminal, and
+never exposes the provider cursor, checkpoint, resume token, raw provider
+payload, or other continuation state.
+
 The Dashboard/Pipelines progress projection may include
 `sourceProgress.recoveredUnits` for the compatibility-named `jobspy` family.
 It counts immutable JobStreaming query/location/board units reclaimed by a

--- a/docs/architecture/pipeline/envelope.md
+++ b/docs/architecture/pipeline/envelope.md
@@ -128,7 +128,7 @@ required-step list is never interpreted as proof of no work.
 ### Broad-Board Search Unit Envelope
 
 The `jobspy` source family name remains a compatibility key, but its provider is
-JobStreaming 0.0.2. At activity start, JobCtrl compiles or verifies an immutable
+JobStreaming 0.0.3. At activity start, JobCtrl compiles or verifies an immutable
 ordered plan of query/location/board units under the exact
 `DiscoveryExecutionRef`. Changing the live target-search configuration cannot
 rewrite a retrying execution's persisted plan.

--- a/docs/architecture/pipeline/operations.md
+++ b/docs/architecture/pipeline/operations.md
@@ -119,8 +119,14 @@ Broad-board progress uses `search units` as its source-level unit. Its
 `filteredJobs` comes from hashed filtered-result receipts, and `recoveredUnits`
 counts units reclaimed by a newer Temporal activity attempt.
 The TypeScript read model preserves that optional field and Pipelines renders
-it as `N resumed`. Raw provider output, checkpoints, owner tokens, and error
-messages are not projected into this broad progress payload.
+it as `N resumed`. JobStreaming 0.0.3 `ProviderProgress` is a separate immutable
+value inside the source progress: provider, phase, unit, completed/total units,
+raw items seen, emitted jobs, and tri-state continuation. The worker stamps the
+exact Discover workflow/run identity onto the progress event, and Operations
+accepts only a matching execution before rendering the latest traversal facts.
+Unknown provider totals stay null and do not become a synthetic percentage or
+ETA. Raw provider output, cursors, resume dictionaries, checkpoints, owner
+tokens, and error messages are not projected into this broad progress payload.
 
 ## Pipeline Operations Snapshot
 
@@ -169,6 +175,12 @@ Source-family progress and reconciliation are also separate. The former counts
 planned family crawls; the latter counts enrichment passes and preparation
 fan-out. Source completion therefore never implies that downstream scoring,
 materials, or PDF work is complete.
+
+Provider traversal progress is observational evidence inside the active broad-
+board family, not a third completion authority. It can explain that a provider
+has completed pages and whether continuation is known. It cannot bound shared-
+pool contention or establish remaining pages when `totalUnits` is null, so the
+ETA estimator remains conservative in those states.
 
 The API prefers an active or draining Discover execution and otherwise shows
 the latest terminal execution. The phase vocabulary is `discovering`,

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -492,7 +492,7 @@ draft leg.
 
 ### Broad-Board Provider Boundary
 
-JobStreaming 0.0.2 is the provider boundary for Indeed, LinkedIn, Glassdoor,
+JobStreaming 0.0.3 is the provider boundary for Indeed, LinkedIn, Glassdoor,
 and ZipRecruiter. The infrastructure gateway translates JobCtrl-owned immutable
 search specifications into provider requests and projects typed provider events
 back into the existing discovery ingestion shape. Provider types do not enter

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2140,6 +2140,11 @@ Cites: `docs/plans/implemented/2026-07-17-resumable-jobstreaming-discovery-plan.
 `docs/architecture/pipeline/envelope.md`; `docs/architecture/storage.md`;
 `workers/automation/tests/test_jobstreaming_resumable_discovery.py`.
 
+Amended (2026-08-10): the provider pin advances to JobStreaming 0.0.3. Its
+normalized, cursor-free `ProviderProgress` observations are projected under the
+exact Discover workflow/run identity, while provider totals remain nullable and
+separate from JobCtrl acceptance counts and whole-pipeline ETA evidence.
+
 ## 2026-07-29: Stable Job Identity And Human-Approved Feedback Learning
 
 Status: accepted

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -50,7 +50,7 @@ corepack pnpm dev:setup
 
 `corepack pnpm dev:setup` installs the Node workspace dependencies and runs
 `uv --project workers/automation sync --extra dev`, which installs the Python
-worker, the pinned `jobstreaming==0.0.2` provider, its locked transitive
+worker, the pinned `jobstreaming==0.0.3` provider, its locked transitive
 dependencies, and the Python dev tools used by local checks. It does not install Temporal or
 Playwright browser binaries. System Chrome/Chromium is optional; contributor
 testing of apply behavior must explicitly enable a browser capability first.

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -96,6 +96,21 @@ uv --project workers/automation run pytest -q \
   workers/automation/tests/test_jobstreaming_gateway.py
 ```
 
+The provider-progress regression additionally emits a JobStreaming page
+boundary carrying a private fake cursor. Verify that the worker callback,
+exact-run Operations response, and expanded **Crawl sources** row expose only
+the normalized provider/page counts and continuation state. The private cursor
+must be absent, an event from another Temporal run must not leak into the
+selected execution, and a missing provider total must render as unavailable
+rather than a synthetic percentage:
+
+```bash
+corepack pnpm --filter @jobctrl/api exec vitest run \
+  test/pipeline-operations.test.ts
+corepack pnpm --filter @jobctrl/web exec vitest run \
+  src/views/pipelines/PipelinesView.test.tsx
+```
+
 ### Preparation ownership and four-process chaos
 
 Score, Tailor, and Cover must recover from both sides of the commit boundary:

--- a/docs/user/discovery.md
+++ b/docs/user/discovery.md
@@ -140,7 +140,11 @@ The workspace deliberately keeps different scopes and units separate:
 - **Source-family progress** reports source intake; enrichment and preparation
   reconciliation report the downstream drain. A finished crawl can therefore
   coexist with preparation that is still running. Broad-board progress also
-  reports how many interrupted search units resumed.
+  reports how many interrupted search units resumed. While a board is active,
+  its latest provider traversal facts show completed pages, raw listings,
+  emitted jobs, and whether more pages are known to exist. When the provider
+  does not publish a total page count, JobCtrl says the total is unavailable
+  instead of inventing a percentage or finish time.
 - **Worker capacity** reports Temporal workers and shared activity slots.
   Source-family internal concurrency is a separate control, and approximate
   task-queue depth is not a count of domain jobs.
@@ -187,7 +191,7 @@ Temporal run ID, and the bounded repair reason code remain available under
 
 ### Resumable Broad-Board Searches
 
-Broad-board discovery uses JobStreaming 0.0.2. At the beginning of the source
+Broad-board discovery uses JobStreaming 0.0.3. At the beginning of the source
 activity, JobCtrl compiles an immutable unit for every query, target/provider
 location, and board under the exact Discover workflow/run identity. JobCtrl,
 not the provider, owns whether that unit is pending, running, completed, failed,
@@ -209,6 +213,13 @@ cursor is reset only after its error event has been acknowledged. Request or
 cursor-schema incompatibility fails explicitly instead of silently starting a
 different search. Healthy boards and already accepted postings remain useful
 when another board fails. Pipelines shows `N resumed` when recovery happened.
+
+JobStreaming page progress is projected separately from JobCtrl acceptance
+counts. The provider payload contains no cursor or resume dictionary, and the
+Pipelines operations view binds it to the exact Discover workflow/run before
+displaying it. These traversal facts explain current crawl activity; they do
+not override a whole-stage ETA that is unavailable because shared worker-pool
+contention or an authoritative provider total is still unknown.
 
 **Stop discovery** is different from interruption: cooperative cancellation
 interrupts provider waits and marks active and pending units canceled. Canceled

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2994,6 +2994,22 @@ export interface ActivityEventResponse {
   event: ActivityEventSummary;
 }
 
+export const DiscoveryProviderProgressSchema = z
+  .object({
+    site: z.string().min(1),
+    phase: z.string().min(1),
+    unit: z.string().min(1),
+    completedUnits: z.number().int().nonnegative(),
+    totalUnits: z.number().int().nonnegative().nullable(),
+    rawItemsSeen: z.number().int().nonnegative().nullable(),
+    jobsEmitted: z.number().int().nonnegative(),
+    hasMore: z.boolean().nullable(),
+  })
+  .strict();
+export type DiscoveryProviderProgress = z.infer<
+  typeof DiscoveryProviderProgressSchema
+>;
+
 export interface PipelineProgressSummary {
   stage: Stage;
   status: "running" | "succeeded" | "failed" | "partial";
@@ -3315,6 +3331,7 @@ export const SourceFamilyProgressSchema = z
     counts: PipelineStageCountsSchema,
     eta: PipelineEtaSchema,
     asOf: z.string(),
+    providerProgress: DiscoveryProviderProgressSchema.nullable().optional(),
   })
   .strict();
 export type SourceFamilyProgress = z.infer<typeof SourceFamilyProgressSchema>;

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "opentelemetry-instrumentation-httpx>=0.48b0",
     # Typed, concurrent job-board events plus resumable checkpoints. Pin the
     # integration contract so JobCtrl's durable adapter changes deliberately.
-    "jobstreaming==0.0.2",
+    "jobstreaming==0.0.3",
     # Pydantic backs the canonical employer-analysis domain model
     # (``domain/materials/analysis.py``) and is also pulled transitively by
     # the agent SDKs below. Declared explicitly because the domain layer
@@ -130,4 +130,4 @@ default-groups = ["provider-runtime"]
 # the lockfile whenever the graph is refreshed. Provider runtimes and the
 # audited JobStreaming integration retain their explicit reviewed cutoffs.
 exclude-newer = "7 days"
-exclude-newer-package = { "google-antigravity" = "2026-06-04T21:19:27Z", "claude-agent-sdk" = "2026-07-10T00:00:00Z", "jobstreaming" = "2026-07-18T00:00:00Z" }
+exclude-newer-package = { "google-antigravity" = "2026-06-04T21:19:27Z", "claude-agent-sdk" = "2026-07-10T00:00:00Z", "jobstreaming" = "2026-08-10T23:59:59Z" }

--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -95,7 +95,7 @@ def _scrape_with_retry(kwargs: dict, max_retries: int = 2, backoff: float = 5.0)
             scrape_legacy_options,
         )
     except ImportError as exc:
-        raise ImportError("jobstreaming 0.0.2 is not installed. Run the JobCtrl setup again.") from exc
+        raise ImportError("jobstreaming 0.0.3 is not installed. Run the JobCtrl setup again.") from exc
     return scrape_legacy_options(
         kwargs,
         max_retries=max_retries,
@@ -1618,6 +1618,7 @@ def _durable_progress_snapshot(
     filtered_jobs: int,
     raw_total: int,
     message: str,
+    provider_progress: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     terminal = {"completed", "skipped", "failed", "canceled"}
     snapshot: dict[str, Any] = {
@@ -1635,6 +1636,9 @@ def _durable_progress_snapshot(
     if current is not None:
         snapshot["current_query"] = current.spec.query
         snapshot["current_location"] = current.spec.target_location
+    if provider_progress is not None:
+        snapshot["provider_progress"] = provider_progress
+        snapshot["providerProgress"] = provider_progress
     return snapshot
 
 
@@ -1702,6 +1706,7 @@ def _durable_full_crawl(
         run_id=run_id,
     )
     stopped_for_limit = False
+    latest_provider_progress: dict[str, Any] | None = None
 
     def emit_progress(current: DiscoverySearchUnit | None, message: str) -> None:
         if progress_callback is None:
@@ -1718,6 +1723,7 @@ def _durable_full_crawl(
                     discovery_execution
                 ),
                 message=message,
+                provider_progress=latest_provider_progress,
             )
         )
 
@@ -1764,6 +1770,7 @@ def _durable_full_crawl(
         repository.reset_checkpoint_if_requested(lease)
         unit = repository.get_unit(discovery_execution, lease.unit_id)
         assert unit is not None
+        latest_provider_progress = None
         message = (
             "Resuming interrupted JobStreaming search unit"
             if unit.recovered
@@ -1905,7 +1912,28 @@ def _durable_full_crawl(
                                 raise DiscoveryResumeRequired(
                                     "JobStreaming ended without a terminal board outcome"
                                 )
-                        elif isinstance(event, (ProgressEvent, WarningEvent)):
+                        elif isinstance(event, ProgressEvent):
+                            latest_provider_progress = {
+                                "site": event.site.value,
+                                "phase": event.progress.phase.value,
+                                "unit": event.progress.unit.value,
+                                "completed_units": event.progress.completed_units,
+                                "completedUnits": event.progress.completed_units,
+                                "total_units": event.progress.total_units,
+                                "totalUnits": event.progress.total_units,
+                                "raw_items_seen": event.progress.raw_items_seen,
+                                "rawItemsSeen": event.progress.raw_items_seen,
+                                "jobs_emitted": event.progress.jobs_emitted,
+                                "jobsEmitted": event.progress.jobs_emitted,
+                                "has_more": event.progress.has_more,
+                                "hasMore": event.progress.has_more,
+                            }
+                            emit_progress(
+                                unit,
+                                "JobStreaming provider page completed",
+                            )
+                            stream.ack(event)
+                        elif isinstance(event, WarningEvent):
                             stream.ack(event)
                         else:  # pragma: no cover - pinned event union is exhaustive
                             raise TypeError(

--- a/workers/automation/src/jobctrl/domain/discovery/__init__.py
+++ b/workers/automation/src/jobctrl/domain/discovery/__init__.py
@@ -65,6 +65,7 @@ from jobctrl.domain.discovery.source_registry import (
     validate_locator_candidate,
 )
 from jobctrl.domain.discovery.scheduler import (
+    DiscoveryProviderProgress,
     DiscoveryRun,
     DiscoveryRunCounts,
     DiscoveryRunProgress,
@@ -123,6 +124,7 @@ __all__ = [
     "SourceRegistryEntry",
     "SourceState",
     "validate_locator_candidate",
+    "DiscoveryProviderProgress",
     "DiscoveryRun",
     "DiscoveryRunCounts",
     "DiscoveryRunProgress",

--- a/workers/automation/src/jobctrl/domain/discovery/scheduler.py
+++ b/workers/automation/src/jobctrl/domain/discovery/scheduler.py
@@ -88,6 +88,62 @@ class DiscoveryRunCounts:
 
 
 @dataclass(frozen=True)
+class DiscoveryProviderProgress:
+    """Client-safe traversal facts for the latest provider observation."""
+
+    site: str
+    phase: str
+    unit: str
+    completed_units: int
+    total_units: int | None
+    raw_items_seen: int | None
+    jobs_emitted: int
+    has_more: bool | None
+
+    def __post_init__(self) -> None:
+        for field_name, value in (
+            ("site", self.site),
+            ("phase", self.phase),
+            ("unit", self.unit),
+        ):
+            if not value.strip():
+                raise ValueError(f"{field_name} must be non-empty")
+        for field_name, value in (
+            ("completed_units", self.completed_units),
+            ("jobs_emitted", self.jobs_emitted),
+        ):
+            if value < 0:
+                raise ValueError(f"{field_name} must be non-negative")
+        for field_name, value in (
+            ("total_units", self.total_units),
+            ("raw_items_seen", self.raw_items_seen),
+        ):
+            if value is not None and value < 0:
+                raise ValueError(f"{field_name} must be non-negative when supplied")
+        if self.total_units is not None and self.completed_units > self.total_units:
+            raise ValueError("completed_units cannot exceed total_units")
+        if self.raw_items_seen is not None and self.jobs_emitted > self.raw_items_seen:
+            raise ValueError("jobs_emitted cannot exceed raw_items_seen")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "site": self.site,
+            "phase": self.phase,
+            "unit": self.unit,
+            "completed_units": self.completed_units,
+            "completedUnits": self.completed_units,
+            "total_units": self.total_units,
+            "totalUnits": self.total_units,
+            "raw_items_seen": self.raw_items_seen,
+            "rawItemsSeen": self.raw_items_seen,
+            "jobs_emitted": self.jobs_emitted,
+            "jobsEmitted": self.jobs_emitted,
+            "has_more": self.has_more,
+            "hasMore": self.has_more,
+        }
+
+
+@dataclass(frozen=True)
 class DiscoveryRunProgress:
     completed: int = 0
     total: int = 0
@@ -100,6 +156,7 @@ class DiscoveryRunProgress:
     error_count: int | None = None
     raw_total: int | None = None
     recovered_units: int | None = None
+    provider_progress: DiscoveryProviderProgress | None = None
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -122,6 +179,16 @@ class DiscoveryRunProgress:
             "rawTotal": self.raw_total,
             "recovered_units": self.recovered_units,
             "recoveredUnits": self.recovered_units,
+            "provider_progress": (
+                self.provider_progress.to_dict()
+                if self.provider_progress is not None
+                else None
+            ),
+            "providerProgress": (
+                self.provider_progress.to_dict()
+                if self.provider_progress is not None
+                else None
+            ),
         }
 
 

--- a/workers/automation/src/jobctrl/infrastructure/discovery/jobstreaming_gateway.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/jobstreaming_gateway.py
@@ -34,7 +34,7 @@ from jobstreaming import (
     default_registry,
     stream_search,
 )
-from jobstreaming.result import jobs_to_dataframe
+from jobstreaming.batch import jobs_to_dataframe
 
 
 @dataclass(frozen=True, slots=True)
@@ -115,7 +115,7 @@ _TLS_CLIENT_SITES = frozenset({Site.GLASSDOOR, Site.ZIP_RECRUITER})
 
 
 class _IntegralTlsTimeoutAdapter(Scraper):
-    """Normalize JobStreaming 0.0.2's float timeout for tls-client adapters."""
+    """Normalize the provider timeout for tls-client adapters that require ints."""
 
     def __init__(self, delegate: Scraper) -> None:
         super().__init__(
@@ -157,13 +157,12 @@ def _normalize_tls_adapter_timeouts(
             site,
             factory,
             replace=True,
-            cursor_schema_version=source.cursor_schema_version(site),
         )
     return normalized
 
 
 class JobStreamingGateway:
-    """Build and consume the pinned JobStreaming 0.0.2 event contract."""
+    """Build and consume the pinned JobStreaming 0.0.3 event contract."""
 
     @staticmethod
     def build_request(spec: JobStreamingSearchSpec) -> SearchRequest:

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_run_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_run_repository.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from jobctrl.database import ensure_discovery_run_tables
 from jobctrl.domain.discovery.scheduler import (
+    DiscoveryProviderProgress,
     DiscoveryRun,
     DiscoveryRunCounts,
     DiscoveryRunProgress,
@@ -106,6 +107,9 @@ def _row_to_run(row: sqlite3.Row | tuple[Any, ...]) -> DiscoveryRun:
 
     counts = _json_dict(get("counts_json", 5))
     progress = _json_dict(get("progress_json", 6))
+    provider_progress = _provider_progress(
+        _first_present(progress, "provider_progress", "providerProgress")
+    )
     return DiscoveryRun(
         tenant_id=TenantId(str(get("tenant_id", 0))),
         run_id=str(get("run_id", 1)),
@@ -134,6 +138,7 @@ def _row_to_run(row: sqlite3.Row | tuple[Any, ...]) -> DiscoveryRun:
             recovered_units=_nullable_int(
                 _first_present(progress, "recovered_units", "recoveredUnits")
             ),
+            provider_progress=provider_progress,
         ),
         error_classes=tuple(str(value) for value in _json_list(get("error_classes_json", 7))),
         started_at=str(get("started_at", 8)),
@@ -176,6 +181,47 @@ def _nullable_int(value: object) -> int | None:
     try:
         return int(value)
     except (TypeError, ValueError):
+        return None
+
+
+def _provider_progress(value: object) -> DiscoveryProviderProgress | None:
+    if not isinstance(value, dict):
+        return None
+    site = _nullable_str(value.get("site"))
+    phase = _nullable_str(value.get("phase"))
+    unit = _nullable_str(value.get("unit"))
+    completed_units = _nullable_int(
+        _first_present(value, "completed_units", "completedUnits")
+    )
+    jobs_emitted = _nullable_int(
+        _first_present(value, "jobs_emitted", "jobsEmitted")
+    )
+    if (
+        site is None
+        or phase is None
+        or unit is None
+        or completed_units is None
+        or jobs_emitted is None
+    ):
+        return None
+    has_more_value = _first_present(value, "has_more", "hasMore")
+    has_more = has_more_value if isinstance(has_more_value, bool) else None
+    try:
+        return DiscoveryProviderProgress(
+            site=site,
+            phase=phase,
+            unit=unit,
+            completed_units=completed_units,
+            total_units=_nullable_int(
+                _first_present(value, "total_units", "totalUnits")
+            ),
+            raw_items_seen=_nullable_int(
+                _first_present(value, "raw_items_seen", "rawItemsSeen")
+            ),
+            jobs_emitted=jobs_emitted,
+            has_more=has_more,
+        )
+    except ValueError:
         return None
 
 

--- a/workers/automation/src/jobctrl/pipeline/runner.py
+++ b/workers/automation/src/jobctrl/pipeline/runner.py
@@ -20,6 +20,7 @@ from jobctrl import config
 from jobctrl import database as db_module
 from jobctrl.database import init_db, get_connection
 from jobctrl.domain.discovery.scheduler import (
+    DiscoveryProviderProgress,
     DiscoveryRun,
     DiscoveryRunCounts,
     DiscoveryRunProgress,
@@ -737,6 +738,7 @@ def _record_discovery_source_progress(
     progress_total: int,
     source_progress: DiscoveryRunProgress,
     message: str,
+    discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> None:
     now = utc_now()
     counts = DiscoveryRunCounts(
@@ -772,6 +774,14 @@ def _record_discovery_source_progress(
             "sourceLabel": label,
             "runId": run_id,
             "sourceIds": list(source_ids),
+            **(
+                {
+                    "discoverWorkflowId": discovery_execution.workflow_id,
+                    "discoverRunId": discovery_execution.temporal_run_id,
+                }
+                if discovery_execution is not None
+                else {}
+            ),
             **_discovery_progress_payload(
                 completed=progress_completed,
                 total=progress_total,
@@ -1303,6 +1313,10 @@ def _optional_text(value: object) -> str | None:
     return text or None
 
 
+def _optional_bool(value: object) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
 def _first_present(*values: object) -> object:
     for value in values:
         if value is not None:
@@ -1508,6 +1522,7 @@ def run_discovery_source_family(
                     source_ids=tuple(item.source_id for item in jobspy_sources if item.should_run),
                     progress_completed=progress_completed,
                     progress_total=progress_total,
+                    discovery_execution=discovery_execution,
                 ),
             )
             return run_discovery(**run_kwargs)
@@ -1910,6 +1925,7 @@ def _jobspy_progress_callback(
     source_ids: tuple[str, ...],
     progress_completed: int,
     progress_total: int,
+    discovery_execution: DiscoveryExecutionRef | None,
 ) -> Callable[[dict[str, Any]], None] | None:
     if not run_id:
         return None
@@ -1920,6 +1936,7 @@ def _jobspy_progress_callback(
             snapshot.get("error_count"),
             snapshot.get("errorCount"),
         )
+        provider_progress = _discovery_provider_progress(snapshot)
         _record_discovery_source_progress(
             source="jobspy",
             label="Broad boards",
@@ -1952,11 +1969,63 @@ def _jobspy_progress_callback(
                         snapshot.get("recoveredUnits"),
                     )
                 ),
+                provider_progress=provider_progress,
             ),
             message=str(snapshot.get("message") or "JobStreaming progress updated"),
+            discovery_execution=discovery_execution,
         )
 
     return record_jobspy_progress
+
+
+def _discovery_provider_progress(
+    snapshot: dict[str, Any],
+) -> DiscoveryProviderProgress | None:
+    raw = _first_present(
+        snapshot.get("provider_progress"),
+        snapshot.get("providerProgress"),
+    )
+    if not isinstance(raw, dict):
+        return None
+    site = _optional_text(raw.get("site"))
+    phase = _optional_text(raw.get("phase"))
+    unit = _optional_text(raw.get("unit"))
+    completed_units = _optional_int(
+        _first_present(raw.get("completed_units"), raw.get("completedUnits"))
+    )
+    jobs_emitted = _optional_int(
+        _first_present(raw.get("jobs_emitted"), raw.get("jobsEmitted"))
+    )
+    if (
+        site is None
+        or phase is None
+        or unit is None
+        or completed_units is None
+        or jobs_emitted is None
+    ):
+        return None
+    try:
+        return DiscoveryProviderProgress(
+            site=site,
+            phase=phase,
+            unit=unit,
+            completed_units=completed_units,
+            total_units=_optional_int(
+                _first_present(raw.get("total_units"), raw.get("totalUnits"))
+            ),
+            raw_items_seen=_optional_int(
+                _first_present(
+                    raw.get("raw_items_seen"),
+                    raw.get("rawItemsSeen"),
+                )
+            ),
+            jobs_emitted=jobs_emitted,
+            has_more=_optional_bool(
+                _first_present(raw.get("has_more"), raw.get("hasMore"))
+            ),
+        )
+    except ValueError:
+        return None
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -1645,11 +1645,11 @@ def test_jobspy_normalizes_source_locations_before_storage(tmp_path):
 
 def test_jobspy_missing_dependency_is_not_reported_as_empty_success(monkeypatch):
     def missing_jobspy(_kwargs: dict, max_retries: int = 2, backoff: float = 5.0):
-        raise ImportError("jobstreaming 0.0.2 is not installed")
+        raise ImportError("jobstreaming 0.0.3 is not installed")
 
     monkeypatch.setattr(jobspy, "_scrape_with_retry", missing_jobspy)
 
-    with pytest.raises(ImportError, match="jobstreaming 0.0.2"):
+    with pytest.raises(ImportError, match="jobstreaming 0.0.3"):
         jobspy._run_one_search(
             {"query": "Director of Engineering", "location": "Barcelona, Spain", "remote": True},
             ["indeed"],

--- a/workers/automation/tests/test_jobstreaming_resumable_discovery.py
+++ b/workers/automation/tests/test_jobstreaming_resumable_discovery.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor
@@ -20,6 +21,8 @@ from jobstreaming import (
     JobPost,
     JobResponse,
     Location,
+    Resumable,
+    ResumeGranularity,
     Scraper,
     SearchCheckpoint,
     Site,
@@ -115,6 +118,30 @@ class _SuccessfulIndeed(_PagedIndeed):
             {"next": 1},
         )
         return JobResponse()
+
+
+class _ProgressIndeed(_SuccessfulIndeed):
+    def scrape(self, request, context=None) -> JobResponse:
+        assert context is not None
+        response = super().scrape(request, context=context)
+        context.emit_progress(
+            {"next": 1, "private_cursor": "must-not-project"},
+            completed_units=3,
+            total_units=None,
+            raw_items_seen=12,
+            has_more=True,
+        )
+        return response
+
+
+class _SchemaV2Indeed(_SuccessfulIndeed):
+    capabilities = AdapterCapabilities(
+        filters=frozenset({"location", "is_remote", "hours_old"}),
+        resume=Resumable(
+            granularity=ResumeGranularity.PAGE,
+            cursor_schema_version=2,
+        ),
+    )
 
 
 class _FilteredIndeed(Scraper):
@@ -436,6 +463,45 @@ def test_store_before_ack_replay_resumes_without_duplicate_counts_or_events(
     )
 
 
+def test_provider_progress_is_projected_without_private_resume_state(
+    discovery_db,
+) -> None:
+    _conn, _db_path = discovery_db
+    progress: list[dict] = []
+
+    result = jobspy.run_discovery(
+        cfg=_config(),
+        progress_callback=progress.append,
+        discovery_execution=_execution("temporal-run-provider-progress"),
+        activity_attempt=1,
+        activity_owner_token="provider-progress-attempt-1",
+        adapter_registry=_registry(indeed_factory=_ProgressIndeed),
+    )
+
+    provider_snapshot = next(
+        snapshot
+        for snapshot in progress
+        if snapshot["message"] == "JobStreaming provider page completed"
+    )
+    assert provider_snapshot["providerProgress"] == {
+        "site": "indeed",
+        "phase": "search",
+        "unit": "page",
+        "completed_units": 3,
+        "completedUnits": 3,
+        "total_units": None,
+        "totalUnits": None,
+        "raw_items_seen": 12,
+        "rawItemsSeen": 12,
+        "jobs_emitted": 1,
+        "jobsEmitted": 1,
+        "has_more": True,
+        "hasMore": True,
+    }
+    assert "private_cursor" not in json.dumps(provider_snapshot)
+    assert result["new"] == 1
+
+
 def test_filtered_count_survives_loss_after_acknowledgement(
     discovery_db,
     monkeypatch: pytest.MonkeyPatch,
@@ -712,11 +778,7 @@ def test_incompatible_cursor_schema_fails_explicitly_without_resetting(
     )
     repository.checkpoint_store(seed_lease).save(checkpoint)
     incompatible_registry = AdapterRegistry()
-    incompatible_registry.register(
-        Site.INDEED,
-        _SuccessfulIndeed,
-        cursor_schema_version=2,
-    )
+    incompatible_registry.register(Site.INDEED, _SchemaV2Indeed)
 
     with pytest.raises(RuntimeError, match="JobStreaming failed for all"):
         jobspy.run_discovery(

--- a/workers/automation/tests/test_workflow_discovery.py
+++ b/workers/automation/tests/test_workflow_discovery.py
@@ -1149,6 +1149,31 @@ def test_discovery_source_progress_emits_temporal_heartbeat(monkeypatch: pytest.
     assert captured == [progress.to_dict()]
 
 
+def test_jobstreaming_progress_snapshot_becomes_typed_provider_facts() -> None:
+    progress = runner._discovery_provider_progress(
+        {
+            "providerProgress": {
+                "site": "indeed",
+                "phase": "search",
+                "unit": "page",
+                "completedUnits": 3,
+                "totalUnits": None,
+                "rawItemsSeen": 12,
+                "jobsEmitted": 4,
+                "hasMore": True,
+            }
+        }
+    )
+
+    assert progress is not None
+    assert progress.site == "indeed"
+    assert progress.completed_units == 3
+    assert progress.total_units is None
+    assert progress.raw_items_seen == 12
+    assert progress.jobs_emitted == 4
+    assert progress.has_more is True
+
+
 def test_discovery_schedule_defaults_disabled() -> None:
     assert DEFAULT_DISCOVERY_SEARCH_CONFIG["scheduling_enabled"] is False
     assert load_discovery_schedule_settings() == (False, "0 7 * * *")

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -20,7 +20,7 @@ exclude-newer-span = "P8D"
 [options.exclude-newer-package]
 claude-agent-sdk = "2026-07-10T00:00:00Z"
 google-antigravity = "2026-06-04T21:19:27Z"
-jobstreaming = "2026-07-18T00:00:00Z"
+jobstreaming = "2026-08-10T23:59:59Z"
 
 [[package]]
 name = "absl-py"
@@ -654,7 +654,7 @@ requires-dist = [
     { name = "google-auth", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "hatchling", marker = "extra == 'dev'", specifier = "==1.29.0" },
     { name = "httpx", specifier = ">=0.24" },
-    { name = "jobstreaming", specifier = "==0.0.2" },
+    { name = "jobstreaming", specifier = "==0.0.3" },
     { name = "mcp", marker = "extra == 'providers'", specifier = ">=1.28.1" },
     { name = "openai-codex", marker = "extra == 'providers'", specifier = "==0.144.4" },
     { name = "openai-codex-cli-bin", marker = "extra == 'providers'", specifier = "==0.144.4" },
@@ -695,19 +695,18 @@ release-build = [
 
 [[package]]
 name = "jobstreaming"
-version = "0.0.2"
+version = "0.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "markdownify" },
-    { name = "pandas" },
     { name = "pydantic" },
     { name = "requests" },
     { name = "tls-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/1c/e0c88cb47d798f9b2f8132e7eead410d02e6fc367a95b8fdff9e91ac7e81/jobstreaming-0.0.2.tar.gz", hash = "sha256:43ad4f9b32a60143dd31f5966ffdd2f13447114ef8888457748343e7f53b11cc", size = 60000, upload-time = "2026-07-17T18:49:04.512Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/a2/704c4f44db95e987721b31757384cab8a8bcb86026e50e7cddc5fec441e2/jobstreaming-0.0.3.tar.gz", hash = "sha256:5a83cc6b1fc039a2f5bb2bf24d85c505c669659d2bb20c1d4a857a2b41af3ada", size = 99735, upload-time = "2026-08-10T10:15:56.91Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/a6/2eb9806cd39314cc5487253885bafab057eae29412d3e740a2157b238492/jobstreaming-0.0.2-py3-none-any.whl", hash = "sha256:94f9f89cfaaaf40a468cae5025c211ccba4089730274911fb21110ecff0d6076", size = 72377, upload-time = "2026-07-17T18:49:03.222Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/46/2abc6e7b2ad1b672982ff270399cce7a92cc1293f3a543407b21ad401a0b/jobstreaming-0.0.3-py3-none-any.whl", hash = "sha256:4eb23380badae578ab9c43479be3fd544424368bcc91be2d2643834a660c2345", size = 105533, upload-time = "2026-08-10T10:15:55.48Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- pin the released public `jobstreaming==0.0.3` package and adopt its current batch and resumable APIs
- normalize provider `ProgressEvent` observations into cursor-free traversal facts
- persist and project only the latest event bound to the selected exact Discover workflow and Temporal run
- suppress stale provider progress after the source family becomes terminal
- render provider traversal facts without turning partial observations into an ETA

## Why

JobCtrl previously acknowledged JobStreaming provider progress without feeding it into the Operations read model. This makes the released observations inspectable while preserving exact-run lineage and keeping provider continuation state private.

## Stack

- Base: `main`
- Follow-up: #787 adds safe recognizable Chrome profile labels

## Validation

- `corepack pnpm check`
- `corepack pnpm test`
- `corepack pnpm docs:build`
- focused worker discovery tests: 82 passed
- API pipeline operations tests: 49 passed
- rendered Pipelines tests: 32 passed
- public 0.0.3 wheel and sdist hashes, attestations, clean-cache install, and locked imports verified
- active-progress Storybook path and terminal live Pipelines path verified with no console errors
- independent review and QA gates: PASS

## Safety

- no live provider crawl was started
- provider cursors, checkpoints, resume tokens, raw provider payloads, local paths, and private data do not cross the projection boundary

## Checklist

- [x] Relevant local checks are listed above.
- [x] No secrets, private profile data, generated materials, raw logs, browser profiles, SQLite databases, or local paths are included.
- [x] DCO is not applicable to these same-repository owner commits.