### PR TITLE
chore(release): reset public version to 0.1.0

### DIFF
--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -1,8 +1,11 @@
 # JobCtrl Public Launch Status
 
-JobCtrl launched its first stable public macOS release,
-[`v2.0.7`](https://github.com/ebarti/JobCtrl/releases/tag/v2.0.7), on
-2026-07-24. The detailed release and recovery record remains in
+JobCtrl's public application version is resetting to `v0.1.0` as an
+early-access release. The withdrawn pre-launch `2.0.x` numbering remains
+preserved in tags, releases, signatures, and immutable artifacts; the reset
+corrects maturity signaling and does not reset product data, database schemas,
+launcher protocols, or signed-release security counters. The detailed release
+and recovery record remains in
 [`docs/publish-checklist.md`](docs/publish-checklist.md).
 
 ## Live Public Surfaces
@@ -18,8 +21,8 @@ JobCtrl launched its first stable public macOS release,
 
 ## Remaining Distribution Follow-Up
 
-- [x] Publish and verify the supported `2.0.7` Python package through the
-  protected PyPI recovery path.
+- [ ] Publish and verify the `0.1.0` early-access Python package, then yank the
+  preserved `2.0.7` and `2.0.8` files without deleting them.
 - [ ] Complete the published-artifact, lifecycle, clean-machine, and real-path
   TTFV acceptance matrix recorded in `docs/publish-checklist.md`.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ refreshes that browser-local workspace once; cookie consent is unchanged.
 
 ## Get Started
 
+JobCtrl `0.1.0` is an early-access application release. The public version was
+reset from the pre-launch `2.0.x` numbering so the version communicates the
+product's actual maturity; this is not a product, data, database-schema,
+launcher-protocol, or security downgrade.
+
 Install the signed Apple-silicon macOS release with the bundled installer:
 
 ```bash

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api",
-  "version": "2.0.8",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/extension",
-  "version": "2.0.8",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "JobCtrl",
   "description": "Save job postings from the browser into the local JobCtrl app.",
-  "version": "2.0.8",
+  "version": "0.1.0",
   "action": {
     "default_popup": "popup.html"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/web",
-  "version": "2.0.8",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -6,7 +6,7 @@ This is the detailed engineering backlog. The public roadmap lives in
 `docs/plans/implemented/`. Delivery history lives in the git log and the
 implemented plan records.
 
-## Current State Snapshot (2026-07-04)
+## Current State Snapshot (2026-08-12)
 
 Delivered work is recorded in the git log and the implemented plan directory.
 Discovery RFC production wiring and scoring intelligence are implemented via
@@ -30,15 +30,17 @@ of legacy `jobs.*` storage fallbacks, table/artifact/profile UX improvements,
 browser QA gaps, frontend a11y deferrals, and tooling / CI enforcement gaps.
 Hosted product, hosted data, hosted automation, and cloud-mode frontend adapters
 remain deferred until the local product is solid. Native distribution is
-implemented and the signed/notarized `v2.0.7` GitHub, R2, Homebrew, and PyPI
-release is live. P7 clean-machine product QA remains an operational release
-follow-up rather than unfinished implementation.
+implemented. The public application version is resetting to the `0.1.0`
+early-access line while the withdrawn pre-launch `2.0.x` tags, releases, and
+immutable artifacts remain preserved. P7 clean-machine product QA remains an
+operational release follow-up rather than unfinished implementation.
 
 ## Release Hardening Follow-Ups
 
-- Publish the approved `v2.0.8` security patch through the signed stable
-  workflow, then run the published-artifact, lifecycle, clean-machine, and
-  real-path TTFV acceptance matrix recorded in `docs/publish-checklist.md`.
+- Publish `v0.1.0` through the signed stable workflow as sequence 3 while
+  retaining minimum-safe sequence 2 and the existing `v2.0.7` revocation, then
+  run the published-artifact, lifecycle, clean-machine, and real-path TTFV
+  acceptance matrix recorded in `docs/publish-checklist.md`.
 - Treat analytics-optional public-demo access and post-accept
   withdrawal/current-visitor erasure as separately scoped privacy work. Keep
   the shipped consent-required behavior unchanged unless an explicit
@@ -49,9 +51,10 @@ follow-up rather than unfinished implementation.
   capability checks, connection verification, model discovery, telemetry and
   spend semantics, every core `LlmPort` operation, employer-analysis synthesis,
   and fail-closed readiness before `LLM_URL` or an equivalent setting can return
-  to the product surface. The v2.0 release supports only Codex, Claude, and
-  Google.
-- Implement the explicitly deferred W2.4 spend-control delta after v2.0.0:
+  to the product surface. The `0.1.0` early-access release supports only Codex,
+  Claude, and Google.
+- Implement the explicitly deferred W2.4 spend-control delta after the initial
+  public release:
   attribute every recorded LLM usage entry to its workflow lane, capture apply
   subprocess usage in the same ledger, enforce configurable per-lane daily
   token ceilings through the existing budget preflight, and expose the lane
@@ -312,8 +315,8 @@ Delivered by
 the signed Apple-silicon release, immutable GitHub/R2 assets, authenticated
 stable pointer, and Homebrew formula are live.
 
-- Publish the approved `v2.0.8` security patch with a new signed sequence and
-  explicit `v2.0.7` rollback revocation.
+- Publish the `v0.1.0` early-access reset at signed sequence 3 without lowering
+  the sequence-2 safety floor or dropping the existing `v2.0.7` revocation.
 - Run the P7 clean-machine curl/Homebrew, no-toolchain/no-system-Chrome,
   upgrade, provider-auth, capability, update/rollback, uninstall, and real-path
   TTFV matrix against published bytes.

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -297,7 +297,7 @@ especially §§11–14. This is a release precondition, not permission to publis
   installation, so the stable pointer, public GitHub Release, Homebrew tap, and
   PyPI package were not published.
   Do not move, delete, or dispatch any of these tags again.
-- **Current release record.** `v2.0.7` is the first published stable release.
+- **First release record.** `v2.0.7` is the first published stable release.
   Its immutable GitHub Release, signed R2 assets, stable channel pointer, native
   lifecycle proof, and verified Homebrew formula were published from audited
   commit `db257efe1087ec00ac2ec49b846a95d2423aecc2`. The initial PyPI upload
@@ -346,25 +346,53 @@ especially §§11–14. This is a release precondition, not permission to publis
   Remove those two temporary branch policies immediately after the run reaches
   a terminal state and verify both environments again admit only `v*` tags.
   Do not change the policies of `release-signing` or `release-publication`.
-- **Approved `v2.0.8` security patch.** Publish the merged release-preparation
-  commit as annotated tag `v2.0.8`, then manually dispatch this workflow at the
-  tag ref. The release advances the signed safety floor and explicitly revokes
-  the vulnerable `v2.0.7` build so a client that accepts `v2.0.8` cannot roll
-  back below the security fixes. Use these exact promotion inputs:
+- **Published `v2.0.8` security release.** The signed workflow published
+  `v2.0.8` from audited commit
+  `92770fe5fcc99e73c0a06e73315acbb7b506a7af` in workflow run
+  `30480825567`. GitHub Releases, R2, Homebrew, and PyPI all received the
+  release. Its signed descriptor advanced to sequence 2, raised the
+  minimum-safe sequence to 2, and revoked only
+  `2.0.7-db257efe1087ec00ac2ec49b846a95d2423aecc2-darwin-arm64`. Preserve the
+  release, tag, signatures, and immutable evidence.
+- **Approved `v0.1.0` public version reset.** Publish the merged
+  release-preparation commit as annotated tag `v0.1.0`, then manually dispatch
+  the signed workflow at the tag ref. This resets only the public application
+  SemVer so JobCtrl communicates its early-access maturity accurately. The
+  pre-launch `2.0.x` numbering is withdrawn, not deleted or rewritten. The
+  reset is not a product, data, database-schema, migration, launcher-protocol,
+  signed-sequence, build-identity, or security downgrade. There are no known
+  external users; the very small public download signals are not verified
+  adoption and do not establish zero historical users.
+
+  Sequence 3 remains newer than sequence 2 even though app SemVer decreases.
+  Keep minimum-safe sequence 2, carry the bytewise-sorted `v2.0.7` revocation,
+  and do not revoke the safe historical `v2.0.8` build solely because of the
+  numbering reset. The Homebrew template and every future render must carry
+  `version_scheme 1` so Homebrew treats the new scheme as newer. Keep the
+  existing `Development Status :: 4 - Beta` Python classifier. No `2.0.9`
+  bridge release is required. Use these exact promotion inputs:
 
   ```text
-  release_tag=v2.0.8
+  release_tag=v0.1.0
   channel=stable
   pypi_recovery_only=false
-  sequence=2
+  sequence=3
   minimum_safe_sequence=2
   revoked_build_ids=["2.0.7-db257efe1087ec00ac2ec49b846a95d2423aecc2-darwin-arm64"]
-  expected_channel_pointer_sha256=071df066a27b937ba7194b663698564c862565a8588753070b65de074ad5241d
+  expected_channel_pointer_sha256=98ce7f2a0ff19b2e7428eece939da75d160bdc991e119182246dc053898a31c2
   ```
 
   Re-read the public stable pointer immediately before dispatch. If its digest
   changed, stop and reconcile the intervening signed release instead of
   weakening the compare-and-swap guard.
+  After `0.1.0` is verified on PyPI, yank rather than delete `2.0.7` with a
+  reason that identifies the withdrawn numbering line and its security-fixed
+  supersession path, and yank `2.0.8` with
+  `Pre-launch version-number reset; use 0.1.0 or later.` Confirm an unpinned
+  fresh install selects `0.1.0`, while exact historical pins remain available
+  with a yank warning. Update the existing GitHub release descriptions without
+  changing their immutable assets: label `v2.0.7` withdrawn and revoked, and
+  label `v2.0.8` a safe historical build superseded by the numbering reset.
 - **Rollback.** Preserve the immutable Release and tag as audit evidence. Yank
   a bad PyPI file/version when necessary, then publish a new higher-sequence
   signed release that explicitly revokes or supersedes the affected build.
@@ -421,7 +449,9 @@ from `main` or merely from a published GitHub Release.
 The formula writes only its Homebrew prefix: its `bin/jobctrl` target is a
 native first-invocation bootstrap holding the signed descriptor resources and
 cached ZIP. It must not create `~/.jobctrl`, mutate a Cellar payload, or link a
-runtime payload from the Cellar during `brew install`.
+runtime payload from the Cellar during `brew install`. The template must retain
+`version_scheme 1` on this and every future render so Homebrew does not compare
+the reset scheme-zero SemVer directly with the withdrawn `2.0.x` line.
 
 - **Action.** Configure the external signing/publication gates, then run the
   implemented signed-descriptor, published-ZIP smoke, formula render,
@@ -461,7 +491,7 @@ Phase 7 and its Definition of Done.
 - **Mandatory canonical-installer cutover.** Treat the immutable signed release
   and the public installer deployment as two linked but different records:
 
-  1. Record the immutable `v2.0.7` tag/release SHA and tree as **R**. Retrieve
+  1. Record the immutable `v0.1.0` tag/release SHA and tree as **R**. Retrieve
      that release's immutable pinned `install.sh` and `SHA256SUMS`, verify
      `install.sh` against its published SHA-256, and retain the verified asset
      URL and checksum with R. Do not reconstruct or edit the retrieved script.
@@ -617,12 +647,16 @@ Perform the following in order and stop at the first failed gate:
    after the exact-tree local gate passes.
 2. Rerun the standard hosted workflows on the recorded SHA and require green
    runs with executed steps.
-3. On that final validated `main` SHA, create and push `v2.0.7`, verify the
-   remote tag resolves to that exact SHA and remains in `origin/main` history,
-   and confirm the exact
-   tag-triggered `Release distribution` run uses the six first-release defaults
-   in 9.4. Complete the signed release, channel-pointer promotion, PyPI
-   publication, Homebrew formula sync, and immutable release evidence as R.
+3. On that final validated `main` SHA, create and push the annotated `v0.1.0`
+   tag, verify the remote tag resolves to that exact SHA and remains in
+   `origin/main` history, and preserve the existing `v2.0.7` and `v2.0.8` tags
+   and evidence unchanged. Re-read the live stable-pointer SHA-256, then
+   manually dispatch `Release distribution` at `v0.1.0` with sequence `3`,
+   minimum-safe sequence `2`, only the existing bytewise-sorted `v2.0.7`
+   revoked build ID, and that fresh digest as the compare-and-swap input, as
+   specified in 9.4. Complete signing, notarization, lifecycle smoke,
+   channel-pointer promotion, PyPI publication, Homebrew formula sync, and
+   immutable release evidence as R.
 4. Complete the separate post-release installer/docs PR in 9.6, merge it, and
    deploy Docs Site as D. Verify its public installer bytes still match R's
    immutable pinned `install.sh` before proceeding.
@@ -679,8 +713,8 @@ rollback evidence, and publish corrections where a public claim proved wrong.
 | 9.1 Visibility flip | Owner | Run the exact-tree local gate, make the repository public, then rerun every standard hosted gate with real executed steps. |
 | 9.2 Docs-site verification | Owner | Docs are already public and deploy is enabled; dispatch at the gated `main` SHA and record the public deployment proof. |
 | 9.3 Rename redirect | Owner | Verify old-URL redirects after the flip and repair any stale repository links. |
-| 9.4 Release and PyPI | Owner | `v2.0.7` is live on GitHub, R2, Homebrew, and PyPI. Publish approved security patch `v2.0.8` as signed sequence 2 with the recorded compare-and-swap and rollback-revocation inputs, then verify every public channel. |
-| 9.5 Homebrew tap | Signed workflow | Completed for `v2.0.7`; retain the verified formula and land the protected top-level deploy-key publication fix for future releases. |
+| 9.4 Release and PyPI | Owner | Publish the `v0.1.0` early-access version reset as signed sequence 3 with minimum-safe sequence 2, the existing `v2.0.7` revocation, and the freshly re-read compare-and-swap digest; then verify every public channel and yank, not delete, PyPI `2.0.7`/`2.0.8`. |
+| 9.5 Homebrew tap | Signed workflow | Publish only the signer-rendered `v0.1.0` formula and require `version_scheme 1` on this and every future render. |
 | 9.6 Installer and artifact acceptance | Owner | Verify immutable `install.sh` from R, land matching `scripts/get` and `docs/public/install.sh` in a separate post-release PR, validate/deploy D, then run public curl/Homebrew smoke. |
 | 9.7 Public live demo | Owner | The demo is already public and deploy is enabled; verify the audited deployment externally and record its release evidence. |
 | 10 Publicization | Owner | Prepare factual assets and platform access today; on launch day announce only after the public release and command smoke pass, then cover responses and record the 1h–72h metrics. |

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -8,6 +8,13 @@ JobCtrl is a local application: the app, database, settings, and generated
 files stay on your computer unless you explicitly connect an external provider.
 Install it once, then use the same `jobctrl` command from any directory.
 
+::: warning Early access
+JobCtrl `0.1.0` resets the public application version from the pre-launch
+`2.0.x` numbering so the version reflects the product's actual maturity. The
+reset does not downgrade product behavior, local data, database schemas,
+launcher protocols, signed-release safety, or security controls.
+:::
+
 ::: tip Want to explore before installing?
 Open the [live demo](https://demo.jobctrl.dev) for an interactive workspace
 with synthetic browser-local data, or use the [Product Tour](product-tour.md)

--- a/launcher/internal/installer/installer_test.go
+++ b/launcher/internal/installer/installer_test.go
@@ -739,6 +739,70 @@ func TestNetworkChannelPointerResolvesOnlyItsImmutablePair(t *testing.T) {
 	}
 }
 
+func TestSignedVersionResetUsesMonotonicSequenceInsteadOfAppSemver(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const origin = "https://releases.jobctrl.dev"
+	const revokedBuild = "2.0.7-db257efe1087ec00ac2ec49b846a95d2423aecc2-darwin-arm64"
+	oldBuild := "2.0.8-" + strings.Repeat("a", 40) + "-darwin-arm64"
+	oldDescriptor := stableDescriptor(origin + "/v1/artifacts/" + oldBuild + "/jobctrl-2.0.8-darwin-arm64.zip")
+	oldDescriptor.Sequence = 2
+	oldDescriptor.MinimumSafeSequence = 2
+	oldDescriptor.RevokedBuildIDs = []string{revokedBuild}
+	oldDescriptor.BuildID = oldBuild
+	oldDescriptor.AppVersion = "2.0.8"
+
+	newBuild := "0.1.0-" + strings.Repeat("b", 40) + "-darwin-arm64"
+	newDescriptor := stableDescriptor(origin + "/v1/artifacts/" + newBuild + "/jobctrl-0.1.0-darwin-arm64.zip")
+	newDescriptor.Sequence = 3
+	newDescriptor.MinimumSafeSequence = 2
+	newDescriptor.RevokedBuildIDs = []string{revokedBuild}
+	newDescriptor.BuildID = newBuild
+	newDescriptor.AppVersion = "0.1.0"
+	newDescriptor.SourceCommit = strings.Repeat("b", 40)
+
+	_, descriptorRaw, signatureRaw, pointer, pointerRaw := signedChannelPointerFixtureFromDescriptor(t, private, origin, newDescriptor)
+	client, _ := channelPointerClient(map[string][]byte{
+		mustDefaultReleaseURL(t, "stable"): pointerRaw,
+		pointer.Descriptor.URL:             descriptorRaw,
+		pointer.Signature.URL:              signatureRaw,
+	})
+	resolved, _, _, err := resolveNetworkRelease(Options{
+		Policy:     launcher.AcquisitionPolicy{ExpectedChannel: "stable", AllowNetwork: true},
+		Trust:      map[string]ed25519.PublicKey{"jobctrl-release-v1": public},
+		HTTPClient: client,
+	}, client)
+	if err != nil {
+		t.Fatalf("resolve signed 0.1.0 reset: %v", err)
+	}
+	if resolved.AppVersion != "0.1.0" || resolved.Sequence != 3 || resolved.MinimumSafeSequence != 2 {
+		t.Fatalf("resolved reset descriptor = %#v", resolved)
+	}
+
+	store, err := release.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RecordMetadata("stable", 2, 2, oldDescriptor.BuildID, strings.Repeat("2", 64), oldDescriptor.RevokedBuildIDs); err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.RecordMetadata("stable", resolved.Sequence, resolved.MinimumSafeSequence, resolved.BuildID, digestBytes(descriptorRaw), resolved.RevokedBuildIDs)
+	if err != nil {
+		t.Fatalf("record higher-sequence lower-SemVer release: %v", err)
+	}
+	if state.MaxSequence != 3 || state.MinimumSafeSequence != 2 || state.RevokedBuildIDs[oldBuild] {
+		t.Fatalf("reset changed monotonic policy or revoked the safe predecessor: %#v", state)
+	}
+	if _, err := store.RecordMetadata("stable", 2, 2, "0.0.9-"+strings.Repeat("c", 40)+"-darwin-arm64", strings.Repeat("3", 64), []string{revokedBuild}); err == nil {
+		t.Fatal("accepted a lower signed sequence after the version reset")
+	}
+	if _, err := store.RecordMetadata("stable", 3, 2, "0.1.0-"+strings.Repeat("c", 40)+"-darwin-arm64", strings.Repeat("4", 64), []string{revokedBuild}); err == nil {
+		t.Fatal("accepted a reused signed sequence for a different build")
+	}
+}
+
 func TestNetworkChannelPointerHashesBothImmutableFilesBeforeSignatureVerification(t *testing.T) {
 	_, private, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
@@ -1221,6 +1285,11 @@ func signedChannelPointerFixtureAtOrigin(t *testing.T, private ed25519.PrivateKe
 	t.Helper()
 	descriptor := stableDescriptor(origin + "/v1/artifacts/fixture-build-0001/jobctrl-2.0.0-darwin-arm64.zip")
 	descriptor.Channel = channel
+	return signedChannelPointerFixtureFromDescriptor(t, private, origin, descriptor)
+}
+
+func signedChannelPointerFixtureFromDescriptor(t *testing.T, private ed25519.PrivateKey, origin string, descriptor Descriptor) (Descriptor, []byte, []byte, channelPointer, []byte) {
+	t.Helper()
 	descriptorRaw, err := json.Marshal(descriptor)
 	if err != nil {
 		t.Fatal(err)
@@ -1236,11 +1305,11 @@ func signedChannelPointerFixtureAtOrigin(t *testing.T, private ed25519.PrivateKe
 		BuildID:       descriptor.BuildID,
 		Sequence:      descriptor.Sequence,
 		Descriptor: pointerAsset{
-			URL:    origin + "/v1/artifacts/fixture-build-0001/release-descriptor.json",
+			URL:    origin + "/v1/artifacts/" + descriptor.BuildID + "/release-descriptor.json",
 			SHA256: digestBytes(descriptorRaw),
 		},
 		Signature: pointerAsset{
-			URL:    origin + "/v1/artifacts/fixture-build-0001/release-descriptor.json.sig",
+			URL:    origin + "/v1/artifacts/" + descriptor.BuildID + "/release-descriptor.json.sig",
 			SHA256: digestBytes(signatureRaw),
 		},
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jobctrl",
-  "version": "2.0.8",
+  "version": "0.1.0",
   "private": true,
   "description": "AI-powered end-to-end job application pipeline",
   "type": "module",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api-client",
-  "version": "2.0.8",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/contracts",
-  "version": "2.0.8",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/domain-types/package.json
+++ b/packages/domain-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/domain-types",
-  "version": "2.0.8",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/tsconfig",
-  "version": "2.0.8",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packaging/homebrew/Formula/jobctrl.rb.tmpl
+++ b/packaging/homebrew/Formula/jobctrl.rb.tmpl
@@ -12,6 +12,7 @@ class Jobctrl < Formula
 
   url "{{ARTIFACT_URL}}"
   version "{{APP_VERSION}}"
+  version_scheme 1
   sha256 "{{ARTIFACT_SHA256}}"
   license "AGPL-3.0-only"
 

--- a/scripts/check-docs-site-runtime.mjs
+++ b/scripts/check-docs-site-runtime.mjs
@@ -200,7 +200,7 @@ const LIFECYCLE_EXPLANATION_CONTRACTS = [
     labels: [
       "Fetch once, then walk the configured extraction cascade.",
       "Verify active state independently.",
-      "Assign confidence from the extraction evidence.",
+      "Assign confidence from the posting-content evidence.",
       "Quarantine instead of guessing.",
       "Surface duplicate candidates from content evidence.",
     ],

--- a/scripts/distribution-homebrew.mjs
+++ b/scripts/distribution-homebrew.mjs
@@ -133,6 +133,7 @@ export function validateRenderedHomebrewFormula({ formula, descriptor, descripto
     `url "${values.ARTIFACT_URL}"`,
     `sha256 "${values.ARTIFACT_SHA256}"`,
     `version "${values.APP_VERSION}"`,
+    "version_scheme 1",
     `JOBCTRL_BUILD_ID = "${values.BUILD_ID}"`,
     `JOBCTRL_MANIFEST_SHA256 = "${values.MANIFEST_SHA256}"`,
     `JOBCTRL_DESCRIPTOR_URL = "${values.DESCRIPTOR_URL}"`,

--- a/scripts/distribution-homebrew.render.bundle.mjs
+++ b/scripts/distribution-homebrew.render.bundle.mjs
@@ -13982,6 +13982,7 @@ function validateRenderedHomebrewFormula({ formula, descriptor, descriptorRaw, s
     `url "${values.ARTIFACT_URL}"`,
     `sha256 "${values.ARTIFACT_SHA256}"`,
     `version "${values.APP_VERSION}"`,
+    "version_scheme 1",
     `JOBCTRL_BUILD_ID = "${values.BUILD_ID}"`,
     `JOBCTRL_MANIFEST_SHA256 = "${values.MANIFEST_SHA256}"`,
     `JOBCTRL_DESCRIPTOR_URL = "${values.DESCRIPTOR_URL}"`,

--- a/scripts/distribution-homebrew.render.bundle.mjs.sha256
+++ b/scripts/distribution-homebrew.render.bundle.mjs.sha256
@@ -1,2 +1,2 @@
-0701bbacb92771005b705930a92216ed1582d58fc0060e04fc055df25bf30cfe  distribution-homebrew.render.bundle.mjs
+156b3d8ec71db3cc6a45dc7af24e8182e02780be067a71332e353098b39a525b  distribution-homebrew.render.bundle.mjs
 9be48ff9788de9019949ff648926aba81d270ca21a9f86a4b18d7a8f1760d4d7  distribution-release-authority-bundles.NOTICE.txt

--- a/scripts/distribution-homebrew.test.mjs
+++ b/scripts/distribution-homebrew.test.mjs
@@ -70,6 +70,7 @@ test("Homebrew render uses the exact signed curl ZIP identity without a toolchai
   await writeFile(formulaPath, rendered.formula);
   assert.equal(validateRenderedHomebrewFormula({ formula: rendered.formula, descriptor: stableDescriptor(), descriptorRaw, signatureRaw, descriptorUrl }), true);
   assert.match(rendered.formula, /url "https:\/\/releases\.jobctrl\.dev\/v1\/artifacts\/stable-build-0000042\/jobctrl-2\.0\.0-darwin-arm64\.zip"/);
+  assert.match(rendered.formula, /^\s*version_scheme 1$/m);
   assert.match(rendered.formula, /JOBCTRL_MANIFEST_SHA256 = "b{64}"/);
   assert.match(rendered.formula, /JOBCTRL_BUILD_ID = "stable-build-0000042"/);
   assert.match(rendered.formula, /resource "jobctrl-release-descriptor"/);
@@ -218,6 +219,10 @@ test("Homebrew formula validation rejects a render that omits launcher or Chromi
   const signatureRaw = `${JSON.stringify(signed.signature, null, 2)}\n`;
   const descriptorUrl = stableDescriptorUrl();
   const rendered = await renderHomebrewFormula({ descriptorRaw, signatureRaw, descriptorUrl, trust: signed.trust });
+  assert.throws(
+    () => validateRenderedHomebrewFormula({ formula: rendered.formula.replace("  version_scheme 1\n", ""), descriptor: stableDescriptor(), descriptorRaw, signatureRaw, descriptorUrl }),
+    /version_scheme 1/,
+  );
   assert.throws(
     () => validateRenderedHomebrewFormula({ formula: rendered.formula.replace('verify_notarized_executable!(buildpath/"launcher/jobctrl")', ""), descriptor: stableDescriptor(), descriptorRaw, signatureRaw, descriptorUrl }),
     /launcher\/jobctrl/,

--- a/scripts/distribution-manifest.test.mjs
+++ b/scripts/distribution-manifest.test.mjs
@@ -97,7 +97,7 @@ test("distribution contracts are complete and every version source resolves", as
   assert.equal(report.nodeLicenseEvidenceCount, 13);
   assert.equal(report.capabilityCount, 3);
   assert.deepEqual(report.platforms, ["darwin-arm64"]);
-  assert.equal(report.versions["jobctrl-launcher"], "2.0.8");
+  assert.equal(report.versions["jobctrl-launcher"], "0.1.0");
   assert.equal(report.versions["playwright-python"], "1.58.0");
   assert.equal(report.versions["font-geist"], "5.2.9");
   assert.equal(report.versions["font-jetbrains-mono"], "5.2.8");

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -186,7 +186,7 @@ test("release CLI rejects non-canonical owner-supplied integers", async (context
 async function writePyPIGateFixture(root, { privateKey, sourceCommit = "a".repeat(40) }) {
   const keyId = "jobctrl-release-v1";
   const publicKeyBase64 = releasePublicKeyBase64(privateKey);
-  const archiveFile = "jobctrl-2.0.0-darwin-arm64.zip";
+  const archiveFile = "jobctrl-0.1.0-darwin-arm64.zip";
   const archive = Buffer.from("fixture P6 archive\n");
   const manifestRaw = '{"fixture":"signed-manifest"}\n';
   const urls = canonicalReleaseUrls("stable", archiveFile, "stable-build-0000042");
@@ -197,7 +197,7 @@ async function writePyPIGateFixture(root, { privateKey, sourceCommit = "a".repea
     minimumSafeSequence: 1,
     revokedBuildIds: [],
     buildId: "stable-build-0000042",
-    appVersion: "2.0.0",
+    appVersion: "0.1.0",
     sourceCommit,
     platform: { id: "darwin-arm64", os: "darwin", arch: "arm64" },
     artifact: {
@@ -298,10 +298,10 @@ test("local fixture release descriptor, signature, and curl contract bind one ZI
     minimumSafeSequence: 0,
     revokedBuildIds: [],
     buildId: "fixture-build-0001",
-    appVersion: "2.0.8",
+    appVersion: "0.1.0",
     platform: { id: "darwin-arm64", os: "darwin", arch: "arm64" },
     artifact: {
-      url: "file:///jobctrl-local-release/jobctrl-2.0.8-darwin-arm64.zip",
+      url: "file:///jobctrl-local-release/jobctrl-0.1.0-darwin-arm64.zip",
       sha256: build.archiveSha256,
       sizeBytes: build.compressedBytes,
       archiveType: "zip",
@@ -732,7 +732,7 @@ test("PyPI promotion binds signed source provenance to protected external releas
   const trustedFixture = await writePyPIGateFixture(trustedRoot, { privateKey: trusted.privateKey, sourceCommit });
   await assert.doesNotReject(verifyPyPIReleaseGate({
     releaseDirectory: trustedRoot,
-    expectedTag: "v2.0.0",
+    expectedTag: "v0.1.0",
     sourceCommit,
     expectedPublicKeyBase64: trustedFixture.publicKeyBase64,
     expectedKeyId: trustedFixture.keyId,
@@ -744,7 +744,7 @@ test("PyPI promotion binds signed source provenance to protected external releas
   await writePyPIGateFixture(attackerRoot, { privateKey: attacker.privateKey, sourceCommit });
   await assert.rejects(verifyPyPIReleaseGate({
     releaseDirectory: attackerRoot,
-    expectedTag: "v2.0.0",
+    expectedTag: "v0.1.0",
     sourceCommit,
     expectedPublicKeyBase64: trustedFixture.publicKeyBase64,
     expectedKeyId: trustedFixture.keyId,

--- a/scripts/docs-launch-copy.test.mjs
+++ b/scripts/docs-launch-copy.test.mjs
@@ -18,6 +18,8 @@ test("public onboarding leads with bundled acquisition and keeps source advanced
     assert.match(document, /curl -fsSL https:\/\/jobctrl\.dev\/install\.sh \| sh/);
     assert.match(document, /brew install ebarti\/tap\/jobctrl/);
     assert.match(document, /jobctrl start/);
+    assert.match(document, /0\.1\.0/);
+    assert.match(document, /early.access/i);
   }
 
   const installer = gettingStarted.indexOf("### Recommended: bundled installer");
@@ -57,11 +59,13 @@ test("public onboarding leads with bundled acquisition and keeps source advanced
     await read("docs/user/normal-flows.md"),
     await read("docs/user/configuration.md"),
     await read("docs/user/data-and-safety.md"),
+    await read("LAUNCH_CHECKLIST.md"),
   ].join("\n");
   assert.doesNotMatch(
     publicCopy,
     /not published yet|not public yet|only public path|current public path|after the first signed bundled release|public channel remains blocked|unpublished bundled product/i,
   );
+  assert.doesNotMatch(publicCopy, /(?:current|latest)[^\n]{0,80}2\.0\.8|2\.0\.8[^\n]{0,80}(?:current|latest)/i);
 
   const claimsLedger = await read("docs/claims-ledger.md");
   assert.match(claimsLedger, /\| CL-082 \|[^\n]+\| Roadmap \|/);

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -889,6 +889,10 @@ def _homebrew_sync_findings(root: Path) -> list[str]:
         findings.append(
             f"{HOMEBREW_FORMULA_TEMPLATE_PATH}: does not define the Jobctrl formula template"
         )
+    if not re.search(r"(?m)^\s*version_scheme 1\s*$", template):
+        findings.append(
+            f"{HOMEBREW_FORMULA_TEMPLATE_PATH}: must preserve Homebrew version_scheme 1 after the public SemVer reset"
+        )
     if "depends_on" in template or re.search(r"(?m)^\s*head\s+", template):
         findings.append(
             f"{HOMEBREW_FORMULA_TEMPLATE_PATH}: must not declare Homebrew dependencies or a HEAD source path"

--- a/scripts/version-contract.test.mjs
+++ b/scripts/version-contract.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const root = new URL("../", import.meta.url);
+const read = (path) => readFile(new URL(path, root), "utf8");
+const readJson = async (path) => JSON.parse(await read(path));
+const APP_VERSION = "0.1.0";
+
+test("public application versions agree without resetting compatibility counters", async () => {
+  const packageVersions = await Promise.all([
+    "package.json",
+    "apps/api/package.json",
+    "apps/extension/package.json",
+    "apps/web/package.json",
+    "packages/api-client/package.json",
+    "packages/contracts/package.json",
+    "packages/domain-types/package.json",
+    "packages/tsconfig/package.json",
+  ].map(async (path) => [path, (await readJson(path)).version]));
+  for (const [path, version] of packageVersions) {
+    assert.equal(version, APP_VERSION, `${path} must carry the public application version`);
+  }
+
+  assert.equal((await readJson("apps/extension/public/manifest.json")).version, APP_VERSION);
+  assert.match(await read("workers/automation/pyproject.toml"), /^version = "0\.1\.0"$/m);
+  assert.match(await read("workers/automation/src/jobctrl/__init__.py"), /^__version__ = "0\.1\.0"$/m);
+  assert.match(
+    await read("workers/automation/uv.lock"),
+    /\[\[package\]\]\nname = "jobctrl"\nversion = "0\.1\.0"\nsource = \{ editable = "\." \}/,
+  );
+
+  assert.match(await read("apps/api/src/schema-manifest.ts"), /EXACT_V7_SCHEMA_MANIFEST[\s\S]*?version: 7,/);
+  assert.match(await read("workers/automation/src/jobctrl/database.py"), /^SCHEMA_VERSION = 7$/m);
+  assert.equal((await readJson("launcher/runtime-manifest.json")).launcherProtocol, 1);
+  assert.match(await read("launcher/internal/launcher/launcher.go"), /^\s*launcherProtocol\s+= 1$/m);
+  assert.match(await read("launcher/internal/launcher/launcher.go"), /^\s*stateSchemaVersion\s+= 1$/m);
+  const platforms = await readJson("packaging/distribution/platforms.json");
+  assert.deepEqual(platforms.platforms[0].launcherCompatibility, { minimum: 1, maximum: 1 });
+});
+
+test("release parity gate accepts the reset tag v0.1.0", async () => {
+  const { stdout, stderr } = await execFileAsync(
+    "python3",
+    ["scripts/release_check.py", "--release-tag", "v0.1.0"],
+    { cwd: new URL("../", import.meta.url), maxBuffer: 16 * 1024 * 1024 },
+  );
+  assert.equal(stderr, "");
+  assert.match(stdout, /release check passed/i);
+});

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jobctrl"
-version = "2.0.8"
+version = "0.1.0"
 description = "AI-powered end-to-end job application pipeline"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/workers/automation/src/jobctrl/__init__.py
+++ b/workers/automation/src/jobctrl/__init__.py
@@ -1,3 +1,3 @@
 """JobCtrl — AI-powered end-to-end job application pipeline."""
 
-__version__ = "2.0.8"
+__version__ = "0.1.0"

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -689,7 +689,7 @@ def test_built_distribution_metadata_must_match_project_version(tmp_path: Path) 
 def _write_homebrew_p4_contract(tmp_path: Path, workflow: str | None = None) -> None:
     _write(
         tmp_path / release_check.HOMEBREW_FORMULA_TEMPLATE_PATH,
-        'class Jobctrl < Formula\n  url "{{ARTIFACT_URL}}"\nend\n',
+        'class Jobctrl < Formula\n  url "{{ARTIFACT_URL}}"\n  version_scheme 1\nend\n',
     )
     _write(tmp_path / release_check.HOMEBREW_FORMULA_GENERATOR_PATH, "// generator\n")
     _write(tmp_path / release_check.HOMEBREW_RELEASE_TRUST_PATH, '{"schemaVersion": 1, "keys": {}}\n')
@@ -715,6 +715,22 @@ def test_homebrew_tap_sync_requires_reusable_signed_render_gate(tmp_path: Path) 
     )
 
     assert release_check._homebrew_sync_findings(tmp_path) == []
+
+
+def test_homebrew_template_requires_version_scheme_after_public_reset(tmp_path: Path) -> None:
+    workflow = (
+        release_check.ROOT / release_check.HOMEBREW_SYNC_WORKFLOW_PATH
+    ).read_text(encoding="utf-8")
+    _write_homebrew_p4_contract(tmp_path, workflow)
+    _write(
+        tmp_path / release_check.HOMEBREW_FORMULA_TEMPLATE_PATH,
+        'class Jobctrl < Formula\n  url "{{ARTIFACT_URL}}"\nend\n',
+    )
+
+    assert release_check._homebrew_sync_findings(tmp_path) == [
+        "packaging/homebrew/Formula/jobctrl.rb.tmpl: must preserve Homebrew "
+        "version_scheme 1 after the public SemVer reset"
+    ]
 
 
 def test_homebrew_tap_key_is_resolved_only_behind_publication_environment() -> None:
@@ -768,7 +784,8 @@ def test_homebrew_template_rejects_toolchain_or_head_spec(tmp_path: Path) -> Non
     )
     _write(
         tmp_path / release_check.HOMEBREW_FORMULA_TEMPLATE_PATH,
-        'class Jobctrl < Formula\n  depends_on "corepack"\n  head "https://example.test/jobctrl.git"\nend\n',
+        'class Jobctrl < Formula\n  version_scheme 1\n  depends_on "corepack"\n'
+        '  head "https://example.test/jobctrl.git"\nend\n',
     )
 
     assert release_check._homebrew_sync_findings(tmp_path) == [

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "jobctrl"
-version = "2.0.8"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## What changed

- resets every canonical JobCtrl public application-version source from `2.0.8` to `0.1.0`
- preserves database schema v7, launcher protocol/state schema 1, migrations, build identities, and signed anti-rollback counters
- requires Homebrew `version_scheme 1` in the template, renderer, generated release-authority bundle, tests, and release preflight
- adds updater coverage for accepting `0.1.0` at signed sequence 3 after `2.0.8` at sequence 2 while rejecting lower or reused sequences
- updates public copy and the release record to describe `0.1.0` as early access and the `2.0.x` line as preserved withdrawn pre-launch numbering
- repairs a stale docs-runtime assertion so it matches the owning enrichment documentation

## Why

The reset makes the public version communicate JobCtrl's actual early-access maturity. It is not a product, data, schema, protocol, or security downgrade. Existing tags, releases, signatures, artifacts, and the safe `v2.0.8` build remain immutable. The next signed release remains sequence 3 with minimum-safe sequence 2 and only the existing `v2.0.7` build revoked.

## Validation

- `corepack pnpm check`
- `corepack pnpm test` — Python 3,479 passed / 2 skipped; Go race suite passed
- focused version, distribution, Homebrew, release/PyPI, and public-copy tests — 61 passed
- `corepack pnpm distribution:audit`
- `corepack pnpm docs:build` — 9,651 emitted references resolved
- `corepack pnpm docs:check:runtime` — PASS
- `corepack pnpm web:test-d` — 11 files / 13 tests, no type errors
- `python3 scripts/release_check.py --strict-prompt --release-tag v0.1.0`
- isolated Python wheel/sdist build — both report `Version: 0.1.0`
- `git diff --check`

Independent Tier 3 gates: reviewer PASS (0 Blocker, 0 High; reported Medium release-instruction contradiction resolved before commit) and QA PASS (0 Blocker, 0 High, 0 Medium, 0 Low).
