### PR TITLE
feat(storage): add exact v8 benchmark schema

### DIFF
--- a/apps/api/src/schema-manifest.ts
+++ b/apps/api/src/schema-manifest.ts
@@ -19,6 +19,13 @@ export const EXACT_V7_SCHEMA_MANIFEST: SchemaManifest = {
   fingerprint: "775312f0ec2640a2a87889602886c90e21a49e06fffc53cf26c435856247da97",
 };
 
+export const EXACT_V8_SCHEMA_MANIFEST: SchemaManifest = {
+  version: 8,
+  objectCount: 272,
+  tableCount: 117,
+  fingerprint: "3705f7c7d90454bbeaa85227a9d4ce87c12efd14935e0d14afc830939e80ff31",
+};
+
 type SqliteMasterRow = [type: string, name: string, tableName: string, sql: string];
 
 type SqliteMasterQueryRow = {
@@ -84,11 +91,22 @@ export function schemaManifest(
 }
 
 export function hasExactV7SchemaManifest(db: Pick<Database.Database, "prepare">): boolean {
-  const observed = schemaManifest(db, EXACT_V7_SCHEMA_MANIFEST.version);
+  return hasExactSchemaManifest(db, EXACT_V7_SCHEMA_MANIFEST);
+}
+
+export function hasExactV8SchemaManifest(db: Pick<Database.Database, "prepare">): boolean {
+  return hasExactSchemaManifest(db, EXACT_V8_SCHEMA_MANIFEST);
+}
+
+function hasExactSchemaManifest(
+  db: Pick<Database.Database, "prepare">,
+  expected: SchemaManifest,
+): boolean {
+  const observed = schemaManifest(db, expected.version);
   return (
-    observed.version === EXACT_V7_SCHEMA_MANIFEST.version
-    && observed.objectCount === EXACT_V7_SCHEMA_MANIFEST.objectCount
-    && observed.tableCount === EXACT_V7_SCHEMA_MANIFEST.tableCount
-    && observed.fingerprint === EXACT_V7_SCHEMA_MANIFEST.fingerprint
+    observed.version === expected.version
+    && observed.objectCount === expected.objectCount
+    && observed.tableCount === expected.tableCount
+    && observed.fingerprint === expected.fingerprint
   );
 }

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -14,7 +14,12 @@ import {
   openReadOnlyDatabase,
   tableExists,
 } from "../src/db.js";
-import { EXACT_V7_SCHEMA_MANIFEST } from "../src/schema-manifest.js";
+import {
+  EXACT_V7_SCHEMA_MANIFEST,
+  EXACT_V8_SCHEMA_MANIFEST,
+  hasExactV8SchemaManifest,
+  schemaManifest,
+} from "../src/schema-manifest.js";
 
 function makeDbWithUserVersion(userVersion: number): { dbPath: string; cleanup: () => void } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-schema-version-"));
@@ -151,6 +156,35 @@ describe("schema version guard at DB open", () => {
       tableCount: 110,
       fingerprint: "775312f0ec2640a2a87889602886c90e21a49e06fffc53cf26c435856247da97",
     });
+    expect(pythonManifest).toContain("version=8,");
+    expect(pythonManifest).toContain("object_count=272,");
+    expect(pythonManifest).toContain("table_count=117,");
+    expect(pythonManifest).toContain(`fingerprint="${EXACT_V8_SCHEMA_MANIFEST.fingerprint}",`);
+    expect(EXACT_V8_SCHEMA_MANIFEST).toEqual({
+      version: 8,
+      objectCount: 272,
+      tableCount: 117,
+      fingerprint: "3705f7c7d90454bbeaa85227a9d4ce87c12efd14935e0d14afc830939e80ff31",
+    });
+  });
+
+  it("computes the exact v8 manifest from the frozen v7 schema plus v8 additions", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-exact-v8-"));
+    const dbPath = path.join(dir, "jobs.db");
+    const migrations = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../../../workers/automation/src/jobctrl/infrastructure/migrations",
+    );
+    const db = new Database(dbPath);
+    try {
+      db.exec(fs.readFileSync(path.join(migrations, "schema_v7.sql"), "utf8"));
+      db.exec(fs.readFileSync(path.join(migrations, "schema_v8.sql"), "utf8"));
+      expect(schemaManifest(db, EXACT_V8_SCHEMA_MANIFEST.version)).toEqual(EXACT_V8_SCHEMA_MANIFEST);
+      expect(hasExactV8SchemaManifest(db)).toBe(true);
+    } finally {
+      db.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/workers/automation/src/jobctrl/infrastructure/migrations/compensation_role_family_seed.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/compensation_role_family_seed.py
@@ -1,0 +1,50 @@
+"""Versioned JobCtrl compensation role-family taxonomy seed."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+ROLE_FAMILY_TAXONOMY_VERSION = "jobctrl-role-family-v1"
+_CREATED_AT = "2026-08-11T00:00:00Z"
+_ROLE_FAMILIES: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    ("software_engineering", "Software Engineering", ("2512", "2513", "2514", "2519")),
+    ("infrastructure_platform", "Infrastructure & Platform", ("2522", "2523", "2529")),
+    ("data_ai", "Data & AI", ("2120", "2511", "2521")),
+    ("security_privacy", "Security & Privacy", ("2529",)),
+    ("product_management", "Product Management", ("2421",)),
+    ("design_research", "Design & Research", ("2166", "2431")),
+    ("sales_business_development", "Sales & Business Development", ("1221", "2433", "2434")),
+    ("marketing_communications", "Marketing & Communications", ("1222", "2431", "2432")),
+    ("customer_success_support", "Customer Success & Support", ("3322", "4222")),
+    ("finance_accounting", "Finance & Accounting", ("1211", "2411", "2412", "2413")),
+    ("people_talent", "People & Talent", ("1212", "2423", "2424")),
+    ("legal_compliance", "Legal & Compliance", ("1213", "2611", "2619")),
+    ("business_operations", "Business Operations", ("1219", "2421", "2422")),
+    ("general_management", "General Management", ("1120",)),
+)
+
+
+def seed_compensation_role_families(conn: sqlite3.Connection) -> None:
+    """Insert the immutable first JobCtrl taxonomy into an empty v8 catalog."""
+
+    conn.executemany(
+        """
+        INSERT INTO compensation_role_families (
+            taxonomy_version, role_family_code, display_name, isco_codes_json, created_at
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        tuple(
+            (
+                ROLE_FAMILY_TAXONOMY_VERSION,
+                code,
+                display_name,
+                json.dumps(isco_codes, separators=(",", ":")),
+                _CREATED_AT,
+            )
+            for code, display_name, isco_codes in _ROLE_FAMILIES
+        ),
+    )
+
+
+__all__ = ["ROLE_FAMILY_TAXONOMY_VERSION", "seed_compensation_role_families"]

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
@@ -29,6 +29,14 @@ EXACT_V7_MANIFEST = SchemaManifest(
 )
 
 
+EXACT_V8_MANIFEST = SchemaManifest(
+    version=8,
+    object_count=272,
+    table_count=117,
+    fingerprint="3705f7c7d90454bbeaa85227a9d4ce87c12efd14935e0d14afc830939e80ff31",
+)
+
+
 class SchemaManifestError(RuntimeError):
     """Raised before writes when a database is not an exact known schema."""
 

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v8.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v8.py
@@ -1,0 +1,122 @@
+"""Self-contained exact-v8 SQLite schema and exact-v7 upgrade contract."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from importlib.resources import files
+
+from jobctrl.infrastructure.migrations.compensation_role_family_seed import (
+    seed_compensation_role_families,
+)
+from jobctrl.infrastructure.migrations.resume_template_seed import (
+    seed_builtin_resume_template,
+)
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    EXACT_V8_MANIFEST,
+    SchemaManifestError,
+    assert_exact_manifest,
+    schema_dump,
+)
+from jobctrl.infrastructure.migrations.schema_v7 import (
+    create_unstamped_exact_v7_candidate,
+)
+
+
+def _schema_statements() -> tuple[str, ...]:
+    statements: list[str] = []
+    buffered = ""
+    schema_text = (
+        files("jobctrl.infrastructure.migrations")
+        .joinpath("schema_v8.sql")
+        .read_text(encoding="utf-8")
+    )
+    for line in schema_text.splitlines():
+        buffered = f"{buffered}\n{line}" if buffered else line
+        if not sqlite3.complete_statement(buffered):
+            continue
+        statements.append(buffered.strip())
+        buffered = ""
+    if buffered.strip():
+        raise SchemaManifestError("the frozen v8 schema extension file is incomplete")
+    return tuple(statements)
+
+
+def create_exact_v8_schema(
+    conn: sqlite3.Connection,
+    *,
+    _execute: Callable[[str], object] | None = None,
+) -> None:
+    """Install the complete exact-v8 schema into an empty database."""
+
+    _create_empty_exact_v8_schema(conn, stamp_version=True, _execute=_execute)
+
+
+def create_unstamped_exact_v8_candidate(
+    conn: sqlite3.Connection,
+    *,
+    _execute: Callable[[str], object] | None = None,
+) -> None:
+    """Build an exact-v8 candidate without stamping its user version."""
+
+    _create_empty_exact_v8_schema(conn, stamp_version=False, _execute=_execute)
+
+
+def upgrade_exact_v7_schema_to_v8(
+    conn: sqlite3.Connection,
+    *,
+    _execute: Callable[[str], object] | None = None,
+) -> None:
+    """Upgrade one isolated exact-v7 candidate to exact v8 transactionally."""
+
+    if conn.in_transaction:
+        raise SchemaManifestError("exact v7-to-v8 upgrade requires no active transaction")
+    if int(conn.execute("PRAGMA user_version").fetchone()[0]) != EXACT_V7_MANIFEST.version:
+        raise SchemaManifestError("exact v7-to-v8 upgrade requires user_version 7")
+    assert_exact_manifest(conn, EXACT_V7_MANIFEST)
+
+    execute = _execute or conn.execute
+    conn.execute("SAVEPOINT exact_v7_to_v8_schema")
+    try:
+        for statement in _schema_statements():
+            execute(statement)
+        seed_compensation_role_families(conn)
+        execute(f"PRAGMA user_version = {EXACT_V8_MANIFEST.version}")
+        assert_exact_manifest(conn, EXACT_V8_MANIFEST)
+        conn.execute("RELEASE SAVEPOINT exact_v7_to_v8_schema")
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT exact_v7_to_v8_schema")
+        conn.execute("RELEASE SAVEPOINT exact_v7_to_v8_schema")
+        raise
+
+
+def _create_empty_exact_v8_schema(
+    conn: sqlite3.Connection,
+    *,
+    stamp_version: bool,
+    _execute: Callable[[str], object] | None,
+) -> None:
+    if schema_dump(conn):
+        raise SchemaManifestError("exact v8 creation requires an empty schema")
+    if not stamp_version and conn.execute("PRAGMA user_version").fetchone()[0] != 0:
+        raise SchemaManifestError(
+            "unstamped exact v8 candidate creation requires user_version 0"
+        )
+
+    execute = _execute or conn.execute
+    conn.execute("SAVEPOINT exact_v8_schema")
+    try:
+        create_unstamped_exact_v7_candidate(conn, _execute=execute)
+        for statement in _schema_statements():
+            execute(statement)
+        if stamp_version:
+            seed_builtin_resume_template(conn)
+            seed_compensation_role_families(conn)
+            execute(f"PRAGMA user_version = {EXACT_V8_MANIFEST.version}")
+        assert_exact_manifest(conn, EXACT_V8_MANIFEST)
+        conn.execute("RELEASE SAVEPOINT exact_v8_schema")
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT exact_v8_schema")
+        conn.execute("RELEASE SAVEPOINT exact_v8_schema")
+        raise

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v8.sql
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v8.sql
@@ -1,0 +1,593 @@
+CREATE TABLE compensation_role_families (
+    taxonomy_version TEXT NOT NULL CHECK (length(trim(taxonomy_version)) > 0),
+    role_family_code TEXT NOT NULL CHECK (length(trim(role_family_code)) > 0),
+    display_name     TEXT NOT NULL CHECK (length(trim(display_name)) > 0),
+    isco_codes_json  TEXT NOT NULL DEFAULT '[]' CHECK (
+        json_valid(isco_codes_json) AND json_type(isco_codes_json) = 'array'
+    ),
+    created_at       TEXT NOT NULL CHECK (length(trim(created_at)) > 0),
+    PRIMARY KEY (taxonomy_version, role_family_code)
+);
+
+CREATE TABLE compensation_direct_benchmark_facts (
+    tenant_id                          TEXT NOT NULL DEFAULT 'local',
+    fact_id                            TEXT NOT NULL CHECK (
+        length(fact_id) = 36
+        AND substr(fact_id, 9, 1) = '-'
+        AND substr(fact_id, 14, 1) = '-'
+        AND substr(fact_id, 19, 1) = '-'
+        AND substr(fact_id, 24, 1) = '-'
+        AND replace(fact_id, '-', '') NOT GLOB '*[^a-f0-9]*'
+    ),
+    taxonomy_version                   TEXT NOT NULL,
+    role_family_code                   TEXT NOT NULL,
+    seniority_label                    TEXT NOT NULL CHECK (
+        seniority_label IN (
+            'entry', 'mid', 'senior', 'staff', 'principal',
+            'manager', 'director', 'executive', 'unknown'
+        )
+    ),
+    country_code                       TEXT NOT NULL CHECK (
+        length(country_code) = 2
+        AND country_code = upper(country_code)
+        AND country_code NOT GLOB '*[^A-Z]*'
+    ),
+    subdivision_code                   TEXT NOT NULL DEFAULT '',
+    locality                           TEXT NOT NULL DEFAULT '',
+    geography_scope                    TEXT NOT NULL CHECK (
+        geography_scope IN ('country', 'country_subdivision', 'locality')
+    ),
+    market_scope                       TEXT NOT NULL CHECK (
+        market_scope IN ('market', 'company')
+    ),
+    normalized_company                 TEXT,
+    component                          TEXT NOT NULL CHECK (
+        component IN ('base_salary', 'total_compensation')
+    ),
+    original_currency                  TEXT NOT NULL CHECK (
+        length(original_currency) = 3
+        AND original_currency = upper(original_currency)
+        AND original_currency NOT GLOB '*[^A-Z]*'
+    ),
+    original_period                    TEXT NOT NULL CHECK (
+        original_period IN ('year', 'month', 'week', 'day', 'hour')
+    ),
+    original_minimum_amount            INTEGER NOT NULL CHECK (original_minimum_amount > 0),
+    original_maximum_amount            INTEGER NOT NULL CHECK (
+        original_maximum_amount >= original_minimum_amount
+    ),
+    eur_annual_minimum_amount          INTEGER NOT NULL CHECK (eur_annual_minimum_amount > 0),
+    eur_annual_maximum_amount          INTEGER NOT NULL CHECK (
+        eur_annual_maximum_amount >= eur_annual_minimum_amount
+    ),
+    confidence_interval_minimum_amount INTEGER NOT NULL CHECK (
+        confidence_interval_minimum_amount > 0
+        AND confidence_interval_minimum_amount <= eur_annual_minimum_amount
+    ),
+    confidence_interval_maximum_amount INTEGER NOT NULL CHECK (
+        confidence_interval_maximum_amount >= eur_annual_maximum_amount
+    ),
+    confidence_score                   REAL NOT NULL CHECK (
+        confidence_score >= 0 AND confidence_score <= 1
+    ),
+    sample_count                       INTEGER NOT NULL CHECK (sample_count > 0),
+    source_id                          TEXT NOT NULL CHECK (length(trim(source_id)) > 0),
+    source_provenance                  TEXT NOT NULL CHECK (
+        source_provenance IN ('public', 'licensed', 'manual', 'employer_posted', 'official')
+    ),
+    source_snapshot_id                 TEXT NOT NULL CHECK (length(trim(source_snapshot_id)) > 0),
+    source_url                         TEXT,
+    attribution                       TEXT NOT NULL CHECK (length(trim(attribution)) > 0),
+    fx_reference_json                  TEXT NOT NULL DEFAULT '{}' CHECK (
+        json_valid(fx_reference_json) AND json_type(fx_reference_json) = 'object'
+    ),
+    as_of_date                         TEXT NOT NULL CHECK (length(trim(as_of_date)) > 0),
+    fetched_at                         TEXT NOT NULL CHECK (length(trim(fetched_at)) > 0),
+    fresh_until                        TEXT NOT NULL CHECK (length(trim(fresh_until)) > 0),
+    evidence_hash                      TEXT NOT NULL CHECK (
+        length(evidence_hash) = 64
+        AND evidence_hash NOT GLOB '*[^a-f0-9]*'
+    ),
+    created_at                         TEXT NOT NULL CHECK (length(trim(created_at)) > 0),
+    PRIMARY KEY (tenant_id, fact_id),
+    UNIQUE (tenant_id, evidence_hash),
+    FOREIGN KEY (taxonomy_version, role_family_code)
+        REFERENCES compensation_role_families(taxonomy_version, role_family_code)
+        ON DELETE RESTRICT,
+    CHECK (subdivision_code = '' OR length(trim(subdivision_code)) > 0),
+    CHECK (locality = '' OR length(trim(locality)) > 0),
+    CHECK (
+        (geography_scope = 'country' AND subdivision_code = '' AND locality = '')
+        OR (
+            geography_scope = 'country_subdivision'
+            AND subdivision_code != ''
+            AND locality = ''
+        )
+        OR (geography_scope = 'locality' AND locality != '')
+    ),
+    CHECK (
+        (market_scope = 'market' AND normalized_company IS NULL)
+        OR (
+            market_scope = 'company'
+            AND normalized_company IS NOT NULL
+            AND length(trim(normalized_company)) > 0
+        )
+    )
+);
+
+CREATE TABLE compensation_price_level_facts (
+    tenant_id            TEXT NOT NULL DEFAULT 'local',
+    fact_id              TEXT NOT NULL CHECK (
+        length(fact_id) = 36
+        AND substr(fact_id, 9, 1) = '-'
+        AND substr(fact_id, 14, 1) = '-'
+        AND substr(fact_id, 19, 1) = '-'
+        AND substr(fact_id, 24, 1) = '-'
+        AND replace(fact_id, '-', '') NOT GLOB '*[^a-f0-9]*'
+    ),
+    country_code         TEXT NOT NULL CHECK (
+        length(country_code) = 2
+        AND country_code = upper(country_code)
+        AND country_code NOT GLOB '*[^A-Z]*'
+    ),
+    category             TEXT NOT NULL CHECK (
+        category IN (
+            'actual_individual_consumption',
+            'household_final_consumption',
+            'general_price_level'
+        )
+    ),
+    reference_year       INTEGER NOT NULL CHECK (reference_year >= 2000),
+    base_geography_code  TEXT NOT NULL CHECK (length(trim(base_geography_code)) > 0),
+    index_value          REAL NOT NULL CHECK (index_value > 0),
+    source_id            TEXT NOT NULL CHECK (
+        source_id IN ('eurostat', 'world_bank', 'oecd', 'manual_official')
+    ),
+    source_snapshot_id   TEXT NOT NULL CHECK (length(trim(source_snapshot_id)) > 0),
+    source_url           TEXT NOT NULL CHECK (length(trim(source_url)) > 0),
+    attribution          TEXT NOT NULL CHECK (length(trim(attribution)) > 0),
+    as_of_date           TEXT NOT NULL CHECK (length(trim(as_of_date)) > 0),
+    fetched_at           TEXT NOT NULL CHECK (length(trim(fetched_at)) > 0),
+    fresh_until          TEXT NOT NULL CHECK (length(trim(fresh_until)) > 0),
+    evidence_hash        TEXT NOT NULL CHECK (
+        length(evidence_hash) = 64
+        AND evidence_hash NOT GLOB '*[^a-f0-9]*'
+    ),
+    created_at           TEXT NOT NULL CHECK (length(trim(created_at)) > 0),
+    PRIMARY KEY (tenant_id, fact_id),
+    UNIQUE (tenant_id, evidence_hash)
+);
+
+CREATE TABLE compensation_extrapolated_benchmark_facts (
+    tenant_id                          TEXT NOT NULL DEFAULT 'local',
+    fact_id                            TEXT NOT NULL CHECK (
+        length(fact_id) = 36
+        AND substr(fact_id, 9, 1) = '-'
+        AND substr(fact_id, 14, 1) = '-'
+        AND substr(fact_id, 19, 1) = '-'
+        AND substr(fact_id, 24, 1) = '-'
+        AND replace(fact_id, '-', '') NOT GLOB '*[^a-f0-9]*'
+    ),
+    anchor_direct_fact_id              TEXT NOT NULL,
+    taxonomy_version                   TEXT NOT NULL,
+    role_family_code                   TEXT NOT NULL,
+    seniority_label                    TEXT NOT NULL CHECK (
+        seniority_label IN (
+            'entry', 'mid', 'senior', 'staff', 'principal',
+            'manager', 'director', 'executive', 'unknown'
+        )
+    ),
+    target_country_code                TEXT NOT NULL CHECK (
+        length(target_country_code) = 2
+        AND target_country_code = upper(target_country_code)
+        AND target_country_code NOT GLOB '*[^A-Z]*'
+    ),
+    target_subdivision_code            TEXT NOT NULL DEFAULT '',
+    target_locality                    TEXT NOT NULL DEFAULT '',
+    target_geography_scope             TEXT NOT NULL CHECK (
+        target_geography_scope IN ('country', 'country_subdivision', 'locality')
+    ),
+    component                          TEXT NOT NULL CHECK (
+        component IN ('base_salary', 'total_compensation')
+    ),
+    currency                           TEXT NOT NULL CHECK (currency = 'EUR'),
+    period                             TEXT NOT NULL CHECK (period = 'year'),
+    minimum_amount                     INTEGER NOT NULL CHECK (minimum_amount > 0),
+    maximum_amount                     INTEGER NOT NULL CHECK (maximum_amount >= minimum_amount),
+    confidence_interval_minimum_amount INTEGER NOT NULL CHECK (
+        confidence_interval_minimum_amount > 0
+        AND confidence_interval_minimum_amount <= minimum_amount
+    ),
+    confidence_interval_maximum_amount INTEGER NOT NULL CHECK (
+        confidence_interval_maximum_amount >= maximum_amount
+    ),
+    confidence_band                    TEXT NOT NULL CHECK (
+        confidence_band IN ('low', 'medium')
+    ),
+    confidence_score                   REAL NOT NULL CHECK (
+        confidence_score >= 0 AND confidence_score <= 1
+    ),
+    extrapolation_method               TEXT NOT NULL CHECK (
+        extrapolation_method = 'evidence_weighted_shrinkage'
+    ),
+    raw_factor                         REAL NOT NULL CHECK (raw_factor > 0),
+    shrinkage_weight                   REAL NOT NULL CHECK (
+        shrinkage_weight >= 0 AND shrinkage_weight <= 1
+    ),
+    lower_factor_bound                 REAL NOT NULL CHECK (lower_factor_bound = 0.1),
+    upper_factor_bound                 REAL NOT NULL CHECK (upper_factor_bound = 10.0),
+    factor_bound_state                 TEXT NOT NULL CHECK (
+        factor_bound_state IN ('within_bounds', 'below_lower_bound', 'above_upper_bound')
+    ),
+    matched_company_count              INTEGER NOT NULL DEFAULT 0 CHECK (matched_company_count >= 0),
+    formula_version                    TEXT NOT NULL CHECK (length(trim(formula_version)) > 0),
+    inputs_hash                        TEXT NOT NULL CHECK (
+        length(inputs_hash) = 64
+        AND inputs_hash NOT GLOB '*[^a-f0-9]*'
+    ),
+    warnings_json                      TEXT NOT NULL DEFAULT '[]' CHECK (
+        json_valid(warnings_json) AND json_type(warnings_json) = 'array'
+    ),
+    as_of_date                         TEXT NOT NULL CHECK (length(trim(as_of_date)) > 0),
+    derived_at                         TEXT NOT NULL CHECK (length(trim(derived_at)) > 0),
+    fresh_until                        TEXT NOT NULL CHECK (length(trim(fresh_until)) > 0),
+    PRIMARY KEY (tenant_id, fact_id),
+    UNIQUE (tenant_id, inputs_hash),
+    FOREIGN KEY (tenant_id, anchor_direct_fact_id)
+        REFERENCES compensation_direct_benchmark_facts(tenant_id, fact_id)
+        ON DELETE RESTRICT,
+    FOREIGN KEY (taxonomy_version, role_family_code)
+        REFERENCES compensation_role_families(taxonomy_version, role_family_code)
+        ON DELETE RESTRICT,
+    CHECK (
+        target_subdivision_code = '' OR length(trim(target_subdivision_code)) > 0
+    ),
+    CHECK (target_locality = '' OR length(trim(target_locality)) > 0),
+    CHECK (
+        (
+            target_geography_scope = 'country'
+            AND target_subdivision_code = ''
+            AND target_locality = ''
+        )
+        OR (
+            target_geography_scope = 'country_subdivision'
+            AND target_subdivision_code != ''
+            AND target_locality = ''
+        )
+        OR (target_geography_scope = 'locality' AND target_locality != '')
+    ),
+    CHECK (
+        (raw_factor < lower_factor_bound AND factor_bound_state = 'below_lower_bound')
+        OR (raw_factor > upper_factor_bound AND factor_bound_state = 'above_upper_bound')
+        OR (
+            raw_factor >= lower_factor_bound
+            AND raw_factor <= upper_factor_bound
+            AND factor_bound_state = 'within_bounds'
+        )
+    )
+);
+
+CREATE TABLE compensation_extrapolation_direct_inputs (
+    tenant_id            TEXT NOT NULL DEFAULT 'local',
+    extrapolated_fact_id TEXT NOT NULL,
+    direct_fact_id       TEXT NOT NULL,
+    input_role           TEXT NOT NULL CHECK (
+        input_role IN (
+            'anchor',
+            'matched_company_source',
+            'matched_company_target',
+            'occupation_anchor'
+        )
+    ),
+    weight               REAL NOT NULL CHECK (weight >= 0 AND weight <= 1),
+    PRIMARY KEY (tenant_id, extrapolated_fact_id, direct_fact_id, input_role),
+    FOREIGN KEY (tenant_id, extrapolated_fact_id)
+        REFERENCES compensation_extrapolated_benchmark_facts(tenant_id, fact_id)
+        ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, direct_fact_id)
+        REFERENCES compensation_direct_benchmark_facts(tenant_id, fact_id)
+        ON DELETE RESTRICT
+);
+
+CREATE TABLE compensation_extrapolation_price_inputs (
+    tenant_id            TEXT NOT NULL DEFAULT 'local',
+    extrapolated_fact_id TEXT NOT NULL,
+    price_level_fact_id  TEXT NOT NULL,
+    input_role           TEXT NOT NULL CHECK (
+        input_role IN ('source_price_level', 'target_price_level', 'shrinkage_prior')
+    ),
+    weight               REAL NOT NULL CHECK (weight >= 0 AND weight <= 1),
+    PRIMARY KEY (tenant_id, extrapolated_fact_id, price_level_fact_id, input_role),
+    FOREIGN KEY (tenant_id, extrapolated_fact_id)
+        REFERENCES compensation_extrapolated_benchmark_facts(tenant_id, fact_id)
+        ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, price_level_fact_id)
+        REFERENCES compensation_price_level_facts(tenant_id, fact_id)
+        ON DELETE RESTRICT
+);
+
+CREATE TABLE compensation_market_refresh_state (
+    tenant_id                       TEXT NOT NULL DEFAULT 'local',
+    taxonomy_version                TEXT NOT NULL,
+    role_family_code                TEXT NOT NULL,
+    seniority_label                 TEXT NOT NULL CHECK (
+        seniority_label IN (
+            'entry', 'mid', 'senior', 'staff', 'principal',
+            'manager', 'director', 'executive', 'unknown'
+        )
+    ),
+    country_code                    TEXT NOT NULL CHECK (
+        length(country_code) = 2
+        AND country_code = upper(country_code)
+        AND country_code NOT GLOB '*[^A-Z]*'
+    ),
+    subdivision_code                TEXT NOT NULL DEFAULT '',
+    locality                        TEXT NOT NULL DEFAULT '',
+    geography_scope                 TEXT NOT NULL CHECK (
+        geography_scope IN ('country', 'country_subdivision', 'locality')
+    ),
+    component                       TEXT NOT NULL CHECK (
+        component IN ('base_salary', 'total_compensation')
+    ),
+    refresh_status                  TEXT NOT NULL CHECK (
+        refresh_status IN (
+            'missing', 'queued', 'refreshing', 'succeeded',
+            'insufficient_evidence', 'failed'
+        )
+    ),
+    last_result_kind                TEXT NOT NULL DEFAULT 'none' CHECK (
+        last_result_kind IN ('none', 'direct', 'extrapolated')
+    ),
+    last_direct_fact_id             TEXT,
+    last_extrapolated_fact_id       TEXT,
+    last_requested_at               TEXT,
+    last_checked_at                 TEXT,
+    next_refresh_at                 TEXT,
+    lease_owner                     TEXT,
+    lease_expires_at                TEXT,
+    attempt_count                   INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+    last_error_code                 TEXT,
+    updated_at                      TEXT NOT NULL CHECK (length(trim(updated_at)) > 0),
+    PRIMARY KEY (
+        tenant_id,
+        taxonomy_version,
+        role_family_code,
+        seniority_label,
+        country_code,
+        subdivision_code,
+        locality,
+        component
+    ),
+    FOREIGN KEY (taxonomy_version, role_family_code)
+        REFERENCES compensation_role_families(taxonomy_version, role_family_code)
+        ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, last_direct_fact_id)
+        REFERENCES compensation_direct_benchmark_facts(tenant_id, fact_id)
+        ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, last_extrapolated_fact_id)
+        REFERENCES compensation_extrapolated_benchmark_facts(tenant_id, fact_id)
+        ON DELETE RESTRICT,
+    CHECK (subdivision_code = '' OR length(trim(subdivision_code)) > 0),
+    CHECK (locality = '' OR length(trim(locality)) > 0),
+    CHECK (
+        (geography_scope = 'country' AND subdivision_code = '' AND locality = '')
+        OR (
+            geography_scope = 'country_subdivision'
+            AND subdivision_code != ''
+            AND locality = ''
+        )
+        OR (geography_scope = 'locality' AND locality != '')
+    ),
+    CHECK (
+        (last_result_kind = 'none' AND last_direct_fact_id IS NULL AND last_extrapolated_fact_id IS NULL)
+        OR (last_result_kind = 'direct' AND last_direct_fact_id IS NOT NULL)
+        OR (last_result_kind = 'extrapolated' AND last_extrapolated_fact_id IS NOT NULL)
+    ),
+    CHECK (
+        (lease_owner IS NULL AND lease_expires_at IS NULL)
+        OR (lease_owner IS NOT NULL AND lease_expires_at IS NOT NULL)
+    )
+);
+
+CREATE INDEX idx_compensation_direct_benchmark_lookup
+    ON compensation_direct_benchmark_facts (
+        tenant_id,
+        taxonomy_version,
+        role_family_code,
+        seniority_label,
+        country_code,
+        subdivision_code,
+        locality,
+        component,
+        fetched_at DESC
+    );
+
+CREATE INDEX idx_compensation_direct_benchmark_company
+    ON compensation_direct_benchmark_facts (
+        tenant_id,
+        normalized_company,
+        role_family_code,
+        seniority_label,
+        country_code
+    );
+
+CREATE INDEX idx_compensation_price_level_lookup
+    ON compensation_price_level_facts (
+        tenant_id,
+        country_code,
+        category,
+        reference_year DESC,
+        fetched_at DESC
+    );
+
+CREATE INDEX idx_compensation_extrapolated_benchmark_lookup
+    ON compensation_extrapolated_benchmark_facts (
+        tenant_id,
+        taxonomy_version,
+        role_family_code,
+        seniority_label,
+        target_country_code,
+        target_subdivision_code,
+        target_locality,
+        component,
+        derived_at DESC
+    );
+
+CREATE INDEX idx_compensation_market_refresh_due
+    ON compensation_market_refresh_state (
+        tenant_id,
+        refresh_status,
+        next_refresh_at,
+        taxonomy_version,
+        role_family_code,
+        seniority_label,
+        country_code
+    );
+
+CREATE TRIGGER prevent_compensation_role_family_collision
+BEFORE INSERT ON compensation_role_families
+WHEN EXISTS (
+    SELECT 1
+    FROM compensation_role_families
+    WHERE taxonomy_version = NEW.taxonomy_version
+      AND role_family_code = NEW.role_family_code
+)
+BEGIN
+    SELECT RAISE(ABORT, 'compensation role families are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_role_family_update
+BEFORE UPDATE ON compensation_role_families
+BEGIN
+    SELECT RAISE(ABORT, 'compensation role families are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_role_family_delete
+BEFORE DELETE ON compensation_role_families
+BEGIN
+    SELECT RAISE(ABORT, 'compensation role families are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_direct_benchmark_collision
+BEFORE INSERT ON compensation_direct_benchmark_facts
+WHEN EXISTS (
+    SELECT 1
+    FROM compensation_direct_benchmark_facts
+    WHERE tenant_id = NEW.tenant_id
+      AND (fact_id = NEW.fact_id OR evidence_hash = NEW.evidence_hash)
+)
+BEGIN
+    SELECT RAISE(ABORT, 'direct compensation benchmark facts are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_direct_benchmark_update
+BEFORE UPDATE ON compensation_direct_benchmark_facts
+BEGIN
+    SELECT RAISE(ABORT, 'direct compensation benchmark facts are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_direct_benchmark_delete
+BEFORE DELETE ON compensation_direct_benchmark_facts
+BEGIN
+    SELECT RAISE(ABORT, 'direct compensation benchmark facts are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_price_level_collision
+BEFORE INSERT ON compensation_price_level_facts
+WHEN EXISTS (
+    SELECT 1
+    FROM compensation_price_level_facts
+    WHERE tenant_id = NEW.tenant_id
+      AND (fact_id = NEW.fact_id OR evidence_hash = NEW.evidence_hash)
+)
+BEGIN
+    SELECT RAISE(ABORT, 'compensation price-level facts are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_price_level_update
+BEFORE UPDATE ON compensation_price_level_facts
+BEGIN
+    SELECT RAISE(ABORT, 'compensation price-level facts are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_price_level_delete
+BEFORE DELETE ON compensation_price_level_facts
+BEGIN
+    SELECT RAISE(ABORT, 'compensation price-level facts are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_extrapolated_benchmark_collision
+BEFORE INSERT ON compensation_extrapolated_benchmark_facts
+WHEN EXISTS (
+    SELECT 1
+    FROM compensation_extrapolated_benchmark_facts
+    WHERE tenant_id = NEW.tenant_id
+      AND (fact_id = NEW.fact_id OR inputs_hash = NEW.inputs_hash)
+)
+BEGIN
+    SELECT RAISE(ABORT, 'extrapolated compensation benchmark facts are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_extrapolated_benchmark_update
+BEFORE UPDATE ON compensation_extrapolated_benchmark_facts
+BEGIN
+    SELECT RAISE(ABORT, 'extrapolated compensation benchmark facts are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_extrapolated_benchmark_delete
+BEFORE DELETE ON compensation_extrapolated_benchmark_facts
+BEGIN
+    SELECT RAISE(ABORT, 'extrapolated compensation benchmark facts are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_extrapolation_direct_input_collision
+BEFORE INSERT ON compensation_extrapolation_direct_inputs
+WHEN EXISTS (
+    SELECT 1
+    FROM compensation_extrapolation_direct_inputs
+    WHERE tenant_id = NEW.tenant_id
+      AND extrapolated_fact_id = NEW.extrapolated_fact_id
+      AND direct_fact_id = NEW.direct_fact_id
+      AND input_role = NEW.input_role
+)
+BEGIN
+    SELECT RAISE(ABORT, 'compensation extrapolation direct inputs are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_extrapolation_direct_input_update
+BEFORE UPDATE ON compensation_extrapolation_direct_inputs
+BEGIN
+    SELECT RAISE(ABORT, 'compensation extrapolation direct inputs are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_extrapolation_direct_input_delete
+BEFORE DELETE ON compensation_extrapolation_direct_inputs
+BEGIN
+    SELECT RAISE(ABORT, 'compensation extrapolation direct inputs are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_extrapolation_price_input_collision
+BEFORE INSERT ON compensation_extrapolation_price_inputs
+WHEN EXISTS (
+    SELECT 1
+    FROM compensation_extrapolation_price_inputs
+    WHERE tenant_id = NEW.tenant_id
+      AND extrapolated_fact_id = NEW.extrapolated_fact_id
+      AND price_level_fact_id = NEW.price_level_fact_id
+      AND input_role = NEW.input_role
+)
+BEGIN
+    SELECT RAISE(ABORT, 'compensation extrapolation price inputs are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_extrapolation_price_input_update
+BEFORE UPDATE ON compensation_extrapolation_price_inputs
+BEGIN
+    SELECT RAISE(ABORT, 'compensation extrapolation price inputs are append-only');
+END;
+
+CREATE TRIGGER prevent_compensation_extrapolation_price_input_delete
+BEFORE DELETE ON compensation_extrapolation_price_inputs
+BEGIN
+    SELECT RAISE(ABORT, 'compensation extrapolation price inputs are append-only');
+END;

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v7_to_v8_execute.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v7_to_v8_execute.py
@@ -1,0 +1,330 @@
+"""Private file-to-file executor for the stopped-runtime v7-to-v8 cutover."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+import stat
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Final, Protocol
+
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    EXACT_V8_MANIFEST,
+    assert_exact_manifest,
+    schema_dump,
+)
+from jobctrl.infrastructure.migrations.schema_v8 import (
+    upgrade_exact_v7_schema_to_v8,
+)
+
+_GENERIC_FAILURE: Final = "v7-to-v8 candidate migration failed"
+_RESULT_SCHEMA_VERSION: Final = 1
+_EMPTY_V8_TABLES: Final = frozenset(
+    {
+        "compensation_direct_benchmark_facts",
+        "compensation_price_level_facts",
+        "compensation_extrapolated_benchmark_facts",
+        "compensation_extrapolation_direct_inputs",
+        "compensation_extrapolation_price_inputs",
+        "compensation_market_refresh_state",
+    }
+)
+
+
+class _Digest(Protocol):
+    def update(self, data: bytes, /) -> object: ...
+
+
+class CandidateExecutionError(RuntimeError):
+    """Raised when an isolated v8 candidate cannot be built and verified."""
+
+
+@dataclass(frozen=True)
+class CandidateExecutionResult:
+    schema_version: int
+    status: str
+    user_version: int
+    source_data_digest: str
+    candidate_data_digest: str
+    candidate_sha256: str
+    job_count: int
+    table_count: int
+
+
+def execute_v7_to_v8_candidate(
+    source_path: Path | str,
+    candidate_path: Path | str,
+    *,
+    _after_stamp: Callable[[], None] | None = None,
+) -> CandidateExecutionResult:
+    """Copy exact v7, add the v8 benchmark schema, and seal a new file."""
+
+    source = Path(source_path)
+    candidate = Path(candidate_path)
+    source_connection: sqlite3.Connection | None = None
+    candidate_connection: sqlite3.Connection | None = None
+    created_identity: tuple[int, int] | None = None
+    try:
+        _assert_paths(source, candidate)
+        descriptor = os.open(candidate, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        try:
+            os.fchmod(descriptor, 0o600)
+            created = os.fstat(descriptor)
+            created_identity = (created.st_dev, created.st_ino)
+        finally:
+            os.close(descriptor)
+
+        source_connection = sqlite3.connect(
+            f"{source.resolve().as_uri()}?mode=ro",
+            uri=True,
+        )
+        source_connection.execute("PRAGMA foreign_keys = ON")
+        if int(source_connection.execute("PRAGMA user_version").fetchone()[0]) != EXACT_V7_MANIFEST.version:
+            raise CandidateExecutionError(_GENERIC_FAILURE)
+        assert_exact_manifest(source_connection, EXACT_V7_MANIFEST)
+        source_tables = _durable_table_names(source_connection)
+        source_digest = _table_data_digest(source_connection, source_tables)
+
+        candidate_connection = sqlite3.connect(candidate)
+        candidate_connection.execute("PRAGMA foreign_keys = ON")
+        source_connection.backup(candidate_connection)
+        candidate_connection.commit()
+        assert_exact_manifest(candidate_connection, EXACT_V7_MANIFEST)
+        if _table_data_digest(candidate_connection, source_tables) != source_digest:
+            raise CandidateExecutionError(_GENERIC_FAILURE)
+
+        upgrade_exact_v7_schema_to_v8(candidate_connection)
+        if _after_stamp is not None:
+            _after_stamp()
+        candidate_connection.commit()
+        _verify_candidate(
+            source_connection,
+            candidate_connection,
+            source_tables=source_tables,
+            source_digest=source_digest,
+        )
+        candidate_digest = _table_data_digest(candidate_connection, source_tables)
+        job_count = int(candidate_connection.execute("SELECT COUNT(*) FROM jobs").fetchone()[0])
+
+        candidate_connection.close()
+        candidate_connection = None
+        source_connection.close()
+        source_connection = None
+        _fsync_regular_file(candidate)
+        _fsync_directory(candidate.parent)
+        return CandidateExecutionResult(
+            schema_version=_RESULT_SCHEMA_VERSION,
+            status="ready",
+            user_version=EXACT_V8_MANIFEST.version,
+            source_data_digest=source_digest,
+            candidate_data_digest=candidate_digest,
+            candidate_sha256=_sha256_file(candidate),
+            job_count=job_count,
+            table_count=EXACT_V8_MANIFEST.table_count,
+        )
+    except BaseException as error:
+        if candidate_connection is not None:
+            candidate_connection.close()
+        if source_connection is not None:
+            source_connection.close()
+        if created_identity is not None:
+            _remove_created_candidate(candidate, created_identity)
+        if isinstance(error, Exception):
+            raise CandidateExecutionError(_GENERIC_FAILURE) from None
+        raise
+
+
+def _verify_candidate(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    *,
+    source_tables: tuple[str, ...],
+    source_digest: str,
+) -> None:
+    if int(source.execute("PRAGMA user_version").fetchone()[0]) != EXACT_V7_MANIFEST.version:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    assert_exact_manifest(source, EXACT_V7_MANIFEST)
+    if _table_data_digest(source, source_tables) != source_digest:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+
+    if int(candidate.execute("PRAGMA user_version").fetchone()[0]) != EXACT_V8_MANIFEST.version:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    assert_exact_manifest(candidate, EXACT_V8_MANIFEST)
+    if _table_data_digest(candidate, source_tables) != source_digest:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    if candidate.execute("PRAGMA foreign_key_check").fetchall():
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    if candidate.execute("PRAGMA integrity_check").fetchone() != ("ok",):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    for table in _EMPTY_V8_TABLES:
+        if int(candidate.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]) != 0:
+            raise CandidateExecutionError(_GENERIC_FAILURE)
+    if int(candidate.execute("SELECT COUNT(*) FROM compensation_role_families").fetchone()[0]) < 1:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+
+
+def _durable_table_names(conn: sqlite3.Connection) -> tuple[str, ...]:
+    return tuple(
+        name
+        for object_type, name, _, _ in schema_dump(conn)
+        if object_type == "table"
+    )
+
+
+def _table_data_digest(conn: sqlite3.Connection, tables: tuple[str, ...]) -> str:
+    digest = hashlib.sha256()
+    for table in tables:
+        columns = tuple(
+            str(row[1])
+            for row in conn.execute(f"PRAGMA table_info({_quote_identifier(table)})")
+        )
+        _digest_value(digest, table)
+        _digest_value(digest, columns)
+        selected = ", ".join(_quote_identifier(column) for column in columns)
+        order_by = ", ".join(_quote_identifier(column) for column in columns)
+        rows = conn.execute(
+            f"SELECT {selected} FROM {_quote_identifier(table)} ORDER BY {order_by}"
+        )
+        for row in rows:
+            _digest_value(digest, tuple(row))
+    _digest_value(digest, _sequence_rows(conn))
+    return digest.hexdigest()
+
+
+def _sequence_rows(conn: sqlite3.Connection) -> tuple[tuple[object, ...], ...]:
+    exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'sqlite_sequence'"
+    ).fetchone()
+    if exists is None:
+        return ()
+    return tuple(
+        tuple(row)
+        for row in conn.execute("SELECT name, seq FROM sqlite_sequence ORDER BY name")
+    )
+
+
+def _digest_value(digest: _Digest, value: object) -> None:
+    if value is None:
+        encoded = b"n"
+    elif isinstance(value, bytes):
+        encoded = b"b" + value
+    elif isinstance(value, str):
+        encoded = b"s" + value.encode("utf-8")
+    elif isinstance(value, int):
+        encoded = b"i" + str(value).encode("ascii")
+    elif isinstance(value, float):
+        encoded = b"f" + value.hex().encode("ascii")
+    elif isinstance(value, tuple):
+        encoded = b"t"
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+        for item in value:
+            _digest_value(digest, item)
+        return
+    else:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    digest.update(len(encoded).to_bytes(8, "big"))
+    digest.update(encoded)
+
+
+def _quote_identifier(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def _assert_paths(source: Path, candidate: Path) -> None:
+    source_stat = source.lstat()
+    if not stat.S_ISREG(source_stat.st_mode):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    if os.path.abspath(source) == os.path.abspath(candidate):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    if os.path.lexists(candidate):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    if any(os.path.lexists(f"{candidate}{suffix}") for suffix in ("-journal", "-shm", "-wal")):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    if not stat.S_ISDIR(candidate.parent.stat().st_mode):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+
+
+def _remove_created_candidate(
+    candidate: Path,
+    created_identity: tuple[int, int],
+) -> None:
+    try:
+        current = candidate.lstat()
+    except FileNotFoundError:
+        current = None
+    if current is not None and (current.st_dev, current.st_ino) == created_identity:
+        candidate.unlink()
+    for suffix in ("-journal", "-shm", "-wal"):
+        Path(f"{candidate}{suffix}").unlink(missing_ok=True)
+
+
+def _fsync_regular_file(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise CandidateExecutionError(_GENERIC_FAILURE)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the authenticated launcher's private migration subprocess."""
+
+    parser = _PrivateArgumentParser(add_help=False)
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--candidate", required=True)
+    try:
+        arguments = parser.parse_args(argv)
+        result = execute_v7_to_v8_candidate(
+            arguments.source,
+            arguments.candidate,
+        )
+    except CandidateExecutionError:
+        print(_GENERIC_FAILURE, file=sys.stderr)
+        return 1
+    print(json.dumps(asdict(result), sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+class _PrivateArgumentParser(argparse.ArgumentParser):
+    """Argument parser that never echoes private transition paths."""
+
+    def error(self, _message: str) -> None:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "CandidateExecutionError",
+    "CandidateExecutionResult",
+    "execute_v7_to_v8_candidate",
+    "main",
+]

--- a/workers/automation/tests/test_exact_v8_schema.py
+++ b/workers/automation/tests/test_exact_v8_schema.py
@@ -1,0 +1,475 @@
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from jobctrl.infrastructure.migrations.compensation_role_family_seed import (
+    ROLE_FAMILY_TAXONOMY_VERSION,
+)
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    EXACT_V8_MANIFEST,
+    SchemaManifestError,
+    assert_exact_manifest,
+    schema_dump,
+)
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.schema_v8 import (
+    create_exact_v8_schema,
+    create_unstamped_exact_v8_candidate,
+    upgrade_exact_v7_schema_to_v8,
+)
+
+
+def test_fresh_exact_v8_schema_has_separate_benchmark_authorities() -> None:
+    conn = sqlite3.connect(":memory:")
+    try:
+        create_exact_v8_schema(conn)
+
+        assert conn.execute("PRAGMA user_version").fetchone() == (8,)
+        assert_exact_manifest(conn, EXACT_V8_MANIFEST)
+        tables = {
+            str(row[0])
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        assert {
+            "compensation_role_families",
+            "compensation_direct_benchmark_facts",
+            "compensation_price_level_facts",
+            "compensation_extrapolated_benchmark_facts",
+            "compensation_extrapolation_direct_inputs",
+            "compensation_extrapolation_price_inputs",
+            "compensation_market_refresh_state",
+        } <= tables
+        seeded = conn.execute(
+            """
+            SELECT role_family_code, display_name
+            FROM compensation_role_families
+            WHERE taxonomy_version = ?
+            ORDER BY role_family_code
+            """,
+            (ROLE_FAMILY_TAXONOMY_VERSION,),
+        ).fetchall()
+        assert ("software_engineering", "Software Engineering") in seeded
+        assert ("security_privacy", "Security & Privacy") in seeded
+    finally:
+        conn.close()
+
+
+def test_unstamped_exact_v8_candidate_keeps_version_zero() -> None:
+    conn = sqlite3.connect(":memory:")
+    try:
+        create_unstamped_exact_v8_candidate(conn)
+
+        assert conn.execute("PRAGMA user_version").fetchone() == (0,)
+        assert_exact_manifest(conn, EXACT_V8_MANIFEST)
+    finally:
+        conn.close()
+
+
+def test_exact_v7_to_v8_upgrade_is_additive_and_seeds_taxonomy() -> None:
+    conn = sqlite3.connect(":memory:")
+    try:
+        create_exact_v7_schema(conn)
+        conn.execute(
+            """
+            INSERT INTO jobs (tenant_id, job_id, url, title, company, location)
+            VALUES ('local', '11111111-1111-4111-8111-111111111111',
+                    'https://jobs.example/1', 'Senior Platform Engineer', 'Acme', 'Spain')
+            """
+        )
+        conn.commit()
+        original_schema = schema_dump(conn)
+        original_job = conn.execute("SELECT * FROM jobs").fetchone()
+
+        upgrade_exact_v7_schema_to_v8(conn)
+
+        assert conn.execute("PRAGMA user_version").fetchone() == (8,)
+        assert_exact_manifest(conn, EXACT_V8_MANIFEST)
+        assert conn.execute("SELECT * FROM jobs").fetchone() == original_job
+        assert tuple(item for item in schema_dump(conn) if item in original_schema) == original_schema
+        assert conn.execute("SELECT COUNT(*) FROM compensation_role_families").fetchone()[0] > 0
+        assert conn.execute("SELECT COUNT(*) FROM compensation_direct_benchmark_facts").fetchone() == (0,)
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+    finally:
+        conn.close()
+
+
+def test_exact_v7_to_v8_fault_rolls_back_to_exact_v7() -> None:
+    conn = sqlite3.connect(":memory:")
+    create_exact_v7_schema(conn)
+    before = schema_dump(conn)
+    executed = 0
+
+    def fail_after_partial_addition(statement: str) -> object:
+        nonlocal executed
+        executed += 1
+        if executed == 3:
+            raise RuntimeError("synthetic v8 schema failure")
+        return conn.execute(statement)
+
+    try:
+        with pytest.raises(RuntimeError, match="synthetic v8 schema failure"):
+            upgrade_exact_v7_schema_to_v8(conn, _execute=fail_after_partial_addition)
+
+        assert executed == 3
+        assert conn.execute("PRAGMA user_version").fetchone() == (7,)
+        assert schema_dump(conn) == before
+        assert_exact_manifest(conn, EXACT_V7_MANIFEST)
+    finally:
+        conn.close()
+
+
+def test_direct_and_extrapolated_benchmark_tables_are_append_only() -> None:
+    conn = sqlite3.connect(":memory:")
+    create_exact_v8_schema(conn)
+    fact_id = "11111111-1111-4111-8111-111111111111"
+    try:
+        conn.execute(
+            """
+            INSERT INTO compensation_direct_benchmark_facts (
+                tenant_id, fact_id, taxonomy_version, role_family_code,
+                seniority_label, country_code, geography_scope, market_scope,
+                component, original_currency, original_period,
+                original_minimum_amount, original_maximum_amount,
+                eur_annual_minimum_amount, eur_annual_maximum_amount,
+                confidence_interval_minimum_amount,
+                confidence_interval_maximum_amount, confidence_score,
+                sample_count, source_id, source_provenance, source_snapshot_id,
+                attribution, as_of_date, fetched_at, fresh_until, evidence_hash,
+                created_at
+            ) VALUES (
+                'local', ?, ?, 'software_engineering', 'senior', 'ES', 'country',
+                'market', 'base_salary', 'EUR', 'year', 80000, 100000, 80000,
+                100000, 72000, 110000, 0.8, 10, 'levels_fyi', 'public',
+                'levels-2026-08', 'Data source: Levels.fyi', '2026-08-01',
+                '2026-08-11T10:00:00Z', '2026-08-18T10:00:00Z', ?,
+                '2026-08-11T10:00:00Z'
+            )
+            """,
+            (fact_id, ROLE_FAMILY_TAXONOMY_VERSION, "a" * 64),
+        )
+
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(
+                "UPDATE compensation_direct_benchmark_facts SET sample_count = 11 WHERE fact_id = ?",
+                (fact_id,),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(
+                "DELETE FROM compensation_direct_benchmark_facts WHERE fact_id = ?",
+                (fact_id,),
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO compensation_direct_benchmark_facts (
+                    tenant_id, fact_id, taxonomy_version, role_family_code,
+                    seniority_label, country_code, geography_scope, market_scope,
+                    component, original_currency, original_period,
+                    original_minimum_amount, original_maximum_amount,
+                    eur_annual_minimum_amount, eur_annual_maximum_amount,
+                    confidence_interval_minimum_amount,
+                    confidence_interval_maximum_amount, confidence_score,
+                    sample_count, source_id, source_provenance, source_snapshot_id,
+                    attribution, as_of_date, fetched_at, fresh_until, evidence_hash,
+                    created_at
+                )
+                SELECT
+                    tenant_id, fact_id, taxonomy_version, role_family_code,
+                    seniority_label, country_code, geography_scope, market_scope,
+                    component, original_currency, original_period,
+                    original_minimum_amount, original_maximum_amount,
+                    eur_annual_minimum_amount, eur_annual_maximum_amount,
+                    confidence_interval_minimum_amount,
+                    confidence_interval_maximum_amount, confidence_score,
+                    99, source_id, source_provenance, source_snapshot_id,
+                    attribution, as_of_date, fetched_at, fresh_until, ?, created_at
+                FROM compensation_direct_benchmark_facts
+                WHERE fact_id = ?
+                """,
+                ("c" * 64, fact_id),
+            )
+        assert conn.execute(
+            "SELECT sample_count, evidence_hash FROM compensation_direct_benchmark_facts WHERE fact_id = ?",
+            (fact_id,),
+        ).fetchone() == (10, "a" * 64)
+    finally:
+        conn.close()
+
+
+def test_append_only_catalog_and_input_links_reject_insert_or_replace() -> None:
+    conn = sqlite3.connect(":memory:")
+    create_exact_v8_schema(conn)
+    try:
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO compensation_role_families (
+                    taxonomy_version, role_family_code, display_name,
+                    isco_codes_json, created_at
+                ) VALUES (?, 'software_engineering', 'Replaced', '[]', '2026-08-11T10:00:00Z')
+                """,
+                (ROLE_FAMILY_TAXONOMY_VERSION,),
+            )
+        assert conn.execute(
+            """
+            SELECT display_name FROM compensation_role_families
+            WHERE taxonomy_version = ? AND role_family_code = 'software_engineering'
+            """,
+            (ROLE_FAMILY_TAXONOMY_VERSION,),
+        ).fetchone() == ("Software Engineering",)
+
+        conn.execute("PRAGMA foreign_keys = ON")
+        _insert_direct_fact(conn)
+        _insert_extrapolated_fact(conn, raw_factor=1.2, bound_state="within_bounds")
+        conn.execute(
+            """
+            INSERT INTO compensation_extrapolation_direct_inputs (
+                tenant_id, extrapolated_fact_id, direct_fact_id, input_role, weight
+            ) VALUES (
+                'local', '22222222-2222-4222-8222-222222222222',
+                '11111111-1111-4111-8111-111111111111', 'anchor', 1.0
+            )
+            """
+        )
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO compensation_extrapolation_direct_inputs (
+                    tenant_id, extrapolated_fact_id, direct_fact_id, input_role, weight
+                ) VALUES (
+                    'local', '22222222-2222-4222-8222-222222222222',
+                    '11111111-1111-4111-8111-111111111111', 'anchor', 0.2
+                )
+                """
+            )
+        assert conn.execute(
+            "SELECT weight FROM compensation_extrapolation_direct_inputs"
+        ).fetchone() == (1.0,)
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize(
+    ("column", "value"),
+    (
+        ("isco_codes_json", "not-json"),
+        ("isco_codes_json", "{}"),
+    ),
+)
+def test_role_family_catalog_rejects_malformed_json(column: str, value: str) -> None:
+    conn = sqlite3.connect(":memory:")
+    create_exact_v8_schema(conn)
+    try:
+        with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+            conn.execute(
+                f"""
+                INSERT INTO compensation_role_families (
+                    taxonomy_version, role_family_code, display_name, {column}, created_at
+                ) VALUES ('test-v1', 'test', 'Test', ?, '2026-08-11T10:00:00Z')
+                """,
+                (value,),
+            )
+    finally:
+        conn.close()
+
+
+def test_direct_fact_rejects_wrong_fx_reference_json_type() -> None:
+    conn = sqlite3.connect(":memory:")
+    create_exact_v8_schema(conn)
+    try:
+        with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+            conn.execute(
+                """
+                INSERT INTO compensation_direct_benchmark_facts (
+                    tenant_id, fact_id, taxonomy_version, role_family_code,
+                    seniority_label, country_code, geography_scope, market_scope,
+                    component, original_currency, original_period,
+                    original_minimum_amount, original_maximum_amount,
+                    eur_annual_minimum_amount, eur_annual_maximum_amount,
+                    confidence_interval_minimum_amount,
+                    confidence_interval_maximum_amount, confidence_score,
+                    sample_count, source_id, source_provenance, source_snapshot_id,
+                    attribution, fx_reference_json, as_of_date, fetched_at,
+                    fresh_until, evidence_hash, created_at
+                ) VALUES (
+                    'local', '11111111-1111-4111-8111-111111111111', ?,
+                    'software_engineering', 'senior', 'ES', 'country', 'market',
+                    'base_salary', 'EUR', 'year', 80000, 100000, 80000, 100000,
+                    72000, 110000, 0.8, 10, 'levels_fyi', 'public', 'levels-2026-08',
+                    'Data source: Levels.fyi', '[]', '2026-08-01',
+                    '2026-08-11T10:00:00Z', '2026-08-18T10:00:00Z', ?,
+                    '2026-08-11T10:00:00Z'
+                )
+                """,
+                (ROLE_FAMILY_TAXONOMY_VERSION, "a" * 64),
+            )
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize(
+    "authority",
+    ("direct", "extrapolated", "refresh"),
+)
+def test_benchmark_authorities_reject_whitespace_geography_keys(authority: str) -> None:
+    conn = sqlite3.connect(":memory:")
+    create_exact_v8_schema(conn)
+    conn.execute("PRAGMA foreign_keys = ON")
+    try:
+        if authority == "direct":
+            with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+                _insert_direct_fact(
+                    conn,
+                    subdivision_code=" ",
+                    geography_scope="country_subdivision",
+                )
+        elif authority == "extrapolated":
+            _insert_direct_fact(conn)
+            with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+                _insert_extrapolated_fact(
+                    conn,
+                    raw_factor=1.2,
+                    bound_state="within_bounds",
+                    subdivision_code=" ",
+                    geography_scope="country_subdivision",
+                )
+        else:
+            with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+                conn.execute(
+                    """
+                    INSERT INTO compensation_market_refresh_state (
+                        tenant_id, taxonomy_version, role_family_code,
+                        seniority_label, country_code, subdivision_code,
+                        geography_scope, component, refresh_status, updated_at
+                    ) VALUES (
+                        'local', ?, 'software_engineering', 'senior', 'ES', ' ',
+                        'country_subdivision', 'base_salary', 'missing',
+                        '2026-08-11T10:00:00Z'
+                    )
+                    """,
+                    (ROLE_FAMILY_TAXONOMY_VERSION,),
+                )
+    finally:
+        conn.close()
+
+
+def test_out_of_bound_factor_requires_explicit_bound_state() -> None:
+    conn = sqlite3.connect(":memory:")
+    create_exact_v8_schema(conn)
+    try:
+        conn.execute("PRAGMA foreign_keys = ON")
+        _insert_direct_fact(conn)
+
+        with pytest.raises(sqlite3.IntegrityError, match="CHECK constraint failed"):
+            _insert_extrapolated_fact(conn, raw_factor=12.0, bound_state="within_bounds")
+
+        _insert_extrapolated_fact(conn, raw_factor=12.0, bound_state="above_upper_bound")
+        row = conn.execute(
+            """
+            SELECT raw_factor, factor_bound_state, minimum_amount, maximum_amount
+            FROM compensation_extrapolated_benchmark_facts
+            """
+        ).fetchone()
+        assert row == (12.0, "above_upper_bound", 960000, 1200000)
+    finally:
+        conn.close()
+
+
+def _insert_direct_fact(
+    conn: sqlite3.Connection,
+    *,
+    subdivision_code: str = "",
+    geography_scope: str = "country",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO compensation_direct_benchmark_facts (
+            tenant_id, fact_id, taxonomy_version, role_family_code,
+            seniority_label, country_code, subdivision_code, geography_scope,
+            market_scope,
+            component, original_currency, original_period,
+            original_minimum_amount, original_maximum_amount,
+            eur_annual_minimum_amount, eur_annual_maximum_amount,
+            confidence_interval_minimum_amount,
+            confidence_interval_maximum_amount, confidence_score,
+            sample_count, source_id, source_provenance, source_snapshot_id,
+            attribution, as_of_date, fetched_at, fresh_until, evidence_hash,
+            created_at
+        ) VALUES (
+            'local', '11111111-1111-4111-8111-111111111111', ?,
+            'software_engineering', 'senior', 'DE', ?, ?, 'market',
+            'base_salary', 'EUR', 'year', 80000, 100000, 80000, 100000,
+            72000, 110000, 0.8, 10, 'levels_fyi', 'public', 'levels-2026-08',
+            'Data source: Levels.fyi', '2026-08-01', '2026-08-11T10:00:00Z',
+            '2026-08-18T10:00:00Z', ?, '2026-08-11T10:00:00Z'
+        )
+        """,
+        (
+            ROLE_FAMILY_TAXONOMY_VERSION,
+            subdivision_code,
+            geography_scope,
+            "a" * 64,
+        ),
+    )
+
+
+def _insert_extrapolated_fact(
+    conn: sqlite3.Connection,
+    *,
+    raw_factor: float,
+    bound_state: str,
+    subdivision_code: str = "",
+    geography_scope: str = "country",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO compensation_extrapolated_benchmark_facts (
+            tenant_id, fact_id, anchor_direct_fact_id, taxonomy_version,
+            role_family_code, seniority_label, target_country_code,
+            target_subdivision_code, target_geography_scope, component,
+            currency, period,
+            minimum_amount, maximum_amount,
+            confidence_interval_minimum_amount,
+            confidence_interval_maximum_amount, confidence_band,
+            confidence_score, extrapolation_method, raw_factor,
+            shrinkage_weight, lower_factor_bound, upper_factor_bound,
+            factor_bound_state, matched_company_count, formula_version,
+            inputs_hash, as_of_date, derived_at, fresh_until
+        ) VALUES (
+            'local', '22222222-2222-4222-8222-222222222222',
+            '11111111-1111-4111-8111-111111111111', ?,
+            'software_engineering', 'senior', 'CH', ?, ?, 'base_salary',
+            'EUR', 'year', 960000, 1200000, 864000, 1320000, 'low', 0.25,
+            'evidence_weighted_shrinkage', ?, 0.2, 0.1, 10.0, ?, 0,
+            'geo-shrinkage-v1', ?, '2026-08-01', '2026-08-11T10:00:00Z',
+            '2026-08-18T10:00:00Z'
+        )
+        """,
+        (
+            ROLE_FAMILY_TAXONOMY_VERSION,
+            subdivision_code,
+            geography_scope,
+            raw_factor,
+            bound_state,
+            "b" * 64,
+        ),
+    )
+
+
+def test_upgrade_rejects_non_exact_v7_without_mutation() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE jobs (id TEXT)")
+    conn.execute("PRAGMA user_version = 7")
+    before = schema_dump(conn)
+    try:
+        with pytest.raises(SchemaManifestError):
+            upgrade_exact_v7_schema_to_v8(conn)
+        assert conn.execute("PRAGMA user_version").fetchone() == (7,)
+        assert schema_dump(conn) == before
+    finally:
+        conn.close()

--- a/workers/automation/tests/test_schema_v7_packaging.py
+++ b/workers/automation/tests/test_schema_v7_packaging.py
@@ -10,7 +10,10 @@ from pathlib import Path
 
 
 _AUTOMATION_ROOT = Path(__file__).resolve().parents[1]
-_SCHEMA_MEMBER = "jobctrl/infrastructure/migrations/schema_v7.sql"
+_SCHEMA_MEMBERS = {
+    "jobctrl/infrastructure/migrations/schema_v7.sql",
+    "jobctrl/infrastructure/migrations/schema_v8.sql",
+}
 
 
 def test_exact_v7_schema_is_bundled_in_wheel_and_sdist(tmp_path: Path) -> None:
@@ -33,8 +36,9 @@ def test_exact_v7_schema_is_bundled_in_wheel_and_sdist(tmp_path: Path) -> None:
 
     wheel = next(tmp_path.glob("*.whl"))
     with zipfile.ZipFile(wheel) as archive:
-        assert _SCHEMA_MEMBER in archive.namelist()
+        assert _SCHEMA_MEMBERS <= set(archive.namelist())
 
     sdist = next(tmp_path.glob("*.tar.gz"))
     with tarfile.open(sdist) as archive:
-        assert any(member.name.endswith(_SCHEMA_MEMBER) for member in archive)
+        names = {member.name for member in archive}
+        assert all(any(name.endswith(schema) for name in names) for schema in _SCHEMA_MEMBERS)

--- a/workers/automation/tests/test_v7_to_v8_execute.py
+++ b/workers/automation/tests/test_v7_to_v8_execute.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    EXACT_V8_MANIFEST,
+    assert_exact_manifest,
+)
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.v7_to_v8_execute import (
+    CandidateExecutionError,
+    execute_v7_to_v8_candidate,
+    main,
+)
+
+
+def test_executor_builds_verified_v8_candidate_without_mutating_source(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.db"
+    candidate = tmp_path / "candidate.db"
+    _create_v7_source(source)
+    source_before = _sha256(source)
+
+    result = execute_v7_to_v8_candidate(source, candidate)
+
+    assert result.schema_version == 1
+    assert result.status == "ready"
+    assert result.user_version == 8
+    assert result.source_data_digest == result.candidate_data_digest
+    assert result.candidate_sha256 == _sha256(candidate)
+    assert result.job_count == 1
+    assert result.table_count == EXACT_V8_MANIFEST.table_count
+    assert _sha256(source) == source_before
+
+    source_conn = sqlite3.connect(source)
+    candidate_conn = sqlite3.connect(candidate)
+    try:
+        assert source_conn.execute("PRAGMA user_version").fetchone() == (7,)
+        assert_exact_manifest(source_conn, EXACT_V7_MANIFEST)
+        assert candidate_conn.execute("PRAGMA user_version").fetchone() == (8,)
+        assert_exact_manifest(candidate_conn, EXACT_V8_MANIFEST)
+        assert candidate_conn.execute("SELECT title FROM jobs").fetchone() == (
+            "Senior Platform Engineer",
+        )
+        assert candidate_conn.execute(
+            "SELECT COUNT(*) FROM compensation_direct_benchmark_facts"
+        ).fetchone() == (0,)
+        assert candidate_conn.execute(
+            "SELECT COUNT(*) FROM compensation_role_families"
+        ).fetchone()[0] > 0
+    finally:
+        source_conn.close()
+        candidate_conn.close()
+
+
+def test_executor_failure_removes_only_created_candidate_and_preserves_source(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.db"
+    candidate = tmp_path / "candidate.db"
+    _create_v7_source(source)
+    before = _sha256(source)
+
+    with pytest.raises(CandidateExecutionError, match="candidate migration failed"):
+        execute_v7_to_v8_candidate(
+            source,
+            candidate,
+            _after_stamp=lambda: (_ for _ in ()).throw(RuntimeError("synthetic")),
+        )
+
+    assert _sha256(source) == before
+    assert not candidate.exists()
+    assert not Path(f"{candidate}-wal").exists()
+    assert not Path(f"{candidate}-shm").exists()
+
+
+def test_executor_rejects_existing_candidate_without_changing_it(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    candidate = tmp_path / "candidate.db"
+    _create_v7_source(source)
+    candidate.write_bytes(b"owned fixture")
+
+    with pytest.raises(CandidateExecutionError, match="candidate migration failed"):
+        execute_v7_to_v8_candidate(source, candidate)
+
+    assert candidate.read_bytes() == b"owned fixture"
+
+
+def test_private_cli_returns_bounded_receipt_and_generic_failure(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "source.db"
+    candidate = tmp_path / "candidate.db"
+    _create_v7_source(source)
+
+    assert main(["--source", str(source), "--candidate", str(candidate)]) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    assert set(receipt) == {
+        "candidate_data_digest",
+        "candidate_sha256",
+        "job_count",
+        "schema_version",
+        "source_data_digest",
+        "status",
+        "table_count",
+        "user_version",
+    }
+    assert receipt["user_version"] == 8
+
+    missing = tmp_path / "missing.db"
+    assert main(["--source", str(missing), "--candidate", str(tmp_path / "failed.db")]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "v7-to-v8 candidate migration failed\n"
+    assert str(missing) not in captured.err
+
+
+def _create_v7_source(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        create_exact_v7_schema(conn)
+        conn.execute(
+            """
+            INSERT INTO jobs (tenant_id, job_id, url, title, company, location)
+            VALUES ('local', '11111111-1111-4111-8111-111111111111',
+                    'https://jobs.example/1', 'Senior Platform Engineer', 'Acme', 'Spain')
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()


### PR DESCRIPTION
## Summary

- add a frozen exact-v8 schema extension for reusable compensation evidence
- keep direct market facts, official price-level facts, and extrapolated facts physically separate
- add relational lineage for direct and price-level extrapolation inputs plus refresh state per role-family/seniority/geography cell
- seed a versioned JobCtrl role-family taxonomy with optional ISCO mappings
- add a file-to-file exact-v7→v8 candidate transformer that preserves all v7 data, verifies integrity, and removes failed candidates
- publish matching Python and TypeScript exact-v8 manifest constants without activating v8 at runtime yet

## Why

The existing `job_market_compensation_estimates` table is a mutable per-job output. It cannot be the reusable authority needed for automatic role-family discovery or for strict separation between observed and geographically extrapolated ranges.

This is an unreleased groundwork layer in stack #791. Runtime activation and canonical writers land above it; this PR alone does not change the currently admitted exact-v7 runtime.

## Data integrity

- immutable authorities reject UPDATE, DELETE, UPSERT, and `INSERT OR REPLACE` collisions
- JSON columns require valid object/array top-level types
- geography keys reject whitespace-only subdivision/locality values
- extrapolated facts retain raw factors and explicit `within_bounds`, `below_lower_bound`, or `above_upper_bound` state for the 0.1x–10x safety envelope
- migration creates benchmark authorities empty and seeds only the public product taxonomy

## Validation

- `uv --project workers/automation run pytest workers/automation/tests/test_exact_v8_schema.py workers/automation/tests/test_v7_to_v8_execute.py workers/automation/tests/test_schema_v7_packaging.py` — 19 passed
- focused exact-v7 preservation/schema suite — 38 passed in independent review
- `uv --project workers/automation run ruff check ...` — passed
- `corepack pnpm --filter @jobctrl/api test -- test/schema-version-guard.test.ts` — 770 API tests passed
- `corepack pnpm --filter @jobctrl/api check` — passed
- `git diff --check` — passed
- independent Tier-3 review — PASS, no findings

## Checklist

- [x] External contributor DCO sign-off — not applicable to repository owner commit
- [x] Relevant local checks are listed above
- [x] No secrets, private profile data, resumes, generated materials, logs, browser profiles, SQLite databases, or local paths are included
