### PR TITLE
fix(compensation): parse posted ranges from descriptions

### DIFF
--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -512,22 +512,30 @@ def _upsert_posted_compensation_fact(
     write_fence: Callable[[], None] | None = None,
     idempotency_key: str | None = None,
 ) -> None:
-    from jobctrl.infrastructure.compensation import SqlitePostedCompensationRepository
+    from jobctrl.infrastructure.compensation import (
+        SqlitePostedCompensationRepository,
+        posted_compensation_source_from_job,
+    )
 
     repository = SqlitePostedCompensationRepository(conn)
     _apply_write_fence(write_fence)
     row = conn.execute(
-        "SELECT job_id, salary FROM jobs WHERE tenant_id = ? AND url = ?",
+        """
+        SELECT job_id, salary, full_description, description
+        FROM jobs
+        WHERE tenant_id = ? AND url = ?
+        """,
         (tenant_id, job_url),
     ).fetchone()
     if row is None:
         return
     job_id = canonical_job_id(str(row["job_id"] if isinstance(row, sqlite3.Row) else row[0]))
-    salary = row["salary"] if isinstance(row, sqlite3.Row) else row[1]
+    source_text, source_field = posted_compensation_source_from_job(row)
     repository.parse_and_save_job_salary(
         job_id,
-        salary,
+        source_text,
         tenant_id=tenant_id,
+        source_field=source_field,
         parsed_at=parsed_at,
         event_idempotency_key=idempotency_key,
         event_write_fence=write_fence,

--- a/workers/automation/src/jobctrl/infrastructure/compensation/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/compensation/sqlite_repository.py
@@ -15,12 +15,21 @@ COMPENSATION_SOURCE_RE = re.compile(
     r"\b(?:salary|compensation|pay range|base pay|base salary|wage|remuneration|ote)\b|on[- ]target earnings",
     re.IGNORECASE,
 )
+BASE_COMPENSATION_SOURCE_RE = re.compile(
+    r"\b(?:salary|pay range|base pay|base salary|wage|remuneration|ote)\b|on[- ]target earnings",
+    re.IGNORECASE,
+)
 COMPENSATION_AMOUNT_RE = re.compile(
     r"(?<![A-Za-z0-9])(?:(?:[€$£]|(?:EUR|USD|GBP|CHF|SEK|NOK|DKK|PLN|CZK)\b)\s*)"
     r"\d{1,3}(?:[,.]\d{3})*(?:[,.]\d+)?\s*(?:k|K)?(?![A-Za-z0-9])"
 )
 NON_COMPENSATION_SCALE_RE = re.compile(
     r"^(?:million|millions|billion|billions|trillion|trillions|mm|bn|b)\b",
+    re.IGNORECASE,
+)
+NON_BASE_COMPENSATION_CONTEXT_RE = re.compile(
+    r"\b(?:bonus|commission|equity|stock|stipend|allowance|learning budget|"
+    r"training budget|wellness|home office|equipment|relocation)\b",
     re.IGNORECASE,
 )
 PAY_PERIOD_RE = re.compile(
@@ -196,12 +205,12 @@ class SqlitePostedCompensationRepository:
 
 
 def posted_compensation_source_from_job(row: Any) -> tuple[str | None, str]:
-    salary = _nonempty_text(_row_value(row, "salary"))
+    salary = _nonempty_text(_job_source_row_value(row, "salary"))
     if salary is not None:
         return salary, "jobs.salary"
 
     for field in ("full_description", "description"):
-        text = _nonempty_text(_row_value(row, field))
+        text = _nonempty_text(_job_source_row_value(row, field))
         if text is None:
             continue
         match = _compensation_source_match(text)
@@ -223,18 +232,65 @@ def _nonempty_text(value: Any) -> str | None:
 
 def _compensation_source_match(text: str) -> re.Match[str] | None:
     keyword_match = COMPENSATION_SOURCE_RE.search(text)
-    if keyword_match is not None:
-        return keyword_match
-
+    generic_candidate: re.Match[str] | None = None
     for amount_match in COMPENSATION_AMOUNT_RE.finditer(text):
         if NON_COMPENSATION_SCALE_RE.match(text[amount_match.end() :].lstrip()):
             continue
         window_start = max(0, amount_match.start() - 40)
         window_end = min(len(text), amount_match.end() + 40)
-        if PAY_PERIOD_RE.search(text[window_start:window_end]):
+        window = text[window_start:window_end]
+        if not PAY_PERIOD_RE.search(window):
+            continue
+        amount_start = amount_match.start() - window_start
+        amount_end = amount_match.end() - window_start
+        base_distance = _nearest_match_distance(
+            BASE_COMPENSATION_SOURCE_RE,
+            window,
+            amount_start,
+            amount_end,
+        )
+        non_base_distance = _nearest_match_distance(
+            NON_BASE_COMPENSATION_CONTEXT_RE,
+            window,
+            amount_start,
+            amount_end,
+        )
+        if base_distance is not None and (
+            non_base_distance is None or base_distance < non_base_distance
+        ):
             return amount_match
+        if (
+            generic_candidate is None
+            and COMPENSATION_SOURCE_RE.search(window)
+            and non_base_distance is None
+        ):
+            generic_candidate = amount_match
 
-    return None
+    return generic_candidate or keyword_match
+
+
+def _nearest_match_distance(
+    pattern: re.Pattern[str],
+    text: str,
+    anchor_start: int,
+    anchor_end: int,
+) -> int | None:
+    distances: list[int] = []
+    for match in pattern.finditer(text):
+        if match.end() <= anchor_start:
+            distances.append(anchor_start - match.end())
+        elif match.start() >= anchor_end:
+            distances.append(match.start() - anchor_end)
+        else:
+            distances.append(0)
+    return min(distances) if distances else None
+
+
+def _job_source_row_value(row: Any, key: str) -> Any:
+    if isinstance(row, sqlite3.Row):
+        return row[key]
+    keys = ("job_id", "salary", "full_description", "description")
+    return row[keys.index(key)]
 
 
 def _row_to_fact(row: sqlite3.Row | tuple[Any, ...]) -> PostedCompensationFact:

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import threading
 from types import SimpleNamespace
 
@@ -23,6 +24,7 @@ from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.infrastructure.compensation import SqlitePostedCompensationRepository
 from jobctrl.infrastructure.discovery import SqliteJobRepository
 from jobctrl.infrastructure.discovery.production_wiring import DurableJobEventPublisher
+from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
 
 
 _JOBSPY_DESCRIPTION = "Lead engineering, platform, security, and delivery teams in Spain. " * 8
@@ -1143,6 +1145,63 @@ def test_jobspy_persists_posted_compensation_fact_from_bounded_salary_text(tmp_p
         assert fact.currency == "EUR"
         assert fact.minimum_amount == 80_000
         assert fact.maximum_amount == 95_000
+    finally:
+        close_connection(db_path)
+
+
+def test_jobspy_projects_posted_compensation_from_full_description_when_salary_is_blank(
+    tmp_path,
+):
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    try:
+        description = (
+            "Competitive compensation and benefits. "
+            "In addition to base salary, the annual learning stipend is €2,000 per year. "
+            + ("Lead platform engineering and delivery teams. " * 16)
+            + "Base pay range per year:\n**€80,000 - €95,000**"
+        )
+        frame = _jobspy_frame(
+            [
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/description-comp",
+                    "title": "Staff Platform Engineer",
+                    "company": "Acme",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                    "description": description,
+                }
+            ]
+        )
+
+        assert jobspy.store_jobspy_results(conn, frame, "Platform", limit=10) == (1, 0)
+        job_id = _stable_job_id(
+            conn,
+            "https://www.linkedin.com/jobs/view/description-comp",
+        )
+        fact = SqlitePostedCompensationRepository(conn).get_fact("local", job_id)
+        salary = conn.execute(
+            "SELECT salary FROM jobs WHERE tenant_id = ? AND job_id = ?",
+            ("local", job_id),
+        ).fetchone()["salary"]
+
+        assert salary in (None, "")
+        assert fact is not None
+        assert fact.source_field == "jobs.full_description"
+        assert fact.parse_state == "parsed_range"
+        assert fact.annualized_minimum_amount == 80_000
+        assert fact.annualized_maximum_amount == 95_000
+
+        ProjectionBuilder(conn_factory=lambda: conn).refresh()
+        projection = conn.execute(
+            "SELECT compensation_summary_json FROM job_list_projections WHERE job_id = ?",
+            (job_id,),
+        ).fetchone()
+        assert projection is not None
+        summary = json.loads(projection["compensation_summary_json"])
+        assert summary["posted"]["parseState"] == "parsed_range"
+        assert summary["posted"]["range"]["annualizedMinimumAmount"] == 80_000
+        assert summary["posted"]["range"]["annualizedMaximumAmount"] == 95_000
     finally:
         close_connection(db_path)
 

--- a/workers/automation/tests/test_posted_compensation_repository.py
+++ b/workers/automation/tests/test_posted_compensation_repository.py
@@ -10,7 +10,10 @@ import pytest
 from jobctrl.database import init_db
 from jobctrl.domain.compensation import parse_posted_compensation
 from jobctrl.domain.identifiers import JobId
-from jobctrl.infrastructure.compensation import SqlitePostedCompensationRepository
+from jobctrl.infrastructure.compensation import (
+    SqlitePostedCompensationRepository,
+    posted_compensation_source_from_job,
+)
 
 
 @pytest.fixture()
@@ -152,6 +155,47 @@ def test_backfill_records_missing_fact_without_erasing_blank_salary(conn: sqlite
     assert fact.parse_state == "missing"
     assert fact.legacy_raw_salary is None
     assert salary is None
+
+
+def test_backfill_prefers_numeric_compensation_excerpt_over_earlier_generic_cue(
+    conn: sqlite3.Connection,
+) -> None:
+    _job_url, job_id = _seed_job(conn, salary=None)
+    full_description = (
+        "Competitive compensation and benefits. "
+        "In addition to base salary, the annual learning stipend is €2,000 per year. "
+        + ("Lead platform engineering and delivery teams. " * 16)
+        + "Base pay range per year:\n**€80,000 - €95,000**"
+    )
+    conn.execute(
+        "UPDATE jobs SET full_description = ? WHERE tenant_id = ? AND job_id = ?",
+        (full_description, "local", job_id),
+    )
+    conn.commit()
+
+    SqlitePostedCompensationRepository(conn).backfill_from_jobs(
+        parsed_at="2026-06-19T10:00:00Z"
+    )
+
+    fact = SqlitePostedCompensationRepository(conn).get_fact("local", job_id)
+    assert fact is not None
+    assert fact.source_field == "jobs.full_description"
+    assert fact.parse_state == "parsed_range"
+    assert fact.currency == "EUR"
+    assert fact.period == "year"
+    assert fact.annualized_minimum_amount == 80_000
+    assert fact.annualized_maximum_amount == 95_000
+
+
+def test_description_source_selection_supports_tuple_job_rows() -> None:
+    full_description = "Base salary €80,000 - €95,000 per year"
+
+    source_text, source_field = posted_compensation_source_from_job(
+        ("job-id", None, full_description, "")
+    )
+
+    assert source_field == "jobs.full_description"
+    assert source_text == full_description
 
 
 def test_backfill_persists_mixed_component_two_amount_text_as_ambiguous(


### PR DESCRIPTION
## Summary

- parse bounded employer-posted salary evidence from structured salary fields and job descriptions
- persist canonical posted-compensation facts without mutating the raw `jobs.salary` field
- reject nearby benefit, stipend, equity, and unrelated monetary amounts before selecting a base-pay range
- preserve provenance and support both `sqlite3.Row` and tuple-backed ingestion paths

## Why

Some job providers include an explicit salary range only in the description. Those ranges were ingested as text but never became canonical compensation facts, so the jobs table and job detail page showed no posted salary.

## Validation

- `uv --project workers/automation run pytest workers/automation/tests/test_discovery_limits.py workers/automation/tests/test_posted_compensation_repository.py` — 48 passed
- `uv --project workers/automation run ruff check workers/automation/src/jobctrl/discovery/jobspy.py workers/automation/src/jobctrl/infrastructure/compensation/sqlite_repository.py workers/automation/tests/test_discovery_limits.py workers/automation/tests/test_posted_compensation_repository.py` — passed
- `git diff --check origin/main...HEAD` — passed
- independent review gate — PASS, no findings
- independent product QA — PASS across synthetic ingestion, persistence, API projection, jobs list, and job detail

## Checklist

- [x] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`) — not applicable to repository owner commit
- [x] I ran the relevant local checks and listed them above
- [x] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths
