### PR TITLE
feat(storage): activate exact v8 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,13 +511,14 @@ This writes `~/.jobctrl/backups/jobctrl-<timestamp>.db` via SQLite
 `VACUUM INTO` and never deletes anything (`--output <path>` to choose a
 target).
 
-The native v7 update performs its own paired migration safeguard. For an
-admitted v6 installation it stops and quiesces JobCtrl, backs up both
-`jobctrl.db` and bundled Temporal state, builds and verifies the JobId-keyed v7
-candidate in one transaction, then activates the verified pair. Any failed
-build, verification, or activation restores the previous pair. The API and
-worker run exact v7 only; there is no mixed-version, dual-write, or permanent
-fallback runtime.
+The native exact-v8 update performs its own paired migration safeguard. It
+stops JobCtrl and backs up both `jobctrl.db` and bundled Temporal state. An
+admitted v6 installation is quiesced and transformed through a private exact-v7
+intermediate before v8 is sealed; an exact-v7 installation receives only the
+additive v8 schema. The intermediate is never installed. Any failed build,
+verification, activation, or readiness check restores the previous pair. The
+API and worker run exact v8 only; there is no mixed-version, dual-write, or
+permanent fallback runtime.
 
 <details>
 <summary><b>Restore steps</b></summary>

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import Database from "better-sqlite3";
 
-import { EXACT_V7_SCHEMA_MANIFEST, hasExactV7SchemaManifest } from "./schema-manifest.js";
+import { EXACT_V8_SCHEMA_MANIFEST, hasExactV8SchemaManifest } from "./schema-manifest.js";
 
 export type SqliteDatabase = Database.Database;
 export type SqliteValue = string | number | bigint | null;
@@ -11,7 +11,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only admits the exact
 // migrated schema shape. Bump both constants together whenever the schema
 // shape changes.
