### PR TITLE
fix(browser): show recognizable Chrome profile labels

### DIFF
--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -477,6 +477,12 @@ every sibling profile. Concurrent replacements must serialize through publish,
 state validation, rollback, and cleanup so a stale failure cannot overwrite a
 newer successful selection.
 
+For Chrome records whose `is_using_default_name` flag is true, use the bounded
+`gaia_name` as the recognizable label instead of Chrome's generic default such
+as `Your Chrome`. A custom profile `name` must continue to win when that flag is
+false, and neither case may return the account `user_name` (email), directory
+name, or host path.
+
 <a id="scoring-policy-eval-gate"></a>
 <a id="saved-views-smoke"></a>
 <a id="daily-digest-smoke"></a>

--- a/workers/automation/src/jobctrl/browser_capabilities.py
+++ b/workers/automation/src/jobctrl/browser_capabilities.py
@@ -575,6 +575,22 @@ def _profile_display_label(record: object, fallback: str) -> str:
     return configured_name
 
 
+def _profile_label_with_ordinal(label: str, ordinal: int) -> str:
+    """Disambiguate duplicate labels without returning a profile directory name."""
+
+    suffix = f" ({ordinal})"
+    max_prefix_units = 80 - len(suffix)
+    prefix: list[str] = []
+    utf16_units = 0
+    for character in label:
+        character_units = 2 if ord(character) > 0xFFFF else 1
+        if utf16_units + character_units > max_prefix_units:
+            break
+        prefix.append(character)
+        utf16_units += character_units
+    return f"{''.join(prefix).rstrip() or 'Profile'}{suffix}"
+
+
 def _profile_metadata(root: Path) -> tuple[dict[str, object], tuple[str, ...]]:
     """Read bounded Chrome display metadata without following a Local State symlink."""
 
@@ -682,21 +698,35 @@ def detect_browser_profiles(browser_id: str) -> tuple[DetectedBrowserProfile, ..
     label_counts: dict[str, int] = {}
     for profile in detected:
         label_counts[profile.label] = label_counts.get(profile.label, 0) + 1
-    return tuple(
-        profile
-        if label_counts[profile.label] == 1
-        else DetectedBrowserProfile(
-            id=profile.id,
-            browser_id=profile.browser_id,
-            label=_safe_profile_label(
-                f"{profile.label} ({profile.directory_name})",
-                profile.label,
-            ),
-            user_data_root=profile.user_data_root,
-            directory_name=profile.directory_name,
-        )
+    label_ordinals: dict[str, int] = {}
+    used_labels = {
+        profile.label
         for profile in detected
-    )
+        if label_counts[profile.label] == 1
+    }
+    disambiguated: list[DetectedBrowserProfile] = []
+    for profile in detected:
+        if label_counts[profile.label] == 1:
+            disambiguated.append(profile)
+            continue
+        ordinal = label_ordinals.get(profile.label, 0)
+        while True:
+            ordinal += 1
+            label = _profile_label_with_ordinal(profile.label, ordinal)
+            if label not in used_labels:
+                break
+        label_ordinals[profile.label] = ordinal
+        used_labels.add(label)
+        disambiguated.append(
+            DetectedBrowserProfile(
+                id=profile.id,
+                browser_id=profile.browser_id,
+                label=label,
+                user_data_root=profile.user_data_root,
+                directory_name=profile.directory_name,
+            )
+        )
+    return tuple(disambiguated)
 
 
 def detect_default_browser_profile(browser_id: str) -> Path | None:

--- a/workers/automation/src/jobctrl/browser_capabilities.py
+++ b/workers/automation/src/jobctrl/browser_capabilities.py
@@ -564,6 +564,17 @@ def _safe_profile_label(value: object, fallback: str) -> str:
     return "".join(result) or fallback
 
 
+def _profile_display_label(record: object, fallback: str) -> str:
+    """Choose Chrome's recognizable display label without exposing account IDs."""
+
+    if not isinstance(record, dict):
+        return fallback
+    configured_name = _safe_profile_label(record.get("name"), fallback)
+    if record.get("is_using_default_name") is True:
+        return _safe_profile_label(record.get("gaia_name"), configured_name)
+    return configured_name
+
+
 def _profile_metadata(root: Path) -> tuple[dict[str, object], tuple[str, ...]]:
     """Read bounded Chrome display metadata without following a Local State symlink."""
 
@@ -657,13 +668,12 @@ def detect_browser_profiles(browser_id: str) -> tuple[DetectedBrowserProfile, ..
             if not profile_directory.is_dir() or profile_directory.is_symlink():
                 continue
             record = metadata.get(directory_name)
-            display_name = record.get("name") if isinstance(record, dict) else None
             fallback = "Default" if directory_name == "Default" else directory_name
             detected.append(
                 DetectedBrowserProfile(
                     id=_detected_profile_id(browser.id, root, directory_name),
                     browser_id=browser.id,
-                    label=_safe_profile_label(display_name, fallback),
+                    label=_profile_display_label(record, fallback),
                     user_data_root=root,
                     directory_name=directory_name,
                 )

--- a/workers/automation/tests/test_browser_capabilities.py
+++ b/workers/automation/tests/test_browser_capabilities.py
@@ -197,6 +197,62 @@ def test_profile_detection_lists_safe_labels_with_opaque_ids(
     )
 
 
+def test_profile_detection_uses_gaia_name_only_for_chrome_default_labels(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from jobctrl import browser_capabilities
+
+    profile_root = tmp_path / "Chrome"
+    (profile_root / "Default").mkdir(parents=True)
+    (profile_root / "Profile 1").mkdir()
+    (profile_root / "Local State").write_text(
+        json.dumps(
+            {
+                "profile": {
+                    "profiles_order": ["Default", "Profile 1"],
+                    "info_cache": {
+                        "Default": {
+                            "name": "Your Chrome",
+                            "gaia_name": "E",
+                            "user_name": "private@example.test",
+                            "is_using_default_name": True,
+                        },
+                        "Profile 1": {
+                            "name": "Work",
+                            "gaia_name": "Other identity",
+                            "user_name": "other-private@example.test",
+                            "is_using_default_name": False,
+                        },
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "detect_supported_browsers",
+        lambda: (
+            DetectedBrowser(
+                "google-chrome",
+                "Google Chrome",
+                tmp_path / "Chrome executable",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "_default_browser_profile_locations",
+        lambda _browser_id: (profile_root,),
+    )
+
+    profiles = detect_browser_profiles("google-chrome")
+
+    assert [profile.label for profile in profiles] == ["E", "Work"]
+    assert "private@example.test" not in repr(profiles)
+    assert "other-private@example.test" not in repr(profiles)
+
+
 def test_profile_detection_bounds_non_bmp_labels_to_the_rpc_contract(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/workers/automation/tests/test_browser_capabilities_rpc.py
+++ b/workers/automation/tests/test_browser_capabilities_rpc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -76,6 +77,92 @@ def test_capability_list_never_returns_executable_paths(monkeypatch: pytest.Monk
     assert "/secret/host/path" not in json.dumps(result)
     assert "/secret/detected/browser/path" not in json.dumps(result)
     assert "/secret/detected/profile/path" not in json.dumps(result)
+
+
+def test_capability_list_disambiguates_duplicate_signed_in_labels_without_directories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from jobctrl import browser_capabilities
+
+    profile_root = tmp_path / "Chrome"
+    (profile_root / "Default").mkdir(parents=True)
+    (profile_root / "Profile 1").mkdir()
+    (profile_root / "Profile 2").mkdir()
+    (profile_root / "Local State").write_text(
+        json.dumps(
+            {
+                "profile": {
+                    "profiles_order": ["Default", "Profile 1", "Profile 2"],
+                    "info_cache": {
+                        "Default": {
+                            "name": "Your Chrome",
+                            "gaia_name": "E",
+                            "user_name": "private@example.test",
+                            "is_using_default_name": True,
+                        },
+                        "Profile 1": {
+                            "name": "Chrome Person 1",
+                            "gaia_name": "E",
+                            "user_name": "other-private@example.test",
+                            "is_using_default_name": True,
+                        },
+                        "Profile 2": {
+                            "name": "E (1)",
+                            "gaia_name": "Unused identity",
+                            "user_name": "third-private@example.test",
+                            "is_using_default_name": False,
+                        },
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "list_browser_capabilities",
+        lambda: (
+            _status("core-browser", "ready"),
+            _status("auto-apply-browser"),
+            _status("authenticated-linkedin-browser"),
+        ),
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "detect_supported_browsers",
+        lambda: (
+            browser_capabilities.DetectedBrowser(
+                "google-chrome",
+                "Google Chrome",
+                tmp_path / "Chrome executable",
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        browser_capabilities,
+        "_default_browser_profile_locations",
+        lambda _browser_id: (profile_root,),
+    )
+
+    result = handlers.browser_capabilities_list({})
+    serialized = json.dumps(result)
+
+    assert [
+        profile["label"]
+        for profile in result["detectedBrowsers"][0]["profiles"]
+    ] == ["E (2)", "E (3)", "E (1)"]
+    assert len(
+        {
+            profile["label"]
+            for profile in result["detectedBrowsers"][0]["profiles"]
+        }
+    ) == 3
+    assert "Default" not in serialized
+    assert "Profile 1" not in serialized
+    assert "private@example.test" not in serialized
+    assert "other-private@example.test" not in serialized
+    assert "third-private@example.test" not in serialized
+    assert str(profile_root) not in serialized
 
 
 def test_enable_accepts_an_explicit_detected_browser_id(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- use bounded Chrome `gaia_name` only when Chrome marks the configured profile name as a generic default
- preserve explicit custom profile names and never return the account `user_name`
- disambiguate duplicate visible labels with globally unique safe ordinals instead of profile directory names
- add detection and full RPC privacy fixtures, including an existing ordinal-label collision

## Why

Chrome can store a signed-in profile as the generic `Your Chrome` label even though its profile picker shows a recognizable signed-in name. JobCtrl should show that safe name without exposing an email, directory name, or host path, and every consent choice must remain visually unique.

## Stack

- Depends on #786
- This PR contains only the Chrome profile-label layer

## Validation

- `corepack pnpm check`
- focused browser capability and RPC tests: 45 passed
- focused Ruff checks
- live `/v1/browser-capabilities` returned `Google Chrome` with profile label `E` and no email or host path
- Settings selector rendered `Google Chrome · E`; interaction exposed no email/path and produced no console warnings or errors
- duplicate fixture `E / E / E (1)` rendered globally unique `E (2) / E (3) / E (1)` labels within the 80 UTF-16-unit contract
- independent review and QA gates: PASS with zero findings

## Safety

- no profile was copied, enabled, launched, or modified during validation
- no browser profile contents, account identifiers, directories, or local paths are returned

## Checklist

- [x] Relevant local checks are listed above.
- [x] No secrets, private profile data, generated materials, raw logs, browser profiles, SQLite databases, or local paths are included.
- [x] DCO is not applicable to these same-repository owner commits.