-export const SUPPORTED_SCHEMA_VERSION = EXACT_V7_SCHEMA_MANIFEST.version;
+export const SUPPORTED_SCHEMA_VERSION = EXACT_V8_SCHEMA_MANIFEST.version;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {
@@ -28,7 +28,7 @@ export class IncompatibleSchemaVersionError extends Error {
 export class IncompatibleSchemaManifestError extends Error {
   constructor() {
     super(
-      "JobCtrl database schema does not match the exact v7 manifest; restore "
+      "JobCtrl database schema does not match the exact v8 manifest; restore "
         + "a compatible backup or complete the documented stopped-runtime migration.",
     );
     this.name = "IncompatibleSchemaManifestError";
@@ -37,14 +37,14 @@ export class IncompatibleSchemaManifestError extends Error {
 
 function assertExactSchemaVersion(db: SqliteDatabase): void {
   // The API never writes ``user_version`` — the Python worker owns stamping so
-  // the schema marker has a single writer. The v6-to-v7 migration is the only
-  // upgrade path; runtime admission accepts only the completed v7 shape.
+  // the schema marker has a single writer. Stopped-runtime migration is the
+  // only upgrade path; runtime admission accepts only the completed v8 shape.
   const current = db.pragma("user_version", { simple: true }) as number;
   if (current !== SUPPORTED_SCHEMA_VERSION) {
     db.close();
     throw new IncompatibleSchemaVersionError(current);
   }
-  if (!hasExactV7SchemaManifest(db)) {
+  if (!hasExactV8SchemaManifest(db)) {
     db.close();
     throw new IncompatibleSchemaManifestError();
   }
@@ -63,7 +63,7 @@ export function openReadOnlyDatabase(dbPath: string): SqliteDatabase {
 export function openDatabase(dbPath: string): SqliteDatabase {
   const db = new Database(dbPath, { fileMustExist: true });
   assertExactSchemaVersion(db);
-  // Exact-v7 permanent deletion relies on the sealed schema's cascade and
+  // Exact-v8 permanent deletion relies on the sealed schema's cascade and
   // RESTRICT constraints. SQLite enables those constraints per connection.
   db.pragma("foreign_keys = ON");
   // L4 (round-1 review): now that read endpoints write (projection

--- a/apps/api/test/application-feedback-v7.test.ts
+++ b/apps/api/test/application-feedback-v7.test.ts
@@ -21,7 +21,7 @@ import {
   recordManualApplicationOutcome,
 } from "../src/application-feedback.js";
 import { InputError } from "../src/write-model.js";
-import { hasExactV7SchemaManifest } from "../src/schema-manifest.js";
+import { hasExactV8SchemaManifest } from "../src/schema-manifest.js";
 import { initializeExactV7Database } from "./v7-schema.js";
 
 const JOB_ID = "00000000-0000-4000-8000-000000000071";
@@ -143,11 +143,11 @@ describe("application feedback exact v7 identity", () => {
 
   it("does not mutate the exact-v7 schema and refuses an invalid job id", () => {
     const db = seededDatabase();
-    expect(hasExactV7SchemaManifest(db)).toBe(true);
+    expect(hasExactV8SchemaManifest(db)).toBe(true);
 
     expect(() =>
       recordManualApplicationOutcome(db, "not-a-canonical-job-id", { kind: "interview" }),
     ).toThrow(InputError);
-    expect(hasExactV7SchemaManifest(db)).toBe(true);
+    expect(hasExactV8SchemaManifest(db)).toBe(true);
   });
 });

--- a/apps/api/test/exact-v7-projections.test.ts
+++ b/apps/api/test/exact-v7-projections.test.ts
@@ -6,7 +6,7 @@ import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { refreshProjections } from "../src/projections.js";
-import { EXACT_V7_SCHEMA_MANIFEST, schemaManifest } from "../src/schema-manifest.js";
+import { EXACT_V8_SCHEMA_MANIFEST, schemaManifest } from "../src/schema-manifest.js";
 import { initializeExactV7Database } from "./v7-schema.js";
 
 const JOB_ID = "00000000-0000-4000-8000-000000000071";
@@ -28,8 +28,8 @@ describe("exact-v7 projection refresh", () => {
     initializeExactV7Database(dbPath);
     const db = new Database(dbPath);
     db.pragma("foreign_keys = ON");
-    const before = schemaManifest(db, EXACT_V7_SCHEMA_MANIFEST.version);
-    expect(before).toEqual(EXACT_V7_SCHEMA_MANIFEST);
+    const before = schemaManifest(db, EXACT_V8_SCHEMA_MANIFEST.version);
+    expect(before).toEqual(EXACT_V8_SCHEMA_MANIFEST);
 
     const insertJob = db.prepare(
       `INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at)
@@ -86,7 +86,7 @@ describe("exact-v7 projection refresh", () => {
         .prepare("SELECT title FROM job_list_projections WHERE tenant_id = ? AND job_id = ?")
         .get("other", JOB_ID),
     ).toEqual({ title: "Other title" });
-    expect(schemaManifest(db, EXACT_V7_SCHEMA_MANIFEST.version)).toEqual(before);
+    expect(schemaManifest(db, EXACT_V8_SCHEMA_MANIFEST.version)).toEqual(before);
     db.close();
   });
 

--- a/apps/api/test/permanent-delete-v7.test.ts
+++ b/apps/api/test/permanent-delete-v7.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { openDatabase } from "../src/db.js";
 import { rebuildTenantDeleteProjections } from "../src/projections.js";
-import { schemaManifest, EXACT_V7_SCHEMA_MANIFEST } from "../src/schema-manifest.js";
+import { schemaManifest, EXACT_V8_SCHEMA_MANIFEST } from "../src/schema-manifest.js";
 import { permanentlyDeleteJob } from "../src/write-model.js";
 import { initializeExactV7Database } from "./v7-schema.js";
 
@@ -261,7 +261,7 @@ describe("exact-v7 permanent job deletion", () => {
   it("purges only the local Job aggregate, preserves independent history, and permits rediscovery", () => {
     const db = exactDatabase();
     seedExactV7DeleteGraph(db);
-    const manifestBefore = schemaManifest(db, EXACT_V7_SCHEMA_MANIFEST.version);
+    const manifestBefore = schemaManifest(db, EXACT_V8_SCHEMA_MANIFEST.version);
     const otherJobsBefore = rowSnapshot(db, "jobs", "tenant_id = ? AND job_id = ?", [OTHER_TENANT, JOB_ID]);
     const otherLocatorsBefore = rowSnapshot(db, "job_locators", "tenant_id = ? AND job_id = ?", [OTHER_TENANT, JOB_ID]);
     const otherEvidenceBefore = rowSnapshot(db, "evidence_usage_projections", "tenant_id = ?", [OTHER_TENANT]);
@@ -360,7 +360,7 @@ describe("exact-v7 permanent job deletion", () => {
       expect.objectContaining({ last_event_id: 999 }),
     ]);
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
-    expect(schemaManifest(db, EXACT_V7_SCHEMA_MANIFEST.version)).toEqual(manifestBefore);
+    expect(schemaManifest(db, EXACT_V8_SCHEMA_MANIFEST.version)).toEqual(manifestBefore);
 
     expect(rowSnapshot(db, "jobs", "tenant_id = ? AND job_id = ?", [OTHER_TENANT, JOB_ID])).toEqual(otherJobsBefore);
     expect(rowSnapshot(db, "job_locators", "tenant_id = ? AND job_id = ?", [OTHER_TENANT, JOB_ID])).toEqual(otherLocatorsBefore);

--- a/apps/api/test/read-model-v7.test.ts
+++ b/apps/api/test/read-model-v7.test.ts
@@ -14,7 +14,7 @@ import {
   listScoringKeywords,
 } from "../src/read-model.js";
 import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
-import { EXACT_V7_SCHEMA_MANIFEST, schemaManifest } from "../src/schema-manifest.js";
+import { EXACT_V8_SCHEMA_MANIFEST, schemaManifest } from "../src/schema-manifest.js";
 import { hideJob, restoreJob, softDeleteJob, unhideJob } from "../src/write-model.js";
 import { initializeExactV7Database } from "./v7-schema.js";
 
@@ -191,7 +191,7 @@ const activeJobQuery: JobListQuery = {
 describe("exact-v7 read model job ids", () => {
   it("keeps same-UUID tenants isolated while preserving URL locators and material/template state", () => {
     const db = seededDatabase();
-    const before = schemaManifest(db, EXACT_V7_SCHEMA_MANIFEST.version);
+    const before = schemaManifest(db, EXACT_V8_SCHEMA_MANIFEST.version);
 
     const jobs = listJobs(db, activeJobQuery);
     const detail = getJobDetail(db, JOB_ID);
@@ -213,7 +213,7 @@ describe("exact-v7 read model job ids", () => {
     expect(detail?.job.resumeTemplate).toEqual(expect.any(Object));
     expect(detail?.stages.find((stage) => stage.stage === "score")).toMatchObject({ retryable: false });
     expect(dashboard.totals.jobs).toBe(1);
-    expect(schemaManifest(db, EXACT_V7_SCHEMA_MANIFEST.version)).toEqual(before);
+    expect(schemaManifest(db, EXACT_V8_SCHEMA_MANIFEST.version)).toEqual(before);
   });
 
   it("filters hidden and deleted jobs and uses only tenant-scoped events and audit rows", () => {

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -30,15 +30,16 @@ function makeDbWithUserVersion(userVersion: number): { dbPath: string; cleanup: 
   return { dbPath, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
 }
 
-function makeExactV7Database(): { dbPath: string; cleanup: () => void } {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-exact-v7-"));
+function makeExactV8Database(): { dbPath: string; cleanup: () => void } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-exact-v8-"));
   const dbPath = path.join(dir, "jobs.db");
-  const schemaPath = path.resolve(
+  const migrations = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
-    "../../../workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql",
+    "../../../workers/automation/src/jobctrl/infrastructure/migrations",
   );
   const db = new Database(dbPath);
-  db.exec(fs.readFileSync(schemaPath, "utf8"));
+  db.exec(fs.readFileSync(path.join(migrations, "schema_v7.sql"), "utf8"));
+  db.exec(fs.readFileSync(path.join(migrations, "schema_v8.sql"), "utf8"));
   db.pragma(`user_version = ${SUPPORTED_SCHEMA_VERSION}`);
   db.close();
   return { dbPath, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
@@ -54,7 +55,7 @@ function tableColumns(db: Database.Database, tableName: string): string[] {
 }
 
 describe("schema version guard at DB open", () => {
-  it.each([0, 6, 8])("refuses schema version %i before runtime writes", (userVersion) => {
+  it.each([0, 6, 7, 9])("refuses schema version %i before runtime writes", (userVersion) => {
     const { dbPath, cleanup } = makeDbWithUserVersion(userVersion);
     try {
       const token = "job" + "ctl";
@@ -83,8 +84,8 @@ describe("schema version guard at DB open", () => {
     }
   });
 
-  it("opens the exact v7 schema", () => {
-    const { dbPath, cleanup } = makeExactV7Database();
+  it("opens the exact v8 schema", () => {
+    const { dbPath, cleanup } = makeExactV8Database();
     try {
       openDatabase(dbPath).close();
       openReadOnlyDatabase(dbPath).close();
@@ -93,7 +94,7 @@ describe("schema version guard at DB open", () => {
     }
   });
 
-  it("rejects a merely stamped v7 database before runtime writes", () => {
+  it("rejects a merely stamped v8 database before runtime writes", () => {
     const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION);
     try {
       expect(() => openDatabase(dbPath)).toThrow(IncompatibleSchemaManifestError);
@@ -110,7 +111,7 @@ describe("schema version guard at DB open", () => {
     }
   });
 
-  it("rejects a malformed v7 database without running legacy tombstone migration", () => {
+  it("rejects a malformed v8 database without running legacy tombstone migration", () => {
     const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION);
     try {
       const token = "job" + "ctl";
@@ -151,7 +152,7 @@ describe("schema version guard at DB open", () => {
     expect(pythonManifest).toContain("table_count=110,");
     expect(pythonManifest).toContain(`fingerprint=\"${EXACT_V7_SCHEMA_MANIFEST.fingerprint}\",`);
     expect(EXACT_V7_SCHEMA_MANIFEST).toEqual({
-      version: SUPPORTED_SCHEMA_VERSION,
+      version: 7,
       objectCount: 242,
       tableCount: 110,
       fingerprint: "775312f0ec2640a2a87889602886c90e21a49e06fffc53cf26c435856247da97",
@@ -161,7 +162,7 @@ describe("schema version guard at DB open", () => {
     expect(pythonManifest).toContain("table_count=117,");
     expect(pythonManifest).toContain(`fingerprint="${EXACT_V8_SCHEMA_MANIFEST.fingerprint}",`);
     expect(EXACT_V8_SCHEMA_MANIFEST).toEqual({
-      version: 8,
+      version: SUPPORTED_SCHEMA_VERSION,
       objectCount: 272,
       tableCount: 117,
       fingerprint: "3705f7c7d90454bbeaa85227a9d4ce87c12efd14935e0d14afc830939e80ff31",

--- a/apps/api/test/score-correction-v7.test.ts
+++ b/apps/api/test/score-correction-v7.test.ts
@@ -15,7 +15,7 @@ vi.mock("../src/read-model.js", async (importOriginal) => ({
   getJobDetail,
 }));
 
-import { hasExactV7SchemaManifest } from "../src/schema-manifest.js";
+import { hasExactV8SchemaManifest } from "../src/schema-manifest.js";
 import { buildApp } from "../src/server.js";
 import { initializeExactV7Database } from "./v7-schema.js";
 
@@ -104,7 +104,7 @@ describe("score correction exact-v7 identity", () => {
             event_type: "ScoreCorrected",
           }),
         ]);
-        expect(hasExactV7SchemaManifest(db)).toBe(true);
+        expect(hasExactV8SchemaManifest(db)).toBe(true);
       } finally {
         db.close();
       }
@@ -136,7 +136,7 @@ describe("score correction exact-v7 identity", () => {
           identity_version: 1,
           event_type: "ScoreRescoreRequested",
         }));
-        expect(hasExactV7SchemaManifest(resetDb)).toBe(true);
+        expect(hasExactV8SchemaManifest(resetDb)).toBe(true);
       } finally {
         resetDb.close();
       }

--- a/apps/api/test/support/reopen-exact-v8.ts
+++ b/apps/api/test/support/reopen-exact-v8.ts
@@ -2,7 +2,7 @@ import { openDatabase, openReadOnlyDatabase } from "../../src/db.js";
 
 const databasePath = process.argv[2];
 if (!databasePath) {
-  throw new Error("exact-v7 reopen probe requires a database path");
+  throw new Error("exact-v8 reopen probe requires a database path");
 }
 
 for (const open of [openDatabase, openReadOnlyDatabase]) {

--- a/apps/api/test/v7-schema.ts
+++ b/apps/api/test/v7-schema.ts
@@ -7,30 +7,33 @@ import Database from "better-sqlite3";
 
 import { SUPPORTED_SCHEMA_VERSION } from "../src/db.js";
 
-const schemaPath = fileURLToPath(
+const v7SchemaPath = fileURLToPath(
   new URL(
     "../../../workers/automation/src/jobctrl/infrastructure/migrations/schema_v7.sql",
     import.meta.url,
   ),
 );
+const v8SchemaPath = fileURLToPath(
+  new URL(
+    "../../../workers/automation/src/jobctrl/infrastructure/migrations/schema_v8.sql",
+    import.meta.url,
+  ),
+);
 
-// schema_v7.sql is pure DDL (110 tables, 108 indexes, 24 triggers, no seed rows
-// and no PRAGMAs), and the seeding hooks across this suite call it once per
-// test. Re-executing it every time made those hooks the slowest thing in CI and
-// pushed them past Vitest's hook deadline on loaded runners. Build it once per
-// worker process and copy the closed file instead: with no PRAGMAs the database
-// is a single self-contained file, so the copy is byte-identical to a fresh
-// build, `user_version` included.
+// The frozen v7 schema plus additive v8 DDL form the exact runtime schema. The
+// seeding hooks across this suite call this helper once per test, so build it
+// once per worker process and copy the closed single-file database instead.
 let templatePath: string | undefined;
 
 function schemaTemplate(): string {
   if (templatePath !== undefined) {
     return templatePath;
   }
-  const templateDir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-v7-schema-"));
-  const template = path.join(templateDir, "schema-v7.db");
+  const templateDir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-v8-schema-"));
+  const template = path.join(templateDir, "schema-v8.db");
   const db = new Database(template);
-  db.exec(fs.readFileSync(path.resolve(schemaPath), "utf8"));
+  db.exec(fs.readFileSync(path.resolve(v7SchemaPath), "utf8"));
+  db.exec(fs.readFileSync(path.resolve(v8SchemaPath), "utf8"));
   db.pragma(`user_version = ${SUPPORTED_SCHEMA_VERSION}`);
   db.close();
   process.on("exit", () => {

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -104,6 +104,12 @@ locking; selector resolution holds a shared selection lock through supervisor
 readiness. Before a candidate is promoted, the old process tree is quiesced
 with the registry's PID/PGID identity checks and both `JOBCTRL_DIR/jobctrl.db`
 and `JOBCTRL_DIR/temporal.db` receive online, hash-verified paired backups.
+The current runtime admits only exact schema v8. A stopped v6 database uses the
+existing Temporal quiescence proof and a private composite v6-to-v8 candidate;
+a stopped exact-v7 database uses the additive v7-to-v8 candidate; an exact-v8
+database needs no schema transition. Neither Python nor the TypeScript API runs
+against the intermediate schema, and recovery removes staged candidates before
+restoring the retained pair.
 Policy finalization happens only after the candidate has passed readiness and
 the paired backup is durable, so a failed health gate cannot revoke the only
 runnable release. A pre-finalization failure restores the full pair and

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -67,7 +67,7 @@ The remaining tables group by owner:
 | --- | --- |
 | Candidate Profile | `candidate_profiles` plus 12 `candidate_profile_*` child tables (experience, bullets, skills, education, achievement evidence, required-content sets, resume constraint metrics) |
 | Resume templates | `resume_templates`, `resume_template_versions`, `resume_template_defaults`, `resume_template_refresh_attempts`, `job_resume_template_assignments` |
-| Compensation | `job_posted_compensation_facts`, `job_market_compensation_estimates` |
+| Compensation | `job_posted_compensation_facts`, per-job `job_market_compensation_estimates`, versioned `compensation_role_families` and mappings, immutable direct/price-level/extrapolated benchmark facts, relational extrapolation inputs, and `compensation_market_refresh_state` |
 | Scoring | `job_scores`, versioned/indexed `job_score_keywords`, `scoring_policies`, `job_score_staleness` |
 | Read-model projections | `job_list_projections`, `job_detail_projections`, `dashboard_projections`, `apply_run_projections`, `workflow_run_projections`, `pipeline_step_projections`, `artifact_list_projections`, `event_watermarks`, `digest_state` |
 | Discovery & preparation | `discovery_runs`, `discovery_execution_jobs`, `discovery_search_units`, `discovery_search_unit_jobs`, `discovery_search_unit_filtered_events`, `discovery_settings`, `discovery_feedback`, `discovery_quarantine_entries`, `job_canonical_identities`, `job_source_observations`, `job_duplicate_links`, legacy `preparation_work_items`, `manual_capture_queue`, `posting_snapshot_sets`, `source_registry_entries`, `source_locator_candidates` |
@@ -87,24 +87,36 @@ licensed-feed coverage policy. Public Levels.fyi Markdown needs no credential.
 Credentials, feed paths/URLs, feed contents, and provider payloads do not belong
 in the settings file.
 
-### Exact v7 identity cutover
+### Exact v8 runtime and compatible cutovers
 
-Schema v7 is an exact runtime contract. The native lifecycle upgrades an
-admitted v6 installation only while the application is stopped: it quiesces
-the local runtime, creates a paired backup of `jobctrl.db` and Temporal state,
-builds an isolated candidate, and runs the v6-to-v7 rewrite in one SQLite
-transaction. URL-rooted job rows and foreign references are mapped to stable
-tenant-scoped JobIds; immutable historical events are upcast only as part of
-that migration.
+Schema v8 is the exact runtime contract. The native lifecycle upgrades admitted
+v6 and exact-v7 installations only while the application is stopped. It creates
+a paired backup of `jobctrl.db` and Temporal state before building an isolated
+candidate. A v6 source first runs the existing identity rewrite into an
+owner-private exact-v7 intermediate and then applies v8; the intermediate is
+deleted and never becomes live. An exact-v7 source receives only the additive
+v8 schema. The v6 path retains the Temporal quiescence proof required before
+URL-rooted job rows and foreign references are mapped to stable tenant-scoped
+JobIds.
 
-Activation happens only after schema, row/reference, projection, and paired
-state verification succeeds. The verified candidate replaces the live pair
-atomically. Any failed build, verification, or activation restores the paired
-backup and leaves the previous version runnable. There is no mixed-version
-runtime, rolling deployment, dual-write path, or permanent compatibility
-layer: the TypeScript API and Python worker accept exact v7 and reject direct
-v6 operation. Runtime projections read registered persisted artifacts only and
-do not reconstruct legacy URL-shaped fallback rows.
+Activation happens only after exact-manifest, row/reference, foreign-key,
+integrity, source-preservation, file-permission, digest, and paired-state
+verification succeeds. The verified v8 candidate replaces the live database
+atomically. Any failed build, verification, activation, or readiness check
+restores the paired backup and leaves the previous version runnable. There is
+no mixed-version runtime, rolling deployment, dual-write path, or permanent
+compatibility layer: the TypeScript API and Python worker accept exact v8 and
+reject direct v6/v7 operation. Runtime projections read registered persisted
+artifacts only and do not reconstruct legacy URL-shaped fallback rows.
+
+V8 adds a versioned JobCtrl role-family taxonomy plus physically separate
+authorities for directly observed market benchmarks, price-level inputs, and
+geographically extrapolated benchmarks. Direct and extrapolated records cannot
+be confused by a nullable discriminator. Their evidence rows and input links
+are append-only, content-addressed, source-dated, and protected against update,
+delete, `INSERT OR REPLACE`, and conflicting UPSERT paths. The existing
+`job_market_compensation_estimates` table remains the per-job materialized
+output; it is not the reusable benchmark authority.
 
 ### Repeat-application authority retained in v7
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2214,3 +2214,13 @@ Cites:
 `docs/plans/2026-07-29-stable-job-identity-workflow-feedback-learning.md`;
 `docs/architecture/domain-model/tactical.md`;
 `docs/user/outcomes-and-feedback.md`.
+
+Amended (2026-08-11): exact schema v8 is now the sole runtime contract. The
+native stopped-runtime lifecycle accepts retained v6 and exact-v7 sources: v6
+is transformed through a private, never-installed exact-v7 intermediate before
+the additive v8 schema is applied, while v7 receives only that additive step.
+Both routes preserve the paired-backup, atomic activation, rollback, and
+no-mixed-runtime invariants above. V8 adds versioned role-family taxonomy and
+physically separate append-only authorities for direct benchmarks, price-level
+inputs, and geographic extrapolations; per-job market estimates remain derived
+materialized output rather than benchmark authority.

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -21,6 +21,7 @@ final PR, then run product QA on the cumulative stack.
 | Public demo browser workspace | `corepack pnpm --filter @jobctrl/web e2e:demo-workspace` |
 | Public demo edge | `corepack pnpm demo-edge:check`, `corepack pnpm demo-edge:test`, and `corepack pnpm demo-edge:dry-run` |
 | Python worker | `uv --project workers/automation run --extra dev ruff check .` and `uv --project workers/automation run --extra dev pytest -q` |
+| SQLite schema or native migration | Focused Python schema/candidate tests, `corepack pnpm api:check`, `corepack pnpm api:test`, `corepack pnpm launcher:check`, and `corepack pnpm launcher:test` |
 | Any patch | `git diff --check` |
 
 Start the attached full stack with `corepack pnpm dev` when the path needs the

--- a/launcher/internal/launcher/homebrew_bootstrap_test.go
+++ b/launcher/internal/launcher/homebrew_bootstrap_test.go
@@ -546,7 +546,7 @@ func preseedUnsignedHomebrewRelease(t *testing.T, home string, fixture homebrewB
 func seedHomebrewSQLitePair(t *testing.T, python, state string) {
 	t.Helper()
 	for _, name := range []string{"jobctrl.db", "temporal.db"} {
-		code := "import pathlib,sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute('create table t(v)'); c.execute('insert into t values (1)'); c.execute('PRAGMA user_version=7') if pathlib.Path(sys.argv[1]).name == 'jobctrl.db' else None; c.commit()"
+		code := "import pathlib,sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute('create table t(v)'); c.execute('insert into t values (1)'); c.execute('PRAGMA user_version=8') if pathlib.Path(sys.argv[1]).name == 'jobctrl.db' else None; c.commit()"
 		if output, err := exec.Command(python, "-c", code, filepath.Join(state, name)).CombinedOutput(); err != nil {
 			t.Fatalf("seed %s: %v %s", name, err, output)
 		}

--- a/launcher/internal/launcher/lifecycle.go
+++ b/launcher/internal/launcher/lifecycle.go
@@ -1120,16 +1120,18 @@ func promoteExisting(ctx launchContext, store *release.Store, active release.Act
 	switch databaseVersion {
 	case legacyJobCtrlSchemaVersion:
 		if err := temporalQuiescenceProof(activeRuntime, candidateRuntime); err != nil {
-			return restartBeforeBackup(fmt.Errorf("v6-to-v7 upgrade blocked before backup: %w", err))
+			return restartBeforeBackup(fmt.Errorf("v6-to-v8 upgrade blocked before backup: %w", err))
 		}
 	case exactJobCtrlSchemaVersion:
-		// Ordinary exact-v7 release promotion uses the existing paired lifecycle.
+		// Exact v7 upgrades add v8 only after the stopped-runtime paired backup.
+	case currentJobCtrlSchemaVersion:
+		// Ordinary exact-v8 release promotion uses the paired lifecycle unchanged.
 	default:
 		return restartBeforeBackup(fmt.Errorf("unsupported stopped JobCtrl schema version %d", databaseVersion))
 	}
 	pair, err := snapshotPair(ctx, active.Receipt)
 	if err != nil {
-		if databaseVersion == legacyJobCtrlSchemaVersion {
+		if databaseVersion != currentJobCtrlSchemaVersion {
 			return restartBeforeBackup(fmt.Errorf("create paired pre-upgrade backup: %w", err))
 		}
 		_ = store.Advance(&journal, release.Failed, err)
@@ -1169,16 +1171,16 @@ func promoteExisting(ctx launchContext, store *release.Store, active release.Act
 		_ = store.Advance(&journal, release.RolledBack, cause)
 		return cause
 	}
-	if databaseVersion == legacyJobCtrlSchemaVersion {
+	if databaseVersion != currentJobCtrlSchemaVersion {
 		candidatePath, err := sealedV7CandidateBuilder(candidateRuntime, pair, journal.ID)
 		if err != nil {
-			return rollbackFailure(fmt.Errorf("build exact-v7 migration candidate: %w", err))
+			return rollbackFailure(fmt.Errorf("build exact-v8 migration candidate: %w", err))
 		}
 		if err := advance(store, &journal, release.MigrationCandidateReady); err != nil {
 			return rollbackFailure(err)
 		}
 		if err := sealedV7CandidateInstaller(candidateRuntime, candidatePath); err != nil {
-			return rollbackFailure(fmt.Errorf("activate exact-v7 database: %w", err))
+			return rollbackFailure(fmt.Errorf("activate exact-v8 database: %w", err))
 		}
 		if err := advance(store, &journal, release.MigrationActivated); err != nil {
 			return rollbackFailure(err)

--- a/launcher/internal/launcher/lifecycle_test.go
+++ b/launcher/internal/launcher/lifecycle_test.go
@@ -927,7 +927,7 @@ func installLifecycleRelease(t *testing.T, runtime, build string, sequence uint6
 func seedLifecycleSQLitePair(t *testing.T, python, state, marker string) {
 	t.Helper()
 	for _, name := range []string{"jobctrl.db", "temporal.db"} {
-		code := "import pathlib,sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute('create table t(v)'); c.execute('insert into t values (?)',(sys.argv[2],)); c.execute('PRAGMA user_version=7') if pathlib.Path(sys.argv[1]).name == 'jobctrl.db' else None; c.commit()"
+		code := "import pathlib,sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute('create table t(v)'); c.execute('insert into t values (?)',(sys.argv[2],)); c.execute('PRAGMA user_version=8') if pathlib.Path(sys.argv[1]).name == 'jobctrl.db' else None; c.commit()"
 		if output, err := exec.Command(python, "-c", code, filepath.Join(state, name), marker+name).CombinedOutput(); err != nil {
 			t.Fatalf("seed %s: %v %s", name, err, output)
 		}

--- a/launcher/internal/launcher/v6_migration.go
+++ b/launcher/internal/launcher/v6_migration.go
@@ -1,9 +1,9 @@
 package launcher
 
-// Native activation glue for the one supported local schema transition. The
-// Python payload owns candidate population and exact-v7 verification; this
-// launcher boundary owns process quiescence, paired backup binding, atomic
-// installation, and recovery.
+// Native activation glue for local schema transitions. The Python payload owns
+// candidate population and exact-schema verification; this launcher boundary
+// owns process quiescence, paired backup binding, atomic installation, and
+// recovery.
 
 import (
 	"bytes"
@@ -23,14 +23,17 @@ import (
 )
 
 const (
-	legacyJobCtrlSchemaVersion = int64(6)
-	exactJobCtrlSchemaVersion  = int64(7)
+	legacyJobCtrlSchemaVersion  = int64(6)
+	exactJobCtrlSchemaVersion   = int64(7)
+	currentJobCtrlSchemaVersion = int64(8)
 )
 
 var (
-	temporalQuiescenceProof    = proveStoppedTemporalQuiescence
-	sealedV7CandidateBuilder   = buildSealedV7Candidate
-	sealedV7CandidateInstaller = installSealedV7Candidate
+	temporalQuiescenceProof = proveStoppedTemporalQuiescence
+	// These seam names are retained for the existing lifecycle fault-injection
+	// matrix. Production builds and installs the current exact-v8 candidate.
+	sealedV7CandidateBuilder   = buildSealedV8Candidate
+	sealedV7CandidateInstaller = installSealedV8Candidate
 )
 
 type temporalQuiescenceReceipt struct {
@@ -390,7 +393,7 @@ func pairedDatabasePath(stateDir string, pair databasePair, name string, version
 		}
 	}
 	if !found {
-		return "", errors.New("paired backup does not contain the required v6 database")
+		return "", errors.New("paired backup does not contain the required database version")
 	}
 	path := filepath.Join(stateDir, "backups", pair.ID, name)
 	actual, err := describeDatabase(path, name, version)
@@ -434,10 +437,14 @@ func v7CandidatePath(stateDir, journalID string) string {
 }
 
 func cleanupV7Candidate(stateDir, journalID string) {
-	path := v7CandidatePath(stateDir, journalID)
-	_ = os.Remove(path)
-	for _, suffix := range []string{"-journal", "-shm", "-wal"} {
-		_ = os.Remove(path + suffix)
+	for _, path := range []string{
+		v7CandidatePath(stateDir, journalID),
+		v8CandidatePath(stateDir, journalID),
+	} {
+		_ = os.Remove(path)
+		for _, suffix := range []string{"-journal", "-shm", "-wal"} {
+			_ = os.Remove(path + suffix)
+		}
 	}
 }
 

--- a/launcher/internal/launcher/v6_migration_test.go
+++ b/launcher/internal/launcher/v6_migration_test.go
@@ -86,7 +86,7 @@ func migrationIntegrationPython(t *testing.T) string {
 			t.Skip("python3 unavailable for the native migration integration test")
 		}
 	}
-	probe := exec.Command(python, "-I", "-B", "-c", "import jobctrl.infrastructure.migrations.v6_to_v7_execute")
+	probe := exec.Command(python, "-I", "-B", "-c", "import jobctrl.infrastructure.migrations.v6_to_v8_execute")
 	if output, err := probe.CombinedOutput(); err != nil {
 		if os.Getenv("CI") != "" || os.Getenv("JOBCTRL_MIGRATION_TEST_PYTHON") != "" {
 			t.Fatalf("native migration integration Python is not provisioned: %v %s", err, output)
@@ -112,12 +112,12 @@ create_shipped_v6_database(pathlib.Path(sys.argv[2]))`
 	}
 }
 
-func reopenMigratedV7WithCandidateRuntime(ctx launchContext, database string) error {
+func reopenMigratedV8WithCandidateRuntime(ctx launchContext, database string) error {
 	python := filepath.Join(ctx.PayloadRoot, "python", "bin", "python3")
 	code := `import sys
-from jobctrl.database import close_connection, open_exact_v7_database
+from jobctrl.database import close_connection, open_exact_v8_database
 path=sys.argv[1]
-connection=open_exact_v7_database(path)
+connection=open_exact_v8_database(path)
 try:
     row=connection.execute("SELECT job_id,url FROM jobs").fetchone()
     if row is None or not row[0] or row[0] == row[1] or row[1] != "https://jobs.example/shipped-v6":
@@ -127,25 +127,29 @@ finally:
 	command := exec.Command(python, "-I", "-B", "-c", code, database)
 	command.Env = ctx.Environment
 	if output, err := command.CombinedOutput(); err != nil {
-		return fmt.Errorf("candidate runtime failed to reopen exact v7: %w: %s", err, output)
+		return fmt.Errorf("candidate runtime failed to reopen exact v8: %w: %s", err, output)
 	}
 	return nil
 }
 
-func reopenMigratedV7WithTypeScriptAPI(database string) error {
+func reopenMigratedV8WithTypeScriptAPI(database string) error {
 	apiRoot, err := filepath.Abs(filepath.Join("..", "..", "..", "apps", "api"))
 	if err != nil {
 		return err
 	}
-	runner, err := exec.LookPath("node")
-	if err != nil {
-		return fmt.Errorf("locate Node.js for TypeScript API reopen probe: %w", err)
+	runner := os.Getenv("JOBCTRL_MIGRATION_TEST_NODE")
+	if runner == "" {
+		var err error
+		runner, err = exec.LookPath("node")
+		if err != nil {
+			return fmt.Errorf("locate Node.js for TypeScript API reopen probe: %w", err)
+		}
 	}
-	probe := filepath.Join(apiRoot, "test", "support", "reopen-exact-v7.ts")
+	probe := filepath.Join(apiRoot, "test", "support", "reopen-exact-v8.ts")
 	command := exec.Command(runner, "--import", "tsx", probe, database)
 	command.Dir = apiRoot
 	if output, err := command.CombinedOutput(); err != nil {
-		return fmt.Errorf("TypeScript API failed to reopen exact v7: %w: %s", err, output)
+		return fmt.Errorf("TypeScript API failed to reopen exact v8: %w: %s", err, output)
 	}
 	return nil
 }
@@ -206,21 +210,21 @@ func postStampFailureCandidateBuilder() func(launchContext, databasePair, string
 		if err != nil {
 			return "", err
 		}
-		path := v7CandidatePath(candidate.Instance.StateDir, journalID)
+		path := v8CandidatePath(candidate.Instance.StateDir, journalID)
 		python := filepath.Join(candidate.PayloadRoot, "python", "bin", "python3")
 		code := `import sys
-from jobctrl.infrastructure.migrations.v6_to_v7_execute import CandidateExecutionError, execute_v6_to_v7_candidate
+from jobctrl.infrastructure.migrations.v6_to_v8_execute import CandidateExecutionError, execute_v6_to_v8_candidate
 reached_after_stamp = False
 def fail_after_stamp():
     global reached_after_stamp
     reached_after_stamp = True
     raise RuntimeError("synthetic post-stamp verification failure")
 try:
-    execute_v6_to_v7_candidate(
+    execute_v6_to_v8_candidate(
         sys.argv[1],
         sys.argv[2],
         migration_at="2026-07-31T14:00:00+00:00",
-        _after_stamp=fail_after_stamp,
+        _after_v8_stamp=fail_after_stamp,
     )
 except CandidateExecutionError:
     if reached_after_stamp:
@@ -232,10 +236,10 @@ raise SystemExit(2)`
 		command.Dir = candidate.Instance.StateDir
 		output, runErr := command.CombinedOutput()
 		if runErr == nil || string(output) != "post_stamp_failure\n" {
-			cleanupV7Candidate(candidate.Instance.StateDir, journalID)
+			cleanupV8Candidate(candidate.Instance.StateDir, journalID)
 			return "", errors.New("post-stamp verification failure did not reach the verifier seam")
 		}
-		cleanupV7Candidate(candidate.Instance.StateDir, journalID)
+		cleanupV8Candidate(candidate.Instance.StateDir, journalID)
 		return "", errors.New("synthetic post-stamp verification failure")
 	}
 }
@@ -371,7 +375,7 @@ func TestV6ToV7ActivationMigratesAndExplicitRollbackReopensV6Pair(t *testing.T) 
 	}
 }
 
-func TestV6ToV7NativePrivateExecutorMigratesAndRollsBackRealSchema(t *testing.T) {
+func TestV6ToV8NativePrivateExecutorMigratesAndRollsBackRealSchema(t *testing.T) {
 	preserveMigrationSeams(t)
 	python := migrationIntegrationPython(t)
 	fixture := newV6ActivationFixtureWithPython(t, python)
@@ -380,7 +384,7 @@ func TestV6ToV7NativePrivateExecutorMigratesAndRollsBackRealSchema(t *testing.T)
 		t.Fatal(err)
 	}
 	createShippedV6Fixture(t, python, database)
-	next := installLifecycleRelease(t, fixture.runtime, "local-v7-next-build-0003", 3, python)
+	next := installLifecycleRelease(t, fixture.runtime, "local-v8-next-build-0003", 3, python)
 
 	// Temporal quiescence has its own real gated-process regression below. This
 	// test keeps that network boundary closed while crossing the production Go
@@ -390,9 +394,9 @@ func TestV6ToV7NativePrivateExecutorMigratesAndRollsBackRealSchema(t *testing.T)
 	migrationBuilds := 0
 	sealedV7CandidateBuilder = func(candidate launchContext, pair databasePair, journalID string) (string, error) {
 		migrationBuilds++
-		return buildSealedV7Candidate(candidate, pair, journalID)
+		return buildSealedV8Candidate(candidate, pair, journalID)
 	}
-	sealedV7CandidateInstaller = installSealedV7Candidate
+	sealedV7CandidateInstaller = installSealedV8Candidate
 	candidateStarts, oldStarts := 0, 0
 	startReleaseCommand = func(base launchContext, receipt release.Receipt, journalID string) error {
 		if journalID == "" {
@@ -406,10 +410,10 @@ func TestV6ToV7NativePrivateExecutorMigratesAndRollsBackRealSchema(t *testing.T)
 		switch receipt.BuildID {
 		case fixture.candidate.BuildID, next.BuildID:
 			candidateStarts++
-			if err := reopenMigratedV7WithCandidateRuntime(runtimeContext, database); err != nil {
+			if err := reopenMigratedV8WithCandidateRuntime(runtimeContext, database); err != nil {
 				return err
 			}
-			return reopenMigratedV7WithTypeScriptAPI(database)
+			return reopenMigratedV8WithTypeScriptAPI(database)
 		case fixture.old.BuildID:
 			oldStarts++
 			return reopenRestoredV6WithPriorRuntime(runtimeContext, database)
@@ -420,11 +424,11 @@ func TestV6ToV7NativePrivateExecutorMigratesAndRollsBackRealSchema(t *testing.T)
 
 	var output bytes.Buffer
 	if err := promoteExisting(fixture.ctx, fixture.store, fixture.active, fixture.candidate.BuildID, "update", &output); err != nil {
-		t.Fatalf("native v6-to-v7 activation: %v", err)
+		t.Fatalf("native v6-to-v8 activation: %v", err)
 	}
 	active, err := fixture.store.ReadActive()
 	if err != nil || active.Receipt != fixture.candidate || candidateStarts != 1 || oldStarts != 0 || migrationBuilds != 1 {
-		t.Fatalf("native v7 activation = active:%#v candidate starts:%d old starts:%d migration builds:%d err:%v", active, candidateStarts, oldStarts, migrationBuilds, err)
+		t.Fatalf("native v8 activation = active:%#v candidate starts:%d old starts:%d migration builds:%d err:%v", active, candidateStarts, oldStarts, migrationBuilds, err)
 	}
 	pair, err := retainedPairForReceipt(fixture.state, fixture.old)
 	if err != nil {
@@ -446,11 +450,11 @@ func TestV6ToV7NativePrivateExecutorMigratesAndRollsBackRealSchema(t *testing.T)
 		t.Fatalf("paired backup did not preserve the shipped v6 source: %v", err)
 	}
 	if err := promoteExisting(fixture.ctx, fixture.store, active, next.BuildID, "update", &output); err != nil {
-		t.Fatalf("native exact-v7 promotion: %v", err)
+		t.Fatalf("native exact-v8 promotion: %v", err)
 	}
 	active, err = fixture.store.ReadActive()
 	if err != nil || active.Receipt != next || candidateStarts != 2 || oldStarts != 0 || migrationBuilds != 1 {
-		t.Fatalf("native exact-v7 promotion = active:%#v candidate starts:%d old starts:%d migration builds:%d err:%v", active, candidateStarts, oldStarts, migrationBuilds, err)
+		t.Fatalf("native exact-v8 promotion = active:%#v candidate starts:%d old starts:%d migration builds:%d err:%v", active, candidateStarts, oldStarts, migrationBuilds, err)
 	}
 
 	if err := rollbackExisting(fixture.ctx, fixture.store, active, fixture.old.BuildID, &output); err != nil {
@@ -465,7 +469,7 @@ func TestV6ToV7NativePrivateExecutorMigratesAndRollsBackRealSchema(t *testing.T)
 	}
 }
 
-func TestV6ToV7NativeVerificationFailureRestoresAndReopensV6(t *testing.T) {
+func TestV6ToV8NativeVerificationFailureRestoresAndReopensV6(t *testing.T) {
 	preserveMigrationSeams(t)
 	python := migrationIntegrationPython(t)
 	fixture := newV6ActivationFixtureWithPython(t, python)
@@ -477,7 +481,7 @@ func TestV6ToV7NativeVerificationFailureRestoresAndReopensV6(t *testing.T) {
 
 	temporalQuiescenceProof = func(_, _ launchContext) error { return nil }
 	sealedV7CandidateBuilder = postStampFailureCandidateBuilder()
-	sealedV7CandidateInstaller = installSealedV7Candidate
+	sealedV7CandidateInstaller = installSealedV8Candidate
 	candidateStarts, oldStarts := 0, 0
 	startReleaseCommand = func(base launchContext, receipt release.Receipt, journalID string) error {
 		if journalID == "" {
@@ -494,10 +498,10 @@ func TestV6ToV7NativeVerificationFailureRestoresAndReopensV6(t *testing.T) {
 			return reopenRestoredV6WithPriorRuntime(runtimeContext, database)
 		case fixture.candidate.BuildID:
 			candidateStarts++
-			if err := reopenMigratedV7WithCandidateRuntime(runtimeContext, database); err != nil {
+			if err := reopenMigratedV8WithCandidateRuntime(runtimeContext, database); err != nil {
 				return err
 			}
-			return reopenMigratedV7WithTypeScriptAPI(database)
+			return reopenMigratedV8WithTypeScriptAPI(database)
 		default:
 			return fmt.Errorf("unexpected release start %s", receipt.BuildID)
 		}
@@ -527,7 +531,7 @@ func TestV6ToV7NativeVerificationFailureRestoresAndReopensV6(t *testing.T) {
 		t.Fatalf("post-stamp rollback did not restore exact v6 bytes: backup=%s restored=%s err=%v", backupDigest, restoredDigest, err)
 	}
 
-	sealedV7CandidateBuilder = buildSealedV7Candidate
+	sealedV7CandidateBuilder = buildSealedV8Candidate
 	if err := promoteExisting(fixture.ctx, fixture.store, active, fixture.candidate.BuildID, "update", &output); err != nil {
 		t.Fatalf("native retry after post-stamp failure: %v", err)
 	}

--- a/launcher/internal/launcher/v8_migration.go
+++ b/launcher/internal/launcher/v8_migration.go
@@ -1,0 +1,150 @@
+package launcher
+
+// Native binding for exact-v8 candidates. Existing v6 installations use the
+// Python composite v6-to-v8 executor; exact-v7 installations use the additive
+// v7-to-v8 executor. Both paths produce the same bounded receipt and candidate
+// contract before this launcher performs the atomic install.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+type sealedV8CandidateReceipt struct {
+	CandidateDataDigest string `json:"candidate_data_digest"`
+	CandidateSHA256     string `json:"candidate_sha256"`
+	JobCount            int    `json:"job_count"`
+	SchemaVersion       int    `json:"schema_version"`
+	SourceDataDigest    string `json:"source_data_digest"`
+	Status              string `json:"status"`
+	TableCount          int    `json:"table_count"`
+	UserVersion         int64  `json:"user_version"`
+}
+
+func buildSealedV8Candidate(candidate launchContext, pair databasePair, journalID string) (string, error) {
+	sourceVersion, err := pairedJobCtrlSchemaVersion(pair)
+	if err != nil {
+		return "", err
+	}
+	source, err := pairedDatabasePath(candidate.Instance.StateDir, pair, "jobctrl.db", sourceVersion)
+	if err != nil {
+		return "", err
+	}
+	path := v8CandidatePath(candidate.Instance.StateDir, journalID)
+	if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+		return "", errors.New("v8 migration candidate path already exists")
+	}
+	python := filepath.Join(candidate.PayloadRoot, "python", "bin", "python3")
+	module := ""
+	arguments := []string{"-I", "-B", "-m"}
+	switch sourceVersion {
+	case legacyJobCtrlSchemaVersion:
+		module = "jobctrl.infrastructure.migrations.v6_to_v8_execute"
+	case exactJobCtrlSchemaVersion:
+		module = "jobctrl.infrastructure.migrations.v7_to_v8_execute"
+	default:
+		return "", errors.New("unsupported source schema for exact-v8 migration")
+	}
+	arguments = append(arguments, module, "--source", source, "--candidate", path)
+	if sourceVersion == legacyJobCtrlSchemaVersion {
+		arguments = append(arguments, "--migration-at", time.Now().UTC().Format(time.RFC3339Nano))
+	}
+	command := exec.Command(python, arguments...)
+	command.Env = candidate.Environment
+	command.Dir = candidate.Instance.StateDir
+	output, err := command.Output()
+	if err != nil || len(output) > 4096 {
+		cleanupV8Candidate(candidate.Instance.StateDir, journalID)
+		return "", errors.New("sealed exact-v8 candidate execution failed")
+	}
+	var receipt sealedV8CandidateReceipt
+	if err := decodeSingleJSON(output, &receipt); err != nil ||
+		receipt.SchemaVersion != 1 || receipt.Status != "ready" ||
+		receipt.UserVersion != currentJobCtrlSchemaVersion || receipt.JobCount < 0 || receipt.TableCount < 1 ||
+		!validSHA256(receipt.SourceDataDigest) || !validSHA256(receipt.CandidateDataDigest) ||
+		receipt.SourceDataDigest != receipt.CandidateDataDigest || !validSHA256(receipt.CandidateSHA256) {
+		cleanupV8Candidate(candidate.Instance.StateDir, journalID)
+		return "", errors.New("sealed exact-v8 candidate receipt is invalid")
+	}
+	info, statErr := os.Lstat(path)
+	if statErr != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {
+		cleanupV8Candidate(candidate.Instance.StateDir, journalID)
+		return "", errors.New("sealed v8 candidate is not an owner-private regular file")
+	}
+	digest, digestErr := sha256Path(path)
+	if digestErr != nil || digest != receipt.CandidateSHA256 {
+		cleanupV8Candidate(candidate.Instance.StateDir, journalID)
+		return "", errors.New("sealed v8 candidate digest verification failed")
+	}
+	version, versionErr := sqliteUserVersion(python, path)
+	if versionErr != nil || version != currentJobCtrlSchemaVersion {
+		cleanupV8Candidate(candidate.Instance.StateDir, journalID)
+		return "", errors.New("sealed v8 candidate schema verification failed")
+	}
+	return path, nil
+}
+
+func pairedJobCtrlSchemaVersion(pair databasePair) (int64, error) {
+	if pair.SchemaVersion != 1 || pair.ID == "" || len(pair.Files) != 2 {
+		return 0, errors.New("migration requires a complete paired backup")
+	}
+	for _, file := range pair.Files {
+		if file.Name != "jobctrl.db" {
+			continue
+		}
+		switch file.SQLiteUserVer {
+		case legacyJobCtrlSchemaVersion, exactJobCtrlSchemaVersion:
+			return file.SQLiteUserVer, nil
+		default:
+			return 0, errors.New("paired backup has an unsupported JobCtrl schema version")
+		}
+	}
+	return 0, errors.New("paired backup does not contain jobctrl.db")
+}
+
+func installSealedV8Candidate(candidate launchContext, candidatePath string) error {
+	info, err := os.Lstat(candidatePath)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {
+		return errors.New("v8 activation candidate is not an owner-private regular file")
+	}
+	live := filepath.Join(candidate.Instance.StateDir, "jobctrl.db")
+	liveInfo, err := os.Lstat(live)
+	if err != nil || !liveInfo.Mode().IsRegular() || liveInfo.Mode()&os.ModeSymlink != 0 {
+		return errors.New("live database is not a regular file")
+	}
+	if err := os.Rename(candidatePath, live); err != nil {
+		return errors.New("atomically install exact-v8 database")
+	}
+	if err := cleanupSQLiteSidecars(candidate.Instance.StateDir, "jobctrl.db"); err != nil {
+		return err
+	}
+	python := filepath.Join(candidate.PayloadRoot, "python", "bin", "python3")
+	if version, err := sqliteUserVersion(python, live); err != nil || version != currentJobCtrlSchemaVersion {
+		return errors.New("installed v8 database did not reopen at the exact schema version")
+	}
+	return nil
+}
+
+func v8CandidatePath(stateDir, journalID string) string {
+	digest := sha256.Sum256([]byte(journalID))
+	return filepath.Join(stateDir, ".jobctrl-v8-candidate-"+hex.EncodeToString(digest[:])[:24]+".db")
+}
+
+func v6ToV8IntermediatePath(candidatePath string) string {
+	return candidatePath + ".exact-v7-intermediate"
+}
+
+func cleanupV8Candidate(stateDir, journalID string) {
+	candidate := v8CandidatePath(stateDir, journalID)
+	for _, path := range []string{candidate, v6ToV8IntermediatePath(candidate)} {
+		_ = os.Remove(path)
+		for _, suffix := range []string{"-journal", "-shm", "-wal"} {
+			_ = os.Remove(path + suffix)
+		}
+	}
+}

--- a/launcher/internal/launcher/v8_migration_test.go
+++ b/launcher/internal/launcher/v8_migration_test.go
@@ -1,0 +1,266 @@
+package launcher
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ebarti/jobctrl/launcher/internal/release"
+)
+
+func fakeV8BuilderContext(t *testing.T, sourceVersion int64) (launchContext, databasePair, string, string) {
+	t.Helper()
+	state, payload := t.TempDir(), t.TempDir()
+	pairID := "pair-v8-builder"
+	pairDir := filepath.Join(state, "backups", pairID)
+	if err := os.MkdirAll(pairDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	jobPath := filepath.Join(pairDir, "jobctrl.db")
+	temporalPath := filepath.Join(pairDir, "temporal.db")
+	if err := os.WriteFile(jobPath, []byte("sealed source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(temporalPath, []byte("temporal source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	jobFile, err := describeDatabase(jobPath, "jobctrl.db", sourceVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	temporalFile, err := describeDatabase(temporalPath, "temporal.db", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pair := databasePair{SchemaVersion: 1, ID: pairID, Files: []databaseFile{jobFile, temporalFile}}
+
+	python := filepath.Join(payload, "python", "bin", "python3")
+	if err := os.MkdirAll(filepath.Dir(python), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	script := `#!/bin/sh
+set -eu
+if [ "$3" = "-m" ]; then
+  [ "$4" = "$JOBCTRL_TEST_EXPECTED_MODULE" ] || exit 41
+  printf '%s\n' "$@" > "$JOBCTRL_TEST_ARGUMENTS"
+  candidate=""
+  previous=""
+  for argument in "$@"; do
+    if [ "$previous" = "--candidate" ]; then candidate="$argument"; fi
+    previous="$argument"
+  done
+  [ -n "$candidate" ] || exit 42
+  umask 077
+  if [ "${JOBCTRL_TEST_CRASH_AFTER_INTERMEDIATE:-}" = "1" ]; then
+    printf '%s' 'private exact-v7 intermediate' > "${candidate}.exact-v7-intermediate"
+    kill -9 $$
+  fi
+  printf '%s' "$JOBCTRL_TEST_CANDIDATE" > "$candidate"
+  printf '%s\n' "$JOBCTRL_TEST_RECEIPT"
+  exit 0
+fi
+if [ "$3" = "-c" ]; then
+  printf '8\n'
+  exit 0
+fi
+exit 43
+`
+	if err := os.WriteFile(python, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	candidateBytes := "sealed exact-v8 candidate"
+	digest := sha256.Sum256([]byte(candidateBytes))
+	receipt, err := json.Marshal(sealedV8CandidateReceipt{
+		CandidateDataDigest: strings.Repeat("a", 64),
+		CandidateSHA256:     hex.EncodeToString(digest[:]),
+		JobCount:            1,
+		SchemaVersion:       1,
+		SourceDataDigest:    strings.Repeat("a", 64),
+		Status:              "ready",
+		TableCount:          117,
+		UserVersion:         currentJobCtrlSchemaVersion,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	module := "jobctrl.infrastructure.migrations.v7_to_v8_execute"
+	if sourceVersion == legacyJobCtrlSchemaVersion {
+		module = "jobctrl.infrastructure.migrations.v6_to_v8_execute"
+	}
+	argumentsPath := filepath.Join(state, "migration-arguments.txt")
+	ctx := launchContext{
+		PayloadRoot: payload,
+		Instance:    instance{StateDir: state},
+		Environment: []string{
+			"JOBCTRL_TEST_EXPECTED_MODULE=" + module,
+			"JOBCTRL_TEST_ARGUMENTS=" + argumentsPath,
+			"JOBCTRL_TEST_CANDIDATE=" + candidateBytes,
+			"JOBCTRL_TEST_RECEIPT=" + string(receipt),
+		},
+	}
+	return ctx, pair, "journal-v8-builder", argumentsPath
+}
+
+func TestBuildSealedV8CandidateDispatchesByPairedSourceVersion(t *testing.T) {
+	for _, sourceVersion := range []int64{legacyJobCtrlSchemaVersion, exactJobCtrlSchemaVersion} {
+		t.Run("source-v"+strconv.FormatInt(sourceVersion, 10), func(t *testing.T) {
+			ctx, pair, journalID, argumentsPath := fakeV8BuilderContext(t, sourceVersion)
+
+			candidate, err := buildSealedV8Candidate(ctx, pair, journalID)
+			if err != nil {
+				t.Fatalf("build exact-v8 candidate: %v", err)
+			}
+			if candidate != v8CandidatePath(ctx.Instance.StateDir, journalID) {
+				t.Fatalf("candidate path = %q", candidate)
+			}
+			arguments, err := os.ReadFile(argumentsPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			module := "jobctrl.infrastructure.migrations.v7_to_v8_execute"
+			if sourceVersion == legacyJobCtrlSchemaVersion {
+				module = "jobctrl.infrastructure.migrations.v6_to_v8_execute"
+			}
+			if !strings.Contains(string(arguments), module) {
+				t.Fatalf("migration module was not dispatched from v%d: %s", sourceVersion, arguments)
+			}
+			hasMigrationAt := strings.Contains(string(arguments), "--migration-at")
+			if hasMigrationAt != (sourceVersion == legacyJobCtrlSchemaVersion) {
+				t.Fatalf("migration-at presence from v%d = %v", sourceVersion, hasMigrationAt)
+			}
+			info, err := os.Stat(candidate)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.Mode().Perm()&0o077 != 0 {
+				t.Fatalf("candidate permissions = %#o", info.Mode().Perm())
+			}
+		})
+	}
+}
+
+func TestBuildSealedV8CandidateRejectsUnboundedReceiptAndCleansFile(t *testing.T) {
+	ctx, pair, journalID, _ := fakeV8BuilderContext(t, exactJobCtrlSchemaVersion)
+	for index, pair := range ctx.Environment {
+		if strings.HasPrefix(pair, "JOBCTRL_TEST_RECEIPT=") {
+			ctx.Environment[index] = `JOBCTRL_TEST_RECEIPT={"candidate_data_digest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","candidate_sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","job_count":1,"schema_version":1,"source_data_digest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","status":"ready","table_count":117,"user_version":8,"unexpected":true}`
+		}
+	}
+
+	if _, err := buildSealedV8Candidate(ctx, pair, journalID); err == nil || !strings.Contains(err.Error(), "receipt is invalid") {
+		t.Fatalf("unbounded receipt passed: %v", err)
+	}
+	if _, err := os.Lstat(v8CandidatePath(ctx.Instance.StateDir, journalID)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("invalid receipt left candidate behind: %v", err)
+	}
+}
+
+func TestBuildSealedV8CandidateCrashRemovesCompositeIntermediate(t *testing.T) {
+	ctx, pair, journalID, _ := fakeV8BuilderContext(t, legacyJobCtrlSchemaVersion)
+	ctx.Environment = append(ctx.Environment, "JOBCTRL_TEST_CRASH_AFTER_INTERMEDIATE=1")
+	candidate := v8CandidatePath(ctx.Instance.StateDir, journalID)
+	intermediate := v6ToV8IntermediatePath(candidate)
+
+	if _, err := buildSealedV8Candidate(ctx, pair, journalID); err == nil || !strings.Contains(err.Error(), "execution failed") {
+		t.Fatalf("crashed composite executor passed: %v", err)
+	}
+	for _, path := range []string{candidate, intermediate} {
+		if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("crashed composite left %s behind: %v", filepath.Base(path), err)
+		}
+	}
+}
+
+func syntheticV8CandidateBuilder(t *testing.T, python string, expectedSourceVersion int64) func(launchContext, databasePair, string) (string, error) {
+	t.Helper()
+	return func(candidate launchContext, pair databasePair, journalID string) (string, error) {
+		source, err := pairedDatabasePath(candidate.Instance.StateDir, pair, "jobctrl.db", expectedSourceVersion)
+		if err != nil {
+			return "", err
+		}
+		path := v8CandidatePath(candidate.Instance.StateDir, journalID)
+		if _, err := sqliteOnlineBackup(python, source, path); err != nil {
+			return "", err
+		}
+		if err := os.Chmod(path, 0o600); err != nil {
+			return "", err
+		}
+		code := "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute('PRAGMA user_version=8'); c.commit(); c.close()"
+		if output, err := exec.Command(python, "-c", code, path).CombinedOutput(); err != nil {
+			return "", errors.New(strings.TrimSpace(string(output)))
+		}
+		return path, nil
+	}
+}
+
+func TestLifecycleMigratesV6AndV7ToV8AndRestoresExactSourceOnRollback(t *testing.T) {
+	for _, sourceVersion := range []int64{legacyJobCtrlSchemaVersion, exactJobCtrlSchemaVersion} {
+		t.Run("source-v"+strconv.FormatInt(sourceVersion, 10), func(t *testing.T) {
+			preserveMigrationSeams(t)
+			fixture := newV6ActivationFixture(t)
+			setJobCtrlUserVersion(t, fixture.python, fixture.state, sourceVersion)
+			proofs := 0
+			temporalQuiescenceProof = func(_, _ launchContext) error {
+				proofs++
+				return nil
+			}
+			sealedV7CandidateBuilder = syntheticV8CandidateBuilder(t, fixture.python, sourceVersion)
+			sealedV7CandidateInstaller = installSealedV8Candidate
+			candidateStarts, oldStarts := 0, 0
+			startReleaseCommand = func(_ launchContext, receipt release.Receipt, journalID string) error {
+				if journalID == "" {
+					t.Fatal("release start is not bound to a journal")
+				}
+				switch receipt.BuildID {
+				case fixture.candidate.BuildID:
+					candidateStarts++
+					version, err := sqliteUserVersion(fixture.python, filepath.Join(fixture.state, "jobctrl.db"))
+					if err != nil || version != currentJobCtrlSchemaVersion {
+						t.Fatalf("candidate opened schema v%d, err=%v", version, err)
+					}
+				case fixture.old.BuildID:
+					oldStarts++
+				default:
+					t.Fatalf("unexpected release start %#v", receipt)
+				}
+				return nil
+			}
+
+			if err := promoteExisting(fixture.ctx, fixture.store, fixture.active, fixture.candidate.BuildID, "update", io.Discard); err != nil {
+				t.Fatalf("promote v%d to v8: %v", sourceVersion, err)
+			}
+			if candidateStarts != 1 || oldStarts != 0 {
+				t.Fatalf("promotion starts candidate=%d old=%d", candidateStarts, oldStarts)
+			}
+			expectedProofs := 0
+			if sourceVersion == legacyJobCtrlSchemaVersion {
+				expectedProofs = 1
+			}
+			if proofs != expectedProofs {
+				t.Fatalf("v%d Temporal proofs = %d", sourceVersion, proofs)
+			}
+			active, err := fixture.store.ReadActive()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := rollbackExisting(fixture.ctx, fixture.store, active, fixture.old.BuildID, io.Discard); err != nil {
+				t.Fatalf("rollback to v%d: %v", sourceVersion, err)
+			}
+			version, err := sqliteUserVersion(fixture.python, filepath.Join(fixture.state, "jobctrl.db"))
+			if err != nil || version != sourceVersion {
+				t.Fatalf("rollback restored v%d, err=%v; expected v%d", version, err, sourceVersion)
+			}
+			if oldStarts != 1 {
+				t.Fatalf("rollback old starts = %d", oldStarts)
+			}
+		})
+	}
+}

--- a/scripts/version-contract.test.mjs
+++ b/scripts/version-contract.test.mjs
@@ -33,8 +33,8 @@ test("public application versions agree without resetting compatibility counters
     /\[\[package\]\]\nname = "jobctrl"\nversion = "0\.1\.0"\nsource = \{ editable = "\." \}/,
   );
 
-  assert.match(await read("apps/api/src/schema-manifest.ts"), /EXACT_V7_SCHEMA_MANIFEST[\s\S]*?version: 7,/);
-  assert.match(await read("workers/automation/src/jobctrl/database.py"), /^SCHEMA_VERSION = 7$/m);
+  assert.match(await read("apps/api/src/schema-manifest.ts"), /EXACT_V8_SCHEMA_MANIFEST[\s\S]*?version: 8,/);
+  assert.match(await read("workers/automation/src/jobctrl/database.py"), /^SCHEMA_VERSION = 8$/m);
   assert.equal((await readJson("launcher/runtime-manifest.json")).launcherProtocol, 1);
   assert.match(await read("launcher/internal/launcher/launcher.go"), /^\s*launcherProtocol\s+= 1$/m);
   assert.match(await read("launcher/internal/launcher/launcher.go"), /^\s*stateSchemaVersion\s+= 1$/m);

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from jobctrl.config import DB_PATH, DEFAULTS
 from jobctrl.infrastructure.migrations.schema_manifest import (
-    EXACT_V7_MANIFEST,
+    EXACT_V8_MANIFEST,
     SchemaManifestError,
     assert_exact_manifest,
     schema_dump,
@@ -31,7 +31,8 @@ from jobctrl.scoring.eligibility_sql import (
 
 # Schema version stamped into the SQLite ``user_version`` header. Runtime opens
 # only this exact schema and refuses databases written by newer code. The only
-# supported upgrade is the explicit stopped-runtime v6-to-v7 cutover.
+# supported upgrades are the explicit stopped-runtime v6-to-v8 composite and
+# v7-to-v8 additive cutovers.
 #
 # v2 (Contact & Outreach): generic ``entity_kind``/``entity_ref`` columns on
 # ``job_events`` so contact-only events carry honest identity without
@@ -45,9 +46,11 @@ from jobctrl.scoring.eligibility_sql import (
 # replay-idempotent receipts for caller-filtered provider results.
 # v6 (repeat-application prevention): evidence-bound confirmations,
 # one-attempt consumption, and immutable protection audit records.
-# v7 replaces URL-shaped storage identity with canonical ``(tenant_id,
-# job_id)`` keys. Posting URLs remain unique locators, never aggregate identity.
-SCHEMA_VERSION = 7
+# v7 replaced URL-shaped storage identity with canonical ``(tenant_id,
+# job_id)`` keys. v8 adds reusable direct and extrapolated compensation facts
+# without changing any v7 table. Posting URLs remain unique locators, never
+# aggregate identity.
+SCHEMA_VERSION = 8
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -55,7 +58,7 @@ class IncompatibleSchemaVersionError(RuntimeError):
 
 
 class SchemaMigrationRequiredError(RuntimeError):
-    """Raised when a stopped-runtime v6 cutover has not been run."""
+    """Raised when a stopped-runtime v6/v7 cutover has not been run."""
 
 
 # Thread-local connection storage — each thread gets its own connection
@@ -98,6 +101,7 @@ def get_connection(
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA busy_timeout=10000")
     conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
     register_score_eligibility_sql(conn)
     _local.connections[path] = conn
     return conn
@@ -181,24 +185,24 @@ def _assert_schema_version_supported(
     return current
 
 
-def create_exact_v7_database(
+def create_exact_v8_database(
     db_path: Path | str | None = None,
 ) -> sqlite3.Connection:
-    """Create a brand-new database directly from the exact v7 schema."""
+    """Create a brand-new database directly from the exact v8 schema."""
     path = Path(db_path or DB_PATH)
     if path.exists():
         raise FileExistsError(
-            f"exact v7 creation requires a missing database path, found {path}"
+            f"exact v8 creation requires a missing database path, found {path}"
         )
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = get_connection(path)
     try:
         if schema_dump(conn):
-            raise SchemaManifestError("fresh v7 creation found pre-existing schema")
+            raise SchemaManifestError("fresh v8 creation found pre-existing schema")
 
-        from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+        from jobctrl.infrastructure.migrations.schema_v8 import create_exact_v8_schema
 
-        create_exact_v7_schema(conn)
+        create_exact_v8_schema(conn)
         conn.commit()
         return conn
     except BaseException:
@@ -213,36 +217,36 @@ def create_exact_v7_database(
         raise
 
 
-def open_exact_v7_database(
+def open_exact_v8_database(
     db_path: Path | str | None = None,
 ) -> sqlite3.Connection:
-    """Open an existing exact-v7 database without performing any writes."""
+    """Open an existing exact-v8 database without performing any writes."""
     path = Path(db_path or DB_PATH)
     if not path.exists():
         raise FileNotFoundError(f"No database to open at {path}")
     conn = get_connection(path, enable_wal=False)
     current_version = _assert_schema_version_supported(conn)
-    if current_version == 6:
+    if current_version in (6, 7):
         raise SchemaMigrationRequiredError(
-            "JobCtrl database is schema v6. Run `jobctrl update` so the native "
-            "lifecycle can stop JobCtrl, verify quiescence, create the paired "
-            "backup, and activate schema v7 before starting the runtime."
+            f"JobCtrl database is schema v{current_version}. Run `jobctrl update` so "
+            "the native lifecycle can stop JobCtrl, create the paired backup, "
+            "and activate schema v8 before starting the runtime."
         )
     if current_version != SCHEMA_VERSION:
         raise SchemaMigrationRequiredError(
-            "JobCtrl can only open the exact schema v7 at runtime; "
+            "JobCtrl can only open the exact schema v8 at runtime; "
             f"found schema version {current_version}."
         )
-    assert_exact_manifest(conn, EXACT_V7_MANIFEST)
+    assert_exact_manifest(conn, EXACT_V8_MANIFEST)
     return conn
 
 
 def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
-    """Create a missing v7 database or read-only validate an existing one."""
+    """Create a missing v8 database or read-only validate an existing one."""
     path = Path(db_path or DB_PATH)
     if not path.exists():
-        return create_exact_v7_database(path)
-    return open_exact_v7_database(path)
+        return create_exact_v8_database(path)
+    return open_exact_v8_database(path)
 
 
 def ensure_projection_tables_in_db(conn: sqlite3.Connection | None = None) -> list[str]:

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -213,6 +213,7 @@ class DurableJobEventPublisher:
             job_id,
             self._stage,
             event.event_type,
+            tenant_id=event.tenant_id,
             message=event.event_type,
             payload=payload,
             occurred_at=event.occurred_at,

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_execute.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v7_execute.py
@@ -14,8 +14,10 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Final, Literal
 
-from jobctrl.database import close_connection, open_exact_v7_database
-from jobctrl.infrastructure.migrations.schema_manifest import EXACT_V7_MANIFEST
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    assert_exact_manifest,
+)
 from jobctrl.infrastructure.migrations.v6_to_v7_candidate import (
     populate_v7_candidate,
 )
@@ -105,12 +107,16 @@ def execute_v6_to_v7_candidate(
         source_connection.close()
         source_connection = None
 
-        reopened = open_exact_v7_database(candidate)
+        reopened = sqlite3.connect(
+            f"{candidate.resolve().as_uri()}?mode=ro",
+            uri=True,
+        )
         try:
             if int(reopened.execute("PRAGMA user_version").fetchone()[0]) != EXACT_V7_MANIFEST.version:
                 raise CandidateExecutionError(_GENERIC_FAILURE)
+            assert_exact_manifest(reopened, EXACT_V7_MANIFEST)
         finally:
-            close_connection(candidate)
+            reopened.close()
 
         _fsync_regular_file(candidate)
         _fsync_directory(candidate.parent)
@@ -129,7 +135,6 @@ def execute_v6_to_v7_candidate(
             candidate_connection.close()
         if source_connection is not None:
             source_connection.close()
-        close_connection(candidate)
         if created_identity is not None:
             _remove_created_candidate(candidate, created_identity)
         if isinstance(error, Exception):

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v8_execute.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v6_to_v8_execute.py
@@ -1,0 +1,145 @@
+"""Private file-to-file executor for the stopped-runtime v6-to-v8 cutover."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import asdict
+from pathlib import Path
+from typing import Final
+
+from jobctrl.infrastructure.migrations.v6_to_v7_execute import (
+    execute_v6_to_v7_candidate,
+)
+from jobctrl.infrastructure.migrations.v7_to_v8_execute import (
+    CandidateExecutionResult,
+    execute_v7_to_v8_candidate,
+)
+
+_GENERIC_FAILURE: Final = "v6-to-v8 candidate migration failed"
+
+
+class CandidateExecutionError(RuntimeError):
+    """Raised when an isolated v8 candidate cannot be built from v6."""
+
+
+def execute_v6_to_v8_candidate(
+    source_path: Path | str,
+    candidate_path: Path | str,
+    *,
+    migration_at: str,
+    job_id_factory: Callable[[], str] | None = None,
+    _after_v8_stamp: Callable[[], None] | None = None,
+) -> CandidateExecutionResult:
+    """Build exact v7 privately, then add v8 without installing either file.
+
+    The native lifecycle owns the source paired backup and final installation.
+    The intermediate exact-v7 file lives in an owner-private directory beside
+    the final candidate and is removed before this function returns.
+    """
+
+    source = Path(source_path)
+    candidate = Path(candidate_path)
+    intermediate = _intermediate_candidate_path(candidate)
+    result: CandidateExecutionResult | None = None
+    intermediate_ready = False
+    try:
+        _assert_candidate_path(candidate)
+        _assert_candidate_path(intermediate)
+        execute_v6_to_v7_candidate(
+            source,
+            intermediate,
+            migration_at=migration_at,
+            job_id_factory=job_id_factory,
+        )
+        intermediate_ready = True
+        result = execute_v7_to_v8_candidate(
+            intermediate,
+            candidate,
+            _after_stamp=_after_v8_stamp,
+        )
+        try:
+            _remove_candidate(intermediate)
+        except OSError:
+            _remove_candidate(candidate, ignore_errors=True)
+            raise CandidateExecutionError(_GENERIC_FAILURE) from None
+        return result
+    except BaseException as error:
+        if intermediate_ready:
+            _remove_candidate(intermediate, ignore_errors=True)
+        if result is not None:
+            _remove_candidate(candidate, ignore_errors=True)
+        if isinstance(error, Exception):
+            raise CandidateExecutionError(_GENERIC_FAILURE) from None
+        raise
+
+
+def _assert_candidate_path(candidate: Path) -> None:
+    try:
+        parent = candidate.parent.stat()
+    except OSError:
+        raise CandidateExecutionError(_GENERIC_FAILURE) from None
+    if not stat.S_ISDIR(parent.st_mode):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    if os.path.lexists(candidate) or any(
+        os.path.lexists(f"{candidate}{suffix}")
+        for suffix in ("-journal", "-shm", "-wal")
+    ):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+
+
+def _intermediate_candidate_path(candidate: Path) -> Path:
+    return Path(f"{candidate}.exact-v7-intermediate")
+
+
+def _remove_candidate(candidate: Path, *, ignore_errors: bool = False) -> None:
+    paths = (candidate, *(Path(f"{candidate}{suffix}") for suffix in ("-journal", "-shm", "-wal")))
+    for path in paths:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            if not ignore_errors:
+                raise
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the authenticated launcher's private composite migration."""
+
+    parser = _PrivateArgumentParser(add_help=False)
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--migration-at", required=True)
+    try:
+        arguments = parser.parse_args(argv)
+        result = execute_v6_to_v8_candidate(
+            arguments.source,
+            arguments.candidate,
+            migration_at=arguments.migration_at,
+        )
+    except CandidateExecutionError:
+        print(_GENERIC_FAILURE, file=sys.stderr)
+        return 1
+    print(json.dumps(asdict(result), sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+class _PrivateArgumentParser(argparse.ArgumentParser):
+    """Argument parser that never echoes private transition paths."""
+
+    def error(self, _message: str) -> None:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "CandidateExecutionError",
+    "execute_v6_to_v8_candidate",
+    "main",
+]

--- a/workers/automation/tests/test_apply_runs_table_dropped.py
+++ b/workers/automation/tests/test_apply_runs_table_dropped.py
@@ -70,7 +70,7 @@ def test_init_db_rejects_legacy_apply_tables_without_mutating_them(
     pre.commit()
     pre.close()
 
-    with pytest.raises(SchemaMigrationRequiredError, match="exact schema v7"):
+    with pytest.raises(SchemaMigrationRequiredError, match="exact schema v8"):
         init_db(fresh_db)
 
     verified = sqlite3.connect(str(fresh_db))

--- a/workers/automation/tests/test_discovery_search_units.py
+++ b/workers/automation/tests/test_discovery_search_units.py
@@ -275,7 +275,7 @@ def test_v4_search_unit_tables_require_an_explicit_v7_upgrade(
     conn.commit()
     close_connection(db_path)
 
-    with pytest.raises(SchemaMigrationRequiredError, match="exact schema v7"):
+    with pytest.raises(SchemaMigrationRequiredError, match="exact schema v8"):
         init_db(db_path)
 
 

--- a/workers/automation/tests/test_employer_analysis_projection.py
+++ b/workers/automation/tests/test_employer_analysis_projection.py
@@ -215,6 +215,18 @@ def test_projection_analysis_is_null_when_no_analysis_exists(conn: sqlite3.Conne
 def test_projection_serves_latest_requirement_fit_report_read_model(
     conn: sqlite3.Connection,
 ) -> None:
+    conn.executemany(
+        """
+        INSERT INTO job_scores (
+            tenant_id, job_id, version, fit_score, breakdown_json,
+            keywords_json, scored_at, trace_json
+        ) VALUES (?, ?, ?, 8, '{}', '[]', ?, '{}')
+        """,
+        [
+            (str(LOCAL_TENANT), str(JOB_ID), 1, "2026-05-04T11:00:00+00:00"),
+            (str(LOCAL_TENANT), str(JOB_ID), 2, "2026-05-04T12:00:00+00:00"),
+        ],
+    )
     repo = SqliteRequirementFitReportRepository(conn)
     repo.save(LOCAL_TENANT, _requirement_fit_report(score_version=1))
     latest = _requirement_fit_report(score_version=2)

--- a/workers/automation/tests/test_event_publication.py
+++ b/workers/automation/tests/test_event_publication.py
@@ -9,6 +9,13 @@ from jobctrl.infrastructure.events.in_process_bus import InProcessEventBus
 from jobctrl.state import record_job_event
 
 
+def _seed_job(conn, job_id) -> None:
+    conn.execute(
+        "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+        (str(LOCAL_TENANT), str(job_id), f"https://jobs.example.test/{job_id}"),
+    )
+
+
 def test_record_job_event_publishes_through_bus(tmp_path: Path) -> None:
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
@@ -18,6 +25,7 @@ def test_record_job_event_publishes_through_bus(tmp_path: Path) -> None:
 
     try:
         job_id = generate_job_id()
+        _seed_job(conn, job_id)
         record_job_event(
             conn,
             job_id,
@@ -53,6 +61,7 @@ def test_record_job_event_without_publisher_only_persists(tmp_path: Path) -> Non
 
     try:
         job_id = generate_job_id()
+        _seed_job(conn, job_id)
         record_job_event(
             conn,
             job_id,
@@ -79,6 +88,7 @@ def test_record_job_event_typed_subscriber_only_receives_match(tmp_path: Path) -
 
     try:
         job_id = generate_job_id()
+        _seed_job(conn, job_id)
         record_job_event(conn, job_id, "score", "StageStarted", publisher=bus)
         record_job_event(conn, job_id, "score", "StageCompleted", publisher=bus)
         record_job_event(conn, job_id, "score", "StageFailed", publisher=bus)

--- a/workers/automation/tests/test_event_type_migration.py
+++ b/workers/automation/tests/test_event_type_migration.py
@@ -19,6 +19,10 @@ def test_migration_renames_legacy_snake_case_event_types(tmp_path: Path) -> None
     conn = init_db(db_path)
     try:
         job_id = generate_job_id()
+        conn.execute(
+            "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+            (str(LOCAL_TENANT), str(job_id), "https://jobs.example.test/legacy-events"),
+        )
         # Seed historical rows that pre-date the PascalCase rip-and-replace.
         conn.executemany(
             """
@@ -72,6 +76,10 @@ def test_migration_is_idempotent(tmp_path: Path) -> None:
     conn = init_db(db_path)
     try:
         job_id = generate_job_id()
+        conn.execute(
+            "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+            (str(LOCAL_TENANT), str(job_id), "https://jobs.example.test/idempotent-event"),
+        )
         conn.execute(
             """
             INSERT INTO job_events (

--- a/workers/automation/tests/test_exact_v7_schema.py
+++ b/workers/automation/tests/test_exact_v7_schema.py
@@ -1,4 +1,4 @@
-"""Exact-v7 schema creation and runtime-open contracts."""
+"""Exact-v7 construction and current runtime-open contracts."""
 
 from __future__ import annotations
 
@@ -13,9 +13,10 @@ from jobctrl.database import (
     close_connection,
     init_db,
 )
-from jobctrl.infrastructure.migrations import schema_v7
+from jobctrl.infrastructure.migrations import schema_v8
 from jobctrl.infrastructure.migrations.schema_manifest import (
     EXACT_V7_MANIFEST,
+    EXACT_V8_MANIFEST,
     SchemaManifestError,
     assert_exact_manifest,
     schema_dump,
@@ -98,13 +99,14 @@ def _create_incomplete_v6_database(path: Path) -> None:
         conn.close()
 
 
-def test_fresh_v7_creation_matches_the_exact_manifest(tmp_path: Path) -> None:
+def test_fresh_runtime_creation_matches_the_exact_v8_manifest(tmp_path: Path) -> None:
     db_path = tmp_path / "jobctrl.db"
 
     conn = init_db(db_path)
 
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
-    assert_exact_manifest(conn, EXACT_V7_MANIFEST)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == EXACT_V8_MANIFEST.version
+    assert_exact_manifest(conn, EXACT_V8_MANIFEST)
+    assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
     assert conn.execute(
         "SELECT name FROM sqlite_master WHERE name = 'job_identity_aliases'"
     ).fetchone() is None
@@ -183,7 +185,7 @@ def test_unstamped_v7_candidate_rejects_nonzero_version_without_mutation(
         conn.close()
 
 
-def test_exact_v7_reopen_has_no_writes_or_schema_or_data_changes(tmp_path: Path) -> None:
+def test_exact_v8_reopen_has_no_writes_or_schema_or_data_changes(tmp_path: Path) -> None:
     db_path = tmp_path / "jobctrl.db"
     conn = init_db(db_path)
     before = _complete_database_dump(db_path)
@@ -231,7 +233,7 @@ def test_exact_v7_reopen_has_no_writes_or_schema_or_data_changes(tmp_path: Path)
     close_connection(db_path)
 
 
-def test_worker_heartbeat_does_not_drift_the_exact_v7_schema(
+def test_worker_heartbeat_does_not_drift_the_exact_v8_schema(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -249,7 +251,7 @@ def test_worker_heartbeat_does_not_drift_the_exact_v7_schema(
 
     reopened = init_db(db_path)
     assert schema_dump(reopened) == before_schema
-    assert_exact_manifest(reopened, EXACT_V7_MANIFEST)
+    assert_exact_manifest(reopened, EXACT_V8_MANIFEST)
     close_connection(db_path)
 
 
@@ -1459,6 +1461,20 @@ def test_incomplete_v6_is_rejected_before_any_write(tmp_path: Path) -> None:
     assert _complete_database_dump(db_path) == before
 
 
+def test_exact_v7_is_rejected_before_any_write(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobctrl.db"
+    conn = sqlite3.connect(db_path)
+    create_exact_v7_schema(conn)
+    conn.close()
+    before = _complete_database_dump(db_path)
+
+    with pytest.raises(SchemaMigrationRequiredError, match="schema v7"):
+        init_db(db_path)
+
+    close_connection(db_path)
+    assert _complete_database_dump(db_path) == before
+
+
 def test_fresh_schema_fault_leaves_no_partial_stamped_v7_database(tmp_path: Path) -> None:
     db_path = tmp_path / "jobctrl.db"
     conn = sqlite3.connect(db_path)
@@ -1516,7 +1532,7 @@ def test_failed_fresh_init_removes_its_file_and_can_retry(
     tmp_path: Path,
 ) -> None:
     db_path = tmp_path / "jobctrl.db"
-    create_schema = schema_v7.create_exact_v7_schema
+    create_schema = schema_v8.create_exact_v8_schema
 
     def fail_after_partial_creation(conn: sqlite3.Connection) -> None:
         executed = 0
@@ -1530,7 +1546,7 @@ def test_failed_fresh_init_removes_its_file_and_can_retry(
 
         create_schema(conn, _execute=fail_second_statement)
 
-    monkeypatch.setattr(schema_v7, "create_exact_v7_schema", fail_after_partial_creation)
+    monkeypatch.setattr(schema_v8, "create_exact_v8_schema", fail_after_partial_creation)
     with pytest.raises(RuntimeError, match="fixture creation failure"):
         init_db(db_path)
 
@@ -1538,7 +1554,7 @@ def test_failed_fresh_init_removes_its_file_and_can_retry(
     assert not Path(f"{db_path}-wal").exists()
     assert not Path(f"{db_path}-shm").exists()
 
-    monkeypatch.setattr(schema_v7, "create_exact_v7_schema", create_schema)
+    monkeypatch.setattr(schema_v8, "create_exact_v8_schema", create_schema)
     conn = init_db(db_path)
-    assert_exact_manifest(conn, EXACT_V7_MANIFEST)
+    assert_exact_manifest(conn, EXACT_V8_MANIFEST)
     close_connection(db_path)

--- a/workers/automation/tests/test_feedback_signal_reader.py
+++ b/workers/automation/tests/test_feedback_signal_reader.py
@@ -184,6 +184,7 @@ def test_signal_reads_are_tenant_scoped_and_deterministic(tmp_path: Path) -> Non
     _insert_job(conn, tenant_id="tenant-a", job_id=_JOB_A, suffix="tenant-a")
     _insert_job(conn, tenant_id="tenant-b", job_id=_JOB_A, suffix="tenant-b")
     _insert_job(conn, tenant_id="tenant-b", job_id=_JOB_B, suffix="tenant-b-only")
+    _insert_job(conn, tenant_id="tenant-c", job_id=_JOB_B, suffix="tenant-c-only")
     for tenant_id, score in (("tenant-a", 8), ("tenant-b", 4)):
         conn.execute(
             """
@@ -215,7 +216,7 @@ def test_signal_reads_are_tenant_scoped_and_deterministic(tmp_path: Path) -> Non
         INSERT INTO job_scores (
             tenant_id, job_id, version, fit_score, breakdown_json,
             keywords_json, scored_at, correction_json, trace_json
-        ) VALUES ('tenant-a', ?, 1, 6, '{}', '[]', ?, NULL, '{}')
+        ) VALUES ('tenant-c', ?, 1, 6, '{}', '[]', ?, NULL, '{}')
         """,
         (_JOB_B, "2026-08-01T08:00:00Z"),
     )
@@ -224,7 +225,7 @@ def test_signal_reads_are_tenant_scoped_and_deterministic(tmp_path: Path) -> Non
         INSERT INTO job_scores (
             tenant_id, job_id, version, fit_score, breakdown_json,
             keywords_json, scored_at, correction_json, trace_json
-        ) VALUES ('tenant-a', ?, 2, 9, '{}', '[]', ?, ?, '{}')
+        ) VALUES ('tenant-c', ?, 2, 9, '{}', '[]', ?, ?, '{}')
         """,
         (
             _JOB_B,
@@ -237,7 +238,7 @@ def test_signal_reads_are_tenant_scoped_and_deterministic(tmp_path: Path) -> Non
         INSERT INTO discovery_feedback (
             tenant_id, feedback_id, job_id, source_id, kind, note, recorded_at
         ) VALUES (
-            'tenant-a', 'cross-tenant-discovery', ?, 'source-private',
+            'tenant-c', 'cross-tenant-discovery', ?, 'source-private',
             'useful', 'private tenant-b-only discovery', ?
         )
         """,
@@ -250,7 +251,7 @@ def test_signal_reads_are_tenant_scoped_and_deterministic(tmp_path: Path) -> Non
             title_display, reason_code, reason, sample_count,
             source_ids_json, evidence_json, created_at, updated_at, decided_at
         ) VALUES (
-            'tenant-a', 'cross-tenant-role', 'approved',
+            'tenant-c', 'cross-tenant-role', 'approved',
             'exact_title_exclusion', 'account executive', 'Account Executive',
             'low_role_fit', 'private role reason', 1, '[]', ?, ?, ?, ?
         )

--- a/workers/automation/tests/test_manual_capture_workflow.py
+++ b/workers/automation/tests/test_manual_capture_workflow.py
@@ -237,6 +237,16 @@ def test_activity_scopes_same_capture_to_tenant_canonical_job_ids(tmp_path: Path
             """,
             (local_payload.item_id,),
         ).fetchall()
+        discovered_events = conn.execute(
+            """
+            SELECT tenant_id, job_id
+            FROM job_events
+            WHERE event_type = 'JobDiscovered'
+              AND job_id IN (?, ?)
+            ORDER BY tenant_id
+            """,
+            (local_first.job_id, other_first.job_id),
+        ).fetchall()
     finally:
         close_connection(db_path)
 
@@ -245,6 +255,10 @@ def test_activity_scopes_same_capture_to_tenant_canonical_job_ids(tmp_path: Path
     assert {row["tenant_id"] for row in rows} == {"local", "other"}
     assert {row["job_id"] for row in rows} == {local_first.job_id, other_first.job_id}
     assert {row["url"] for row in rows} == {_CAPTURE_URL}
+    assert [(row["tenant_id"], row["job_id"]) for row in discovered_events] == [
+        ("local", local_first.job_id),
+        ("other", other_first.job_id),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/workers/automation/tests/test_outreach_draft_gates.py
+++ b/workers/automation/tests/test_outreach_draft_gates.py
@@ -146,6 +146,14 @@ def _counter():
 def _setup(tmp_path: Path):
     conn = init_db(tmp_path / "jobctrl.db")
     conn.row_factory = sqlite3.Row
+    conn.execute(
+        "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+        (
+            str(LOCAL_TENANT),
+            "00000000-0000-4000-8000-000000000001",
+            "https://jobs.example.test/outreach-draft",
+        ),
+    )
     bus = InProcessEventBus()
     contact_repo = SqliteContactRepository(conn, publisher=bus)
     thread_repo = SqliteOutreachThreadRepository(conn, publisher=bus)

--- a/workers/automation/tests/test_outreach_follow_up_derivation.py
+++ b/workers/automation/tests/test_outreach_follow_up_derivation.py
@@ -117,6 +117,14 @@ def test_recurring_reminder_can_be_enabled_but_never_sends() -> None:
 def _repo() -> tuple[SqliteOutreachThreadRepository, sqlite3.Connection]:
     conn = init_db(Path(tempfile.mkdtemp()) / "jobctrl.db")
     conn.row_factory = sqlite3.Row
+    conn.execute(
+        "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+        (
+            str(LOCAL_TENANT),
+            "00000000-0000-4000-8000-000000000001",
+            "https://jobs.example.test/outreach-follow-up",
+        ),
+    )
     return SqliteOutreachThreadRepository(conn, publisher=InProcessEventBus()), conn
 
 

--- a/workers/automation/tests/test_outreach_no_auto_send.py
+++ b/workers/automation/tests/test_outreach_no_auto_send.py
@@ -61,6 +61,14 @@ _PASS_GATES = DraftGateResults(
 def _repo() -> tuple[SqliteOutreachThreadRepository, sqlite3.Connection]:
     conn = init_db(Path(tempfile.mkdtemp()) / "jobctrl.db")
     conn.row_factory = sqlite3.Row
+    conn.execute(
+        "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+        (
+            str(LOCAL_TENANT),
+            "00000000-0000-4000-8000-000000000001",
+            "https://jobs.example.test/outreach-no-send",
+        ),
+    )
     return SqliteOutreachThreadRepository(conn, publisher=InProcessEventBus()), conn
 
 

--- a/workers/automation/tests/test_outreach_repository_v7.py
+++ b/workers/automation/tests/test_outreach_repository_v7.py
@@ -26,6 +26,13 @@ _JOB_ID = JobId("00000000-0000-4000-8000-000000000001")
 def _repo(tmp_path: Path) -> tuple[SqliteOutreachThreadRepository, sqlite3.Connection]:
     conn = init_db(tmp_path / "jobctrl.db")
     conn.row_factory = sqlite3.Row
+    conn.executemany(
+        "INSERT INTO jobs (tenant_id, job_id, url) VALUES (?, ?, ?)",
+        [
+            ("tenant-a", str(_JOB_ID), "https://jobs.example.test/tenant-a/outreach"),
+            ("tenant-b", str(_JOB_ID), "https://jobs.example.test/tenant-b/outreach"),
+        ],
+    )
     return SqliteOutreachThreadRepository(conn, publisher=InProcessEventBus()), conn
 
 

--- a/workers/automation/tests/test_stage_runner_thread_safety.py
+++ b/workers/automation/tests/test_stage_runner_thread_safety.py
@@ -112,6 +112,10 @@ def test_failed_to_running_transition_skips_validation(
     production."""
 
     job_id = generate_job_id()
+    db.execute(
+        "INSERT INTO jobs (tenant_id, job_id, url) VALUES ('local', ?, ?)",
+        (str(job_id), f"https://jobs.example.test/{job_id}"),
+    )
     ensure_job_stage_rows(db, job_id, discovered_at="2026-01-01T00:00:00+00:00")
     # Seed the row in 'failed' state via the validation bypass — the
     # canonical state machine doesn't permit pending -> failed directly,

--- a/workers/automation/tests/test_v6_to_v7_execute.py
+++ b/workers/automation/tests/test_v6_to_v7_execute.py
@@ -10,7 +10,10 @@ from pathlib import Path
 
 import pytest
 
-from jobctrl.database import close_connection, open_exact_v7_database
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V7_MANIFEST,
+    assert_exact_manifest,
+)
 from jobctrl.infrastructure.migrations.v6_to_v7_execute import (
     CandidateExecutionError,
     execute_v6_to_v7_candidate,
@@ -62,14 +65,15 @@ def test_executor_builds_a_closed_exact_v7_candidate_without_mutating_source(
     assert result.candidate_sha256 == _sha256(candidate)
     assert len(result.source_digest) == 64
     assert len(result.candidate_logical_digest) == 64
-    reopened = open_exact_v7_database(candidate)
+    reopened = sqlite3.connect(candidate)
     try:
         assert tuple(reopened.execute("PRAGMA user_version").fetchone()) == (7,)
+        assert_exact_manifest(reopened, EXACT_V7_MANIFEST)
         assert tuple(
             reopened.execute("SELECT job_id FROM jobs").fetchone()
         ) == (_JOB_ID,)
     finally:
-        close_connection(candidate)
+        reopened.close()
 
 
 @pytest.mark.parametrize(

--- a/workers/automation/tests/test_v6_to_v8_execute.py
+++ b/workers/automation/tests/test_v6_to_v8_execute.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V8_MANIFEST,
+    assert_exact_manifest,
+)
+from jobctrl.infrastructure.migrations.v6_to_v8_execute import (
+    CandidateExecutionError,
+    execute_v6_to_v8_candidate,
+    main,
+)
+from tests.v6_migration_fixture import create_shipped_v6_database
+
+_MIGRATION_AT = "2026-08-11T12:00:00+00:00"
+_JOB_ID = "00000000-0000-4000-8000-000000000061"
+
+
+def _allocator(*values: str) -> Callable[[], str]:
+    allocated: Iterator[str] = iter(values)
+    return allocated.__next__
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_executor_builds_exact_v8_from_v6_without_leaking_intermediate(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "paired-backup-jobctrl.db"
+    candidate = tmp_path / "jobctrl.db.v8-candidate"
+    create_shipped_v6_database(source)
+    source_before = source.read_bytes()
+
+    result = execute_v6_to_v8_candidate(
+        source,
+        candidate,
+        migration_at=_MIGRATION_AT,
+        job_id_factory=_allocator(_JOB_ID),
+    )
+
+    assert source.read_bytes() == source_before
+    assert candidate.stat().st_mode & 0o777 == 0o600
+    assert result.schema_version == 1
+    assert result.status == "ready"
+    assert result.user_version == 8
+    assert result.source_data_digest == result.candidate_data_digest
+    assert result.candidate_sha256 == _sha256(candidate)
+    assert result.job_count == 1
+    assert result.table_count == EXACT_V8_MANIFEST.table_count
+    assert not Path(f"{candidate}.exact-v7-intermediate").exists()
+
+    conn = sqlite3.connect(candidate)
+    try:
+        assert_exact_manifest(conn, EXACT_V8_MANIFEST)
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+        assert conn.execute("SELECT job_id FROM jobs").fetchone() == (_JOB_ID,)
+    finally:
+        conn.close()
+
+
+def test_late_failure_preserves_v6_source_and_removes_all_candidates(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.db"
+    candidate = tmp_path / "candidate.db"
+    create_shipped_v6_database(source)
+    source_before = source.read_bytes()
+
+    with pytest.raises(CandidateExecutionError, match="candidate migration failed"):
+        execute_v6_to_v8_candidate(
+            source,
+            candidate,
+            migration_at=_MIGRATION_AT,
+            job_id_factory=_allocator(_JOB_ID),
+            _after_v8_stamp=lambda: (_ for _ in ()).throw(
+                RuntimeError("private fixture text")
+            ),
+        )
+
+    assert source.read_bytes() == source_before
+    assert not candidate.exists()
+    assert not Path(f"{candidate}-wal").exists()
+    assert not Path(f"{candidate}-shm").exists()
+    assert not Path(f"{candidate}.exact-v7-intermediate").exists()
+
+
+def test_existing_candidate_is_not_modified(tmp_path: Path) -> None:
+    source = tmp_path / "source.db"
+    candidate = tmp_path / "candidate.db"
+    create_shipped_v6_database(source)
+    candidate.write_bytes(b"owned fixture")
+
+    with pytest.raises(CandidateExecutionError, match="candidate migration failed"):
+        execute_v6_to_v8_candidate(
+            source,
+            candidate,
+            migration_at=_MIGRATION_AT,
+            job_id_factory=_allocator(_JOB_ID),
+        )
+
+    assert candidate.read_bytes() == b"owned fixture"
+    assert not Path(f"{candidate}.exact-v7-intermediate").exists()
+
+
+def test_private_cli_returns_bounded_receipt_and_sanitized_failure(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "source.db"
+    candidate = tmp_path / "candidate.db"
+    create_shipped_v6_database(source)
+
+    assert main(
+        [
+            "--source",
+            str(source),
+            "--candidate",
+            str(candidate),
+            "--migration-at",
+            _MIGRATION_AT,
+        ]
+    ) == 0
+    captured = capsys.readouterr()
+    receipt = json.loads(captured.out)
+    assert captured.err == ""
+    assert set(receipt) == {
+        "candidate_data_digest",
+        "candidate_sha256",
+        "job_count",
+        "schema_version",
+        "source_data_digest",
+        "status",
+        "table_count",
+        "user_version",
+    }
+    assert receipt["user_version"] == 8
+    assert str(source) not in captured.out
+    assert str(candidate) not in captured.out
+
+    missing = tmp_path / "private-missing.db"
+    assert main(
+        [
+            "--source",
+            str(missing),
+            "--candidate",
+            str(tmp_path / "failed.db"),
+            "--migration-at",
+            _MIGRATION_AT,
+        ]
+    ) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "v6-to-v8 candidate migration failed\n"
+    assert str(missing) not in captured.err

--- a/workers/automation/tests/test_v7_score_runtime.py
+++ b/workers/automation/tests/test_v7_score_runtime.py
@@ -416,6 +416,7 @@ def test_score_stage_events_carry_owning_workflow_id_under_a_run(
 def test_employer_analysis_event_preserves_tenant_and_job_id(
     conn: sqlite3.Connection,
 ) -> None:
+    _seed_target(conn, tenant_id=_TENANT_B, job_id=_JOB_ID_B)
     event = create_employer_analyzed(
         _TENANT_B,
         EmployerAnalyzedPayload(
@@ -468,6 +469,7 @@ def test_employer_analysis_recorder_skips_cache_hits_when_opted_out(
     """``record_cached_hits=False`` records fresh analyses but never cache
     hits — the score stage resolves the analysis on every pass and must not
     duplicate the timeline row per retry/rescore."""
+    _seed_target(conn, tenant_id=_TENANT_B, job_id=_JOB_ID_B)
     recorder = EmployerAnalyzedEventRecorder(conn, stage="score", record_cached_hits=False)
 
     recorder.publish(_employer_analyzed_event(cached=True))
@@ -484,6 +486,7 @@ def test_employer_analysis_recorder_records_cache_hits_by_default(
     conn: sqlite3.Connection,
 ) -> None:
     """The default recorder (tailor path) keeps recording cache hits."""
+    _seed_target(conn, tenant_id=_TENANT_B, job_id=_JOB_ID_B)
     EmployerAnalyzedEventRecorder(conn, stage="tailor").publish(_employer_analyzed_event(cached=True))
 
     count = conn.execute("SELECT COUNT(*) FROM job_events WHERE event_type = 'EmployerAnalyzed'").fetchone()


### PR DESCRIPTION
## Summary

- make exact schema v8 the only Python and TypeScript runtime contract
- migrate exact v6 and v7 databases to v8 through the stopped-runtime candidate, paired-backup, atomic-install, and rollback protocol
- make the v6-to-v8 intermediate journal-bound so crash recovery removes every candidate artifact
- enforce SQLite foreign keys on runtime connections and preserve tenant ownership when discovery events are recorded
- advance the public release-version contract from exact schema v7 to exact schema v8
- document exact-v8 update, storage, recovery, and QA behavior

## Stack

- depends on #790, which adds the frozen exact-v8 compensation benchmark schema
- #789 remains the bottom stack layer for employer-posted salary extraction and display

## Validation

- `corepack pnpm python:lint` — passed
- `corepack pnpm python:test` — 3504 passed, 2 skipped
- formerly failing foreign-key and tenant slice — 95 passed
- focused Python migration/runtime suite — 53 passed
- `corepack pnpm api:check` — passed
- API test suite — 771 passed
- real Python/Node-backed native v6-to-v8 migration integration under `go test -race` — passed
- launcher race suite excluding the fixed-port hermetic lifecycle test — passed; that single aggregate test is environment-constrained because the active local Temporal service owns port 7233
- `node --test --test-name-pattern='public application versions agree' scripts/version-contract.test.mjs` — passed against the rebased v8 candidate
- `corepack pnpm docs:build` — passed
- `git diff --check` — passed
- independent Tier-3 review — Gate PASS, 0 Blocker / 0 High / 0 Medium / 0 Low

## Checklist

- [x] I ran the relevant local checks and listed them above.
- [x] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.
