### PR TITLE
fix(compensation): clarify salary evidence decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,12 @@ evidence, qualifications, and the complete capability matrix.
   seven-day-old slices. When a country has no direct benchmark, it can derive a
   range from an exact foreign anchor using official cost-of-living evidence and
   same-company cross-country pay ratios. The Jobs UI exposes the direct or
-  extrapolated authority, sample size, freshness, exact bridge inputs, formula,
-  confidence, and out-of-bounds warnings instead of presenting an unexplained
-  number. See [Compensation Evidence](docs/user/compensation-evidence.md).
+  extrapolated range as the primary answer. If the evidence is not reliable
+  enough, it withholds the number and explains why. Evidence records, reported
+  sample counts, matching scores, freshness, bridge inputs, formula, and
+  warnings stay inspectable in expandable details rather than competing with
+  the result. See
+  [Compensation Evidence](docs/user/compensation-evidence.md).
 - Keep each job under one tenant-scoped, immutable `JobId`. Posting and
   application URLs are locators resolved only at explicit capture/import/API
   boundaries, so a URL change cannot detach scores, materials, outcomes, or

--- a/apps/api/src/posted-compensation-facts.ts
+++ b/apps/api/src/posted-compensation-facts.ts
@@ -21,7 +21,13 @@ type PostedCompensationFactRow = {
   parse_state: "missing" | "unparseable" | "ambiguous" | "parsed_range";
   currency: string | null;
   period: "hour" | "month" | "year" | "unknown";
-  component: "base_salary" | "ote" | "bonus" | "commission" | "equity" | "unknown";
+  component:
+    | "base_salary"
+    | "ote"
+    | "bonus"
+    | "commission"
+    | "equity"
+    | "unknown";
   minimum_amount: number | null;
   maximum_amount: number | null;
   annualized_minimum_amount: number | null;
@@ -35,19 +41,23 @@ type PostedCompensationFactRow = {
 };
 
 const WARNING_MESSAGES: Record<PostedCompensationWarningCode, string> = {
-  ambiguous_multiple_amounts: "Multiple compensation amounts were present and the primary range is ambiguous.",
+  ambiguous_multiple_amounts:
+    "Multiple compensation amounts were present and the primary range is ambiguous.",
   bonus_component: "The source text mentions bonus compensation.",
   broad_range: "The posted range is broad enough to reduce precision.",
   commission_component: "The source text mentions commission compensation.",
-  equity_component: "The source text mentions equity or stock compensation.",
+  equity_component:
+    "The posting mentions stock or equity compensation; review the amount type below.",
   hourly_period: "The source text uses an hourly compensation period.",
   missing_currency: "The parser could not identify an explicit currency.",
-  missing_period: "The parser could not identify an explicit compensation period.",
+  missing_period:
+    "The parser could not identify an explicit compensation period.",
   monthly_period: "The source text uses a monthly compensation period.",
   no_amount_found: "No compensation amount could be safely extracted.",
   one_sided_range: "The posted range is one-sided.",
   ote_component: "The source text mentions on-target earnings.",
-  source_text_truncated: "The stored source text was truncated to the bounded salary excerpt limit.",
+  source_text_truncated:
+    "Only a bounded posting excerpt is stored; the excerpt below shows exactly what was parsed.",
 };
 
 export function getPostedCompensationFact(
@@ -143,7 +153,10 @@ function mapFactRow(row: PostedCompensationFactRow): PostedCompensationFact {
     annualizedMinimumAmount: nullableNumber(row.annualized_minimum_amount),
     annualizedMaximumAmount: nullableNumber(row.annualized_maximum_amount),
     annualizationAssumption: nullableText(row.annualization_assumption),
-    confidence: row.confidence === "high" || row.confidence === "medium" ? row.confidence : "low",
+    confidence:
+      row.confidence === "high" || row.confidence === "medium"
+        ? row.confidence
+        : "low",
   };
 }
 
@@ -158,7 +171,9 @@ function parseWarnings(value: string): PostedCompensationWarning[] {
     return [];
   }
   return parsed
-    .filter((entry): entry is PostedCompensationWarningCode => isWarningCode(entry))
+    .filter((entry): entry is PostedCompensationWarningCode =>
+      isWarningCode(entry),
+    )
     .map((code) => ({ code, message: WARNING_MESSAGES[code] }));
 }
 

--- a/apps/web/e2e/tests/jobs-drawer.spec.ts
+++ b/apps/web/e2e/tests/jobs-drawer.spec.ts
@@ -1,7 +1,7 @@
 import Database from "better-sqlite3";
 import { test, expect, type Locator, type Page } from "@playwright/test";
 
-import { QA_PLATFORM_JOB_ID } from "../fixtures/e2e-state.js";
+import { loadE2eDbPath, QA_PLATFORM_JOB_ID } from "../fixtures/e2e-state.js";
 
 const FILTER_PARAMS =
   "stage=all&state=all&deleted=active&sort=fit_score&dir=desc&page=1&pageSize=50";
@@ -42,19 +42,12 @@ function watchProhibitedProductPathRequests(page: Page): string[] {
 }
 
 function seedSyntheticCompensationData(): void {
-  const dbPath = process.env["JOBCTRL_E2E_DB_PATH"];
-  if (!dbPath) {
-    throw new Error(
-      "JOBCTRL_E2E_DB_PATH is required for Jobs compensation e2e data.",
-    );
-  }
+  const dbPath = loadE2eDbPath();
   const db = new Database(dbPath);
   try {
-    db.prepare("UPDATE jobs SET salary = ? WHERE tenant_id = ? AND job_id = ?").run(
-      "€55,000/year",
-      "local",
-      QA_PLATFORM_JOB_ID,
-    );
+    db.prepare(
+      "UPDATE jobs SET salary = ? WHERE tenant_id = ? AND job_id = ?",
+    ).run("€55,000/year", "local", QA_PLATFORM_JOB_ID);
     db.prepare(
       `INSERT INTO job_posted_compensation_facts (
         tenant_id, job_id, source_field, source_text, legacy_raw_salary,
@@ -106,10 +99,10 @@ function seedSyntheticCompensationData(): void {
         minimum_amount, maximum_amount, confidence_band, confidence_score,
         source_count, sample_count, aggregate_bucket, geography_scope,
         occupation_code, occupation_label, seniority_label, source_snapshot_json,
-        factor_reasons_json, insufficient_reasons_json, unsupported_reasons_json,
+        factor_reasons_json, selected_evidence_json, insufficient_reasons_json, unsupported_reasons_json,
         source_unavailable_reasons_json, warnings_json, estimator_version, estimated_at,
         company_name, normalized_company, role_title, normalized_role, company_tier, match_scope
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(tenant_id, job_id) DO UPDATE SET
         estimate_state = excluded.estimate_state,
         currency = excluded.currency,
@@ -125,6 +118,7 @@ function seedSyntheticCompensationData(): void {
         geography_scope = excluded.geography_scope,
         source_snapshot_json = excluded.source_snapshot_json,
         factor_reasons_json = excluded.factor_reasons_json,
+        selected_evidence_json = excluded.selected_evidence_json,
         warnings_json = excluded.warnings_json,
         estimator_version = excluded.estimator_version,
         estimated_at = excluded.estimated_at,
@@ -179,6 +173,52 @@ function seedSyntheticCompensationData(): void {
       JSON.stringify([
         { name: "company", score: 1, band: "high", reason: "Company matched." },
         { name: "role", score: 1, band: "high", reason: "Role matched." },
+      ]),
+      JSON.stringify([
+        {
+          source_id: "levels_fyi",
+          source_url:
+            "https://www.levels.fyi/companies/gitlab/salaries/software-engineer",
+          company_name: "GitLab",
+          role_title: "Director of Platform Engineering",
+          location: "Europe",
+          level_label: "director",
+          company_tier: "tier_2_ambitious",
+          component: "total_compensation",
+          currency: "EUR",
+          period: "year",
+          minimum_amount: 112_000,
+          maximum_amount: 138_000,
+          sample_count: 4,
+          release_year: 2026,
+          company_score: 1,
+          role_score: 0.96,
+          level_score: 0.95,
+          location_score: 0.78,
+          freshness_score: 0.95,
+        },
+        {
+          source_id: "glassdoor",
+          source_url:
+            "https://www.glassdoor.com/Salary/GitLab-Engineering-Director-Salaries-E1296544.htm",
+          company_name: "GitLab",
+          role_title: "Engineering Director",
+          location: "Europe",
+          level_label: "director",
+          company_tier: "tier_2_ambitious",
+          component: "total_compensation",
+          currency: "EUR",
+          period: "year",
+          minimum_amount: 118_000,
+          maximum_amount: 142_000,
+          sample_count: 3,
+          release_year: 2026,
+          company_score: 1,
+          role_score: 0.92,
+          level_score: 0.95,
+          location_score: 0.78,
+          freshness_score: 0.95,
+        },
       ]),
       "[]",
       "[]",
@@ -353,12 +393,12 @@ test("Jobs compensation source-conflict evidence stays product-visible without u
   await expect(
     compensation.getByText("EUR 112000-142000/year").first(),
   ).toBeVisible();
-  await expect(
-    compensation.getByText("reported_compensation_sample"),
-  ).toBeVisible();
-  await expect(
-    compensation.getByText("source_conflict_with_posted_salary"),
-  ).toBeVisible();
+  await expect(compensation.getByText("Market salary estimate")).toBeVisible();
+  await expect(compensation.getByText(/medium reliability/i)).toBeVisible();
+  await expect(compensation.getByText("Evidence reviewed")).toBeVisible();
+  await expect(compensation.getByText("How this was assessed")).toBeVisible();
+  await compensation.getByText("Evidence reviewed").click();
+  await compensation.getByText("How this was assessed").click();
   await expect(
     compensation.getByText(
       "Reported compensation diverges materially from the posted salary.",
@@ -372,7 +412,10 @@ test("Jobs compensation source-conflict evidence stays product-visible without u
   await expect(compensation.getByText("Reported source trail")).toBeVisible();
   await expect(compensation.getByText("Levels.fyi").first()).toBeVisible();
   await expect(compensation.getByText("Glassdoor").first()).toBeVisible();
-  await expect(compensation.getByText("Confidence factors")).toBeVisible();
+  await expect(compensation.getByText("Reliability factors")).toBeVisible();
+  await expect(
+    compensation.getByText("Observation JSON path (optional)"),
+  ).toHaveCount(0);
 
   await expect(triage.getByText("reported_compensation_sample")).toHaveCount(0);
   await expect(

--- a/apps/web/src/contexts/enrichment/components/CompensationEvidence.test.tsx
+++ b/apps/web/src/contexts/enrichment/components/CompensationEvidence.test.tsx
@@ -1,0 +1,428 @@
+import type {
+  JobCompensationAudit,
+  JobCompensationSummary,
+  MarketCompensationDirectBenchmarkLineage,
+} from "@jobctrl/contracts";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  sampleCompensationAudit,
+  sampleCompensationSummary,
+} from "../../../test/fixtures/projections.js";
+import { CompensationAuditSection } from "./CompensationEvidence.js";
+
+function recordedAudit() {
+  if (
+    sampleCompensationAudit.posted.recordStatus !== "recorded" ||
+    sampleCompensationAudit.posted.fact.parseState !== "parsed_range" ||
+    sampleCompensationAudit.market.recordStatus !== "recorded" ||
+    sampleCompensationAudit.market.estimate.estimateState !== "estimated_range"
+  ) {
+    throw new Error("compensation fixtures must contain recorded ranges");
+  }
+  return {
+    posted: sampleCompensationAudit.posted.fact,
+    market: sampleCompensationAudit.market.estimate,
+  };
+}
+
+function renderCompensation({
+  summary = sampleCompensationSummary,
+  audit = sampleCompensationAudit,
+  fallbackSalary = null,
+}: {
+  readonly summary?: JobCompensationSummary | null;
+  readonly audit?: JobCompensationAudit | null;
+  readonly fallbackSalary?: string | null;
+} = {}) {
+  render(
+    <CompensationAuditSection
+      audit={audit}
+      fallbackSalary={fallbackSalary}
+      summary={summary}
+    />,
+  );
+  return screen.getByRole("region", { name: "Compensation evidence" });
+}
+
+describe("<CompensationAuditSection>", () => {
+  it("labels an explicitly priced stock amount as equity rather than additive cash", () => {
+    const { posted } = recordedAudit();
+    const audit: JobCompensationAudit = {
+      ...sampleCompensationAudit,
+      posted: {
+        ok: true,
+        recordStatus: "recorded",
+        fact: {
+          ...posted,
+          sourceText: "Equity compensation: USD 100,000/year in stock options.",
+          component: "equity",
+          currency: "USD",
+          minimumAmount: 100_000,
+          maximumAmount: 100_000,
+          annualizedMinimumAmount: 100_000,
+          annualizedMaximumAmount: 100_000,
+          parserVersion: "posted-compensation-v2",
+          warnings: [
+            {
+              code: "equity_component",
+              message:
+                "The posting mentions stock or equity compensation; review the amount type below.",
+            },
+          ],
+        },
+      },
+    };
+    const summary: JobCompensationSummary = {
+      ...sampleCompensationSummary,
+      posted: {
+        ...sampleCompensationSummary.posted,
+        range: {
+          ...sampleCompensationSummary.posted.range!,
+          currency: "USD",
+          component: "equity",
+          minimumAmount: 100_000,
+          maximumAmount: 100_000,
+          annualizedMinimumAmount: 100_000,
+          annualizedMaximumAmount: 100_000,
+          displayRange: "USD 100000/year",
+        },
+        displayRange: "USD 100000/year",
+      },
+    };
+
+    const compensation = renderCompensation({ audit, summary });
+
+    expect(
+      within(compensation).getByRole("heading", {
+        level: 4,
+        name: "Employer posted",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText(/employer-stated value of the equity/i),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).queryByText(/cash amount stated/i),
+    ).not.toBeInTheDocument();
+    fireEvent.click(within(compensation).getByText("View posting evidence"));
+    expect(within(compensation).getByText("equity")).toBeInTheDocument();
+  });
+
+  it("distinguishes unavailable sources from weak or dispersed evidence", () => {
+    const { market } = recordedAudit();
+    const audit: JobCompensationAudit = {
+      ...sampleCompensationAudit,
+      market: {
+        ok: true,
+        recordStatus: "recorded",
+        estimate: {
+          ...market,
+          estimateState: "source_unavailable",
+          sources: [],
+          evidence: [],
+          sourceCount: 0,
+          sampleCount: null,
+          sourceUnavailableReasons: [
+            {
+              code: "stale_source_snapshot",
+              message: "The available salary snapshot is stale.",
+            },
+          ],
+        },
+      },
+    };
+    const summary: JobCompensationSummary = {
+      ...sampleCompensationSummary,
+      market: {
+        ...sampleCompensationSummary.market,
+        estimateState: "source_unavailable",
+        sourceCount: 0,
+        sampleCount: null,
+        range: null,
+        displayRange: null,
+        confidenceInterval: null,
+        displayConfidenceInterval: null,
+      },
+    };
+
+    const compensation = renderCompensation({ audit, summary });
+
+    expect(
+      within(compensation).getByText("Market sources unavailable"),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText(/could not be used/i),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText("The available salary snapshot is stale."),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).queryByText(/too dispersed|weakly matched/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("explains unsupported market inputs without claiming evidence was reviewed", () => {
+    const { market } = recordedAudit();
+    const audit: JobCompensationAudit = {
+      ...sampleCompensationAudit,
+      market: {
+        ok: true,
+        recordStatus: "recorded",
+        estimate: {
+          ...market,
+          estimateState: "unsupported",
+          sources: [],
+          evidence: [],
+          sourceCount: 0,
+          sampleCount: null,
+          unsupportedReasons: [
+            {
+              code: "unsupported_component",
+              message: "Equity-only market ranges are not supported.",
+            },
+          ],
+        },
+      },
+    };
+    const summary: JobCompensationSummary = {
+      ...sampleCompensationSummary,
+      market: {
+        ...sampleCompensationSummary.market,
+        estimateState: "unsupported",
+        sourceCount: 0,
+        sampleCount: null,
+        range: null,
+        displayRange: null,
+        confidenceInterval: null,
+        displayConfidenceInterval: null,
+      },
+    };
+
+    const compensation = renderCompensation({ audit, summary });
+
+    expect(
+      within(compensation).getByText("Market range unsupported"),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText(/outside the supported market model/i),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText(
+        "Equity-only market ranges are not supported.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).queryByText(/salary records were reviewed/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows canonical all-level director evidence with aggregate sample counts", () => {
+    const { market } = recordedAudit();
+    const lineage = market.benchmarkLineage;
+    if (!lineage) throw new Error("market fixture must include lineage");
+    const directLineage: MarketCompensationDirectBenchmarkLineage = {
+      kind: "direct",
+      factId: "benchmark-direct-es-privacy-all-levels",
+      taxonomyVersion: lineage.taxonomyVersion,
+      roleFamilyCode: "security_privacy",
+      seniorityLabel: "unknown",
+      targetGeography: lineage.targetGeography,
+      component: lineage.component,
+      asOfDate: lineage.asOfDate,
+      observedAt: lineage.observedAt,
+      freshUntil: lineage.freshUntil,
+      directInputs: lineage.directInputs,
+      priceLevelInputs: [],
+    };
+    const audit: JobCompensationAudit = {
+      ...sampleCompensationAudit,
+      market: {
+        ok: true,
+        recordStatus: "recorded",
+        estimate: {
+          ...market,
+          seniorityLabel: "unknown",
+          roleTitle: "Privacy Engineering Director",
+          normalizedRole: "privacy engineering director",
+          sourceCount: 1,
+          sampleCount: 20,
+          sources: [
+            {
+              ...market.sources[0]!,
+              sampleCount: 20,
+            },
+          ],
+          evidence: [
+            {
+              ...market.evidence[0]!,
+              roleTitle: "Security and privacy engineering",
+              levelLabel: "All levels",
+              sampleCount: 20,
+            },
+          ],
+          factors: [
+            {
+              name: "role",
+              score: 1,
+              band: "high",
+              reason: "Matched canonical role family security_privacy.",
+            },
+            {
+              name: "level",
+              score: 0.72,
+              band: "medium",
+              reason:
+                "Used all-level fallback for the director benchmark slice.",
+            },
+          ],
+          benchmarkLineage: directLineage,
+          estimatorVersion:
+            "company-role-reported-compensation-canonical-benchmark-v1:direct:benchmark-direct-es-privacy-all-levels",
+        },
+      },
+    };
+    const summary: JobCompensationSummary = {
+      ...sampleCompensationSummary,
+      market: {
+        ...sampleCompensationSummary.market,
+        benchmarkKind: "direct",
+        sourceCount: 1,
+        sampleCount: 20,
+      },
+    };
+
+    const compensation = renderCompensation({ audit, summary });
+
+    expect(
+      within(compensation).getByRole("heading", {
+        level: 4,
+        name: "Market salary estimate",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText(
+        /direct benchmark for the matched role family/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText(/uses all-level evidence/i),
+    ).toBeInTheDocument();
+    const evidenceSummary = within(compensation).getByText("Evidence reviewed");
+    expect(evidenceSummary.closest("details")).toHaveTextContent(
+      "1 evidence record · 1 provider · 20 reported samples",
+    );
+    const assessmentSummary = within(compensation).getByText(
+      "How this was assessed",
+    );
+    expect(
+      assessmentSummary.closest("details")?.querySelector("svg"),
+    ).not.toBeNull();
+    fireEvent.click(assessmentSummary);
+    expect(
+      within(compensation).getByText("Benchmark level").closest("div"),
+    ).toHaveTextContent("all levels");
+    expect(
+      within(compensation).getByText(
+        "Matched canonical role family security_privacy.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText(
+        "Used all-level fallback for the director benchmark slice.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).queryByText(/classified as unknown/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps an unparsed employer value visible beside a current market result", () => {
+    const summary: JobCompensationSummary = {
+      ...sampleCompensationSummary,
+      legacyRawSalary: "EUR 95k/year",
+      posted: {
+        sourceKind: "posted",
+        recordStatus: "not_recorded",
+        parseState: null,
+        confidence: "none",
+        warningCount: 0,
+        range: null,
+        displayRange: null,
+      },
+    };
+
+    const compensation = renderCompensation({
+      audit: null,
+      summary,
+    });
+
+    expect(within(compensation).getByText("EUR 95k/year")).toBeInTheDocument();
+    expect(
+      within(compensation).getByText("unparsed posting value"),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText("EUR 112000-142000/year"),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps a raw posting value visible when projections are absent", () => {
+    const compensation = renderCompensation({
+      audit: null,
+      fallbackSalary: "USD 180k-220k",
+      summary: null,
+    });
+
+    expect(within(compensation).getByText("USD 180k-220k")).toBeInTheDocument();
+    expect(
+      within(compensation).getByText("unparsed posting value"),
+    ).toBeInTheDocument();
+  });
+
+  it("uses summary authority without inventing missing detailed evidence counts", () => {
+    const compensation = renderCompensation({
+      audit: null,
+      summary: sampleCompensationSummary,
+    });
+
+    expect(
+      within(compensation).getByText("EUR 112000-142000/year"),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText(
+        /derived from a matched role-family benchmark/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText(
+        /detailed evidence records are unavailable/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText(
+        /summary records 2 providers and 7 reported samples/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).queryByText(/0 evidence records/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("reconstructs posted and market ranges from an audit-only projection", () => {
+    const compensation = renderCompensation({
+      audit: sampleCompensationAudit,
+      summary: null,
+    });
+
+    expect(
+      within(compensation).getAllByText("EUR 70000-90000/year").length,
+    ).toBeGreaterThan(0);
+    expect(
+      within(compensation).getByText("EUR 112000-142000/year"),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).queryByText("No safe amount extracted"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/contexts/enrichment/components/CompensationEvidence.tsx
+++ b/apps/web/src/contexts/enrichment/components/CompensationEvidence.tsx
@@ -1,5 +1,4 @@
-import { IconRefresh } from "@tabler/icons-react";
-import { type FormEvent, useState } from "react";
+import { IconChevronDown, IconRefresh } from "@tabler/icons-react";
 import type {
   JobCompensationAudit,
   JobCompensationAuditMarketEstimate,
@@ -21,12 +20,6 @@ import type {
 
 import { Empty } from "../../../shared/ui/empty.js";
 import { Button } from "../../../shared/ui/button.js";
-import {
-  Field,
-  FieldDescription,
-  FieldLabel,
-} from "../../../shared/ui/field.js";
-import { Input } from "../../../shared/ui/input.js";
 import { StatusBadge } from "../../../shared/ui/status-badge.js";
 import { useRefreshCompensationMutation } from "../hooks/useRefreshCompensationMutation.js";
 
@@ -79,17 +72,24 @@ function optionalCount(value: number | null | undefined): number | null {
   return Number.isFinite(value) ? Number(value) : null;
 }
 
-function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
+function plural(
+  count: number,
+  singular: string,
+  pluralForm = `${singular}s`,
+): string {
   return `${count} ${count === 1 ? singular : pluralForm}`;
 }
 
 function benchmarkSource(market: JobMarketCompensationSummary): string {
   if (market.benchmarkKind === "direct") return "direct market benchmark";
-  if (market.benchmarkKind === "extrapolated") return "geographically extrapolated benchmark";
+  if (market.benchmarkKind === "extrapolated")
+    return "geographically extrapolated benchmark";
   return "reported company-role market";
 }
 
-function formatGeography(geography: MarketCompensationBenchmarkGeography): string {
+function formatGeography(
+  geography: MarketCompensationBenchmarkGeography,
+): string {
   return [geography.locality, geography.subdivisionCode, geography.countryCode]
     .filter(Boolean)
     .join(", ");
@@ -99,7 +99,9 @@ function formatMultiplier(value: number): string {
   return `${Number(value.toFixed(3))}x`;
 }
 
-const amountFormatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
+const amountFormatter = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+});
 
 function formatAmount(value: number): string {
   return amountFormatter.format(value);
@@ -112,6 +114,71 @@ function formatEvidenceRange(row: MarketCompensationEvidenceRow): string {
     return `${prefix}${formatAmount(row.minimumAmount)}${suffix}`;
   }
   return `${prefix}${formatAmount(row.minimumAmount)}-${formatAmount(row.maximumAmount)}${suffix}`;
+}
+
+function formatCompensationRange(
+  currency: string | null | undefined,
+  minimum: number | null | undefined,
+  maximum: number | null | undefined,
+  period: string | null | undefined,
+): string | null {
+  if (minimum === null || minimum === undefined) {
+    return maximum === null || maximum === undefined
+      ? null
+      : `${currency ? `${currency} ` : ""}up to ${maximum}${period ? `/${period}` : ""}`;
+  }
+  const prefix = currency ? `${currency} ` : "";
+  const suffix = period ? `/${period}` : "";
+  if (maximum === null || maximum === undefined) {
+    return `${prefix}${minimum}+${suffix}`;
+  }
+  return minimum === maximum
+    ? `${prefix}${minimum}${suffix}`
+    : `${prefix}${minimum}-${maximum}${suffix}`;
+}
+
+function auditPostedRange(
+  fact: JobCompensationAuditPostedFact,
+): JobPostedCompensationSummary["range"] {
+  if (fact.parseState !== "parsed_range") return null;
+  const displayRange = formatCompensationRange(
+    fact.currency,
+    fact.minimumAmount,
+    fact.maximumAmount,
+    fact.period,
+  );
+  if (!displayRange) return null;
+  return {
+    currency: fact.currency,
+    period: fact.period,
+    component: fact.component,
+    minimumAmount: fact.minimumAmount,
+    maximumAmount: fact.maximumAmount,
+    annualizedMinimumAmount: fact.annualizedMinimumAmount,
+    annualizedMaximumAmount: fact.annualizedMaximumAmount,
+    displayRange,
+  };
+}
+
+function auditMarketRange(
+  estimate: JobCompensationAuditMarketEstimate,
+): JobMarketCompensationSummary["range"] {
+  if (estimate.estimateState !== "estimated_range") return null;
+  const displayRange = formatCompensationRange(
+    estimate.currency,
+    estimate.minimumAmount,
+    estimate.maximumAmount,
+    estimate.period,
+  );
+  if (!displayRange) return null;
+  return {
+    currency: estimate.currency,
+    period: estimate.period,
+    component: estimate.component,
+    minimumAmount: estimate.minimumAmount,
+    maximumAmount: estimate.maximumAmount,
+    displayRange,
+  };
 }
 
 function matchScores(row: MarketCompensationEvidenceRow): string {
@@ -133,25 +200,32 @@ function confidenceTone(confidence: string | null | undefined): TagTone {
   return "muted";
 }
 
-function marketConfidenceText(market: JobMarketCompensationSummary): string {
+function marketReliabilityText(market: JobMarketCompensationSummary): string {
   if (market.recordStatus !== "recorded") {
-    return "market confidence none";
+    return "market reliability not available";
   }
-  const score = formatPercent(market.confidenceScore);
   const sourceCount = finiteCount(market.sourceCount);
   const sampleCount = optionalCount(market.sampleCount);
   return [
-    `market confidence ${formatToken(market.confidenceBand) || "none"}`,
-    score,
-    plural(sourceCount, "source"),
+    `${formatToken(market.confidenceBand) || "no"} reliability`,
+    plural(sourceCount, "provider"),
     sampleCount === null ? null : plural(sampleCount, "sample"),
   ]
     .filter(Boolean)
     .join(" · ");
 }
 
-function postedConfidenceText(posted: JobPostedCompensationSummary): string {
-  return `posted confidence ${formatToken(posted.confidence) || "none"}`;
+function postedAuthorityText(posted: JobPostedCompensationSummary): string {
+  if (
+    posted.recordStatus === "recorded" &&
+    posted.parseState === "parsed_range"
+  ) {
+    return "employer posted";
+  }
+  if (posted.recordStatus === "recorded") {
+    return "posting needs review";
+  }
+  return "not stated by employer";
 }
 
 function primaryCompensation(
@@ -177,11 +251,14 @@ function primaryCompensation(
         };
   }
 
-  if (summary.market.recordStatus === "recorded" && summary.market.displayRange) {
+  if (
+    summary.market.recordStatus === "recorded" &&
+    summary.market.displayRange
+  ) {
     return {
       range: summary.market.displayRange,
       source: benchmarkSource(summary.market),
-      confidence: marketConfidenceText(summary.market),
+      confidence: marketReliabilityText(summary.market),
       tone: confidenceTone(summary.market.confidenceBand),
       warningCount: finiteCount(summary.market.warningCount),
     };
@@ -191,17 +268,18 @@ function primaryCompensation(
     return {
       range: summary.posted.displayRange,
       source: "posted salary",
-      confidence: postedConfidenceText(summary.posted),
-      tone: confidenceTone(summary.posted.confidence),
+      confidence: postedAuthorityText(summary.posted),
+      tone: "ok",
       warningCount: finiteCount(summary.posted.warningCount),
     };
   }
 
   if (summary.market.recordStatus === "recorded") {
     return {
-      range: formatToken(summary.market.estimateState) || "market estimate recorded",
+      range:
+        formatToken(summary.market.estimateState) || "market estimate recorded",
       source: benchmarkSource(summary.market),
-      confidence: marketConfidenceText(summary.market),
+      confidence: marketReliabilityText(summary.market),
       tone: confidenceTone(summary.market.confidenceBand),
       warningCount: finiteCount(summary.market.warningCount),
     };
@@ -211,8 +289,8 @@ function primaryCompensation(
     return {
       range: formatToken(summary.posted.parseState) || "posted salary recorded",
       source: "posted salary",
-      confidence: postedConfidenceText(summary.posted),
-      tone: confidenceTone(summary.posted.confidence),
+      confidence: postedAuthorityText(summary.posted),
+      tone: "warn",
       warningCount: finiteCount(summary.posted.warningCount),
     };
   }
@@ -252,11 +330,15 @@ export function compensationSearchText(
     formatToken(summary.market.estimateState),
     formatToken(summary.market.benchmarkKind),
     formatToken(summary.market.confidenceBand),
-    finiteCount(summary.market.sourceCount) ? plural(finiteCount(summary.market.sourceCount), "source") : null,
+    finiteCount(summary.market.sourceCount)
+      ? plural(finiteCount(summary.market.sourceCount), "source")
+      : null,
     optionalCount(summary.market.sampleCount) === null
       ? null
       : plural(optionalCount(summary.market.sampleCount) ?? 0, "sample"),
-    finiteCount(summary.warningCount) ? plural(finiteCount(summary.warningCount), "warning") : null,
+    finiteCount(summary.warningCount)
+      ? plural(finiteCount(summary.warningCount), "warning")
+      : null,
   ]
     .filter(Boolean)
     .join(" ");
@@ -353,7 +435,10 @@ function WarningList({
   warnings,
 }: {
   readonly title: string;
-  readonly warnings: readonly (PostedCompensationWarning | MarketCompensationWarning)[];
+  readonly warnings: readonly (
+    | PostedCompensationWarning
+    | MarketCompensationWarning
+  )[];
 }) {
   if (!warnings.length) {
     return null;
@@ -364,7 +449,6 @@ function WarningList({
       <ul>
         {warnings.map((warning) => (
           <li key={`${warning.code}:${warning.message}`}>
-            <code>{warning.code}</code>
             <span>{warning.message}</span>
           </li>
         ))}
@@ -395,20 +479,43 @@ function ReasonList({
   );
 }
 
-function MarketReasonLists({ estimate }: { readonly estimate: JobCompensationAuditMarketEstimate }) {
+function MarketReasonLists({
+  estimate,
+}: {
+  readonly estimate: JobCompensationAuditMarketEstimate;
+}) {
   if (estimate.estimateState === "unsupported") {
-    return <ReasonList title="Unsupported reasons" reasons={estimate.unsupportedReasons} />;
+    return (
+      <ReasonList
+        title="Unsupported reasons"
+        reasons={estimate.unsupportedReasons}
+      />
+    );
   }
   if (estimate.estimateState === "source_unavailable") {
-    return <ReasonList title="Unavailable-source reasons" reasons={estimate.sourceUnavailableReasons} />;
+    return (
+      <ReasonList
+        title="Unavailable-source reasons"
+        reasons={estimate.sourceUnavailableReasons}
+      />
+    );
   }
   if (estimate.estimateState === "insufficient_evidence") {
-    return <ReasonList title="Insufficient-evidence reasons" reasons={estimate.insufficientReasons} />;
+    return (
+      <ReasonList
+        title="Why no range is shown"
+        reasons={estimate.insufficientReasons}
+      />
+    );
   }
   return null;
 }
 
-function SourceTrail({ sources }: { readonly sources: readonly MarketCompensationSourceSnapshot[] }) {
+function SourceTrail({
+  sources,
+}: {
+  readonly sources: readonly MarketCompensationSourceSnapshot[];
+}) {
   if (!sources.length) {
     return null;
   }
@@ -420,11 +527,17 @@ function SourceTrail({ sources }: { readonly sources: readonly MarketCompensatio
           <li key={`${source.sourceId}:${source.snapshotVersion}`}>
             <b>{source.displayName}</b>
             <span>
-              {[source.aggregateBucket, source.geographyScope, source.releaseYear]
+              {[
+                source.aggregateBucket,
+                source.geographyScope,
+                source.releaseYear,
+              ]
                 .filter(Boolean)
                 .join(" · ")}
             </span>
-            {source.sampleCount === null ? null : <span>{plural(source.sampleCount, "sample")}</span>}
+            {source.sampleCount === null ? null : (
+              <span>{plural(source.sampleCount, "sample")}</span>
+            )}
           </li>
         ))}
       </ul>
@@ -432,21 +545,91 @@ function SourceTrail({ sources }: { readonly sources: readonly MarketCompensatio
   );
 }
 
-function FactorList({ factors }: { readonly factors: readonly MarketCompensationFactor[] }) {
+function factorExplanation(
+  factor: MarketCompensationFactor,
+  estimate: JobCompensationAuditMarketEstimate,
+): string {
+  if (
+    estimate.estimatorVersion.startsWith(
+      "company-role-reported-compensation-canonical-benchmark-",
+    )
+  ) {
+    return factor.reason;
+  }
+  const score = formatPercent(factor.score) ?? "no";
+  const company = estimate.companyName || "this company";
+  if (factor.name === "company") {
+    if (estimate.matchScope === "exact_company_role") {
+      return `Direct reported salary evidence matched ${company}; company support is ${score}.`;
+    }
+    if (estimate.matchScope === "company_adjacent_role") {
+      return `Direct ${company} evidence exists only for adjacent roles; company support is ${score}.`;
+    }
+    if (estimate.matchScope === "tier_role_fallback") {
+      return `No direct ${company} salary record matched; comparable-company evidence provides ${score} support.`;
+    }
+    if (estimate.matchScope === "same_location_role_fallback") {
+      return `No direct ${company} salary record matched; same-location role evidence provides ${score} support.`;
+    }
+    if (estimate.matchScope === "market_baseline_fallback") {
+      return `No direct ${company} salary record matched; broader market evidence provides ${score} support.`;
+    }
+  }
+  if (factor.name === "level") {
+    return `The job was classified as ${formatToken(estimate.seniorityLabel) || "an unknown level"}; selected records provide ${score} seniority support.`;
+  }
+  if (factor.name === "role") {
+    return `Selected records provide ${score} support for ${estimate.roleTitle || "this role"}.`;
+  }
+  return factor.reason;
+}
+
+function benchmarkLevelLabel(
+  estimate: JobCompensationAuditMarketEstimate,
+): string {
+  const level = formatToken(estimate.seniorityLabel);
+  return !level || level === "unknown" ? "all levels" : level;
+}
+
+function isLegacyMarketAssessment(
+  estimate: JobCompensationAuditMarketEstimate,
+): boolean {
+  return /^company-role-reported-compensation-v[12](?::|$)/.test(
+    estimate.estimatorVersion,
+  );
+}
+
+function isCanonicalAllLevelBenchmark(
+  estimate: JobCompensationAuditMarketEstimate,
+): boolean {
+  return (
+    estimate.estimatorVersion.startsWith(
+      "company-role-reported-compensation-canonical-benchmark-",
+    ) && benchmarkLevelLabel(estimate) === "all levels"
+  );
+}
+
+function FactorList({
+  factors,
+  estimate,
+}: {
+  readonly factors: readonly MarketCompensationFactor[];
+  readonly estimate: JobCompensationAuditMarketEstimate;
+}) {
   if (!factors.length) {
     return null;
   }
   return (
     <div className="compensation-factor-list">
-      <h4>Confidence factors</h4>
+      <h4>Reliability factors</h4>
       <ul>
         {factors.map((factor) => (
           <li key={factor.name}>
             <span>{formatToken(factor.name)}</span>
             <b className={`tag ${confidenceTone(factor.band)}`}>
-              {formatToken(factor.band)} {formatPercent(factor.score)}
+              {formatPercent(factor.score)} support
             </b>
-            <p>{factor.reason}</p>
+            <p>{factorExplanation(factor, estimate)}</p>
           </li>
         ))}
       </ul>
@@ -454,17 +637,40 @@ function FactorList({ factors }: { readonly factors: readonly MarketCompensation
   );
 }
 
-function EvidenceRows({ rows }: { readonly rows: readonly MarketCompensationEvidenceRow[] }) {
+function EvidenceRows({
+  rows,
+  sources,
+  sampleCount,
+}: {
+  readonly rows: readonly MarketCompensationEvidenceRow[];
+  readonly sources: readonly MarketCompensationSourceSnapshot[];
+  readonly sampleCount: number | null;
+}) {
   if (!rows.length) {
     return null;
   }
+  const providerCount = new Set([
+    ...rows.map((row) => row.sourceId),
+    ...sources.map((source) => source.sourceId),
+  ]).size;
+  const reportedSampleCount = optionalCount(sampleCount);
   return (
-    <details className="compensation-evidence-rows">
+    <details className="compensation-disclosure compensation-evidence-rows">
       <summary>
-        <span>Evidence rows</span>
-        <b>{plural(rows.length, "row")}</b>
+        <span className="compensation-disclosure-label">
+          <IconChevronDown aria-hidden="true" size={16} />
+          <span>Evidence reviewed</span>
+        </span>
+        <b>
+          {plural(rows.length, "evidence record")} ·{" "}
+          {plural(providerCount, "provider")}
+          {reportedSampleCount === null
+            ? null
+            : ` · ${plural(reportedSampleCount, "reported sample")}`}
+        </b>
       </summary>
       <div className="compensation-evidence-row-list">
+        <SourceTrail sources={sources} />
         {rows.map((row, index) => (
           <article
             key={`${row.sourceId}:${row.companyName}:${row.roleTitle}:${row.minimumAmount}:${row.maximumAmount}:${index}`}
@@ -481,8 +687,20 @@ function EvidenceRows({ rows }: { readonly rows: readonly MarketCompensationEvid
               <DetailRow label="Level" value={row.levelLabel} />
               <DetailRow label="Tier" value={formatToken(row.companyTier)} />
               <DetailRow label="Component" value={formatToken(row.component)} />
-              <DetailRow label="Samples" value={row.sampleCount === null ? null : plural(row.sampleCount, "sample")} />
-              <DetailRow label="Release" value={row.releaseYear === null ? null : String(row.releaseYear)} />
+              <DetailRow
+                label="Samples"
+                value={
+                  row.sampleCount === null
+                    ? null
+                    : plural(row.sampleCount, "sample")
+                }
+              />
+              <DetailRow
+                label="Release"
+                value={
+                  row.releaseYear === null ? null : String(row.releaseYear)
+                }
+              />
               <DetailLinkRow label="Source" href={row.sourceUrl}>
                 Open source
               </DetailLinkRow>
@@ -490,6 +708,68 @@ function EvidenceRows({ rows }: { readonly rows: readonly MarketCompensationEvid
             <p>{matchScores(row)}</p>
           </article>
         ))}
+      </div>
+    </details>
+  );
+}
+
+function MarketAssessmentDetails({
+  market,
+  estimate,
+}: {
+  readonly market: JobMarketCompensationSummary;
+  readonly estimate: JobCompensationAuditMarketEstimate;
+}) {
+  const lineage = estimate.benchmarkLineage ?? null;
+  const score = formatPercent(estimate.confidenceScore) ?? "not scored";
+  return (
+    <details className="compensation-disclosure compensation-assessment-details">
+      <summary>
+        <span className="compensation-disclosure-label">
+          <IconChevronDown aria-hidden="true" size={16} />
+          <span>How this was assessed</span>
+        </span>
+        <b>{benchmarkLevelLabel(estimate)}</b>
+      </summary>
+      <div className="compensation-disclosure-content">
+        <dl className="compensation-detail-grid">
+          <DetailRow
+            label="Reliability"
+            value={`${formatToken(market.confidenceBand)} · ${score}`}
+          />
+          <DetailRow label="Role" value={estimate.roleTitle} />
+          <DetailRow
+            label={
+              isLegacyMarketAssessment(estimate)
+                ? "Stored benchmark level"
+                : "Benchmark level"
+            }
+            value={benchmarkLevelLabel(estimate)}
+          />
+          <DetailRow
+            label="Match approach"
+            value={formatToken(estimate.matchScope)}
+          />
+          <DetailRow label="Geography" value={estimate.geographyScope} />
+          <DetailRow
+            label="Component"
+            value={market.range ? formatToken(market.range.component) : null}
+          />
+          <DetailRow
+            label="Confidence interval"
+            value={market.displayConfidenceInterval}
+          />
+        </dl>
+        <BenchmarkLineage lineage={lineage} />
+        <div className="compensation-reliability-explainer">
+          <p>
+            Overall reliability is capped by the weakest critical match. Each
+            percentage below is the support contributed by one input, not a
+            probability that the salary is correct.
+          </p>
+          <FactorList factors={estimate.factors} estimate={estimate} />
+        </div>
+        <WarningList title="Estimate caveats" warnings={estimate.warnings} />
       </div>
     </details>
   );
@@ -513,17 +793,36 @@ function DirectBenchmarkInputs({
             <header>
               <b>{formatToken(input.inputRole)}</b>
               <span>
-                EUR {formatAmount(input.minimumAmountEur)}-{formatAmount(input.maximumAmountEur)}/year
+                EUR {formatAmount(input.minimumAmountEur)}-
+                {formatAmount(input.maximumAmountEur)}/year
               </span>
             </header>
             <dl>
-              <DetailRow label="Geography" value={formatGeography(input.geography)} />
-              <DetailRow label="Company" value={input.normalizedCompany ?? "market aggregate"} />
-              <DetailRow label="Source" value={`${input.sourceId} · ${formatToken(input.sourceProvenance)}`} />
+              <DetailRow
+                label="Geography"
+                value={formatGeography(input.geography)}
+              />
+              <DetailRow
+                label="Company"
+                value={input.normalizedCompany ?? "market aggregate"}
+              />
+              <DetailRow
+                label="Source"
+                value={`${input.sourceId} · ${formatToken(input.sourceProvenance)}`}
+              />
               <DetailRow label="Snapshot" value={input.sourceSnapshotId} />
-              <DetailRow label="Samples" value={plural(input.sampleCount, "sample")} />
-              <DetailRow label="Confidence" value={formatPercent(input.confidenceScore)} />
-              <DetailRow label="Bridge weight" value={formatPercent(input.weight)} />
+              <DetailRow
+                label="Samples"
+                value={plural(input.sampleCount, "sample")}
+              />
+              <DetailRow
+                label="Confidence"
+                value={formatPercent(input.confidenceScore)}
+              />
+              <DetailRow
+                label="Bridge weight"
+                value={formatPercent(input.weight)}
+              />
               <DetailRow label="As of" value={input.asOfDate} />
               <DetailRow label="Fresh through" value={input.freshUntil} />
               <DetailRow label="Fact ID" value={input.factId} />
@@ -562,7 +861,10 @@ function PriceLevelInputs({
               <DetailRow label="Index base" value={input.baseGeographyCode} />
               <DetailRow label="Source" value={input.sourceId} />
               <DetailRow label="Snapshot" value={input.sourceSnapshotId} />
-              <DetailRow label="Bridge weight" value={formatPercent(input.weight)} />
+              <DetailRow
+                label="Bridge weight"
+                value={formatPercent(input.weight)}
+              />
               <DetailRow label="As of" value={input.asOfDate} />
               <DetailRow label="Fresh through" value={input.freshUntil} />
               <DetailRow label="Fact ID" value={input.factId} />
@@ -582,16 +884,26 @@ function BenchmarkLineage({
   if (!lineage) return null;
   const extrapolated = lineage.kind === "extrapolated" ? lineage : null;
   const boundTone: TagTone =
-    extrapolated && extrapolated.factorBoundState !== "within_bounds" ? "warn" : "info";
+    extrapolated && extrapolated.factorBoundState !== "within_bounds"
+      ? "warn"
+      : "info";
   return (
     <section
       className={`compensation-benchmark-lineage compensation-benchmark-lineage-${lineage.kind}`}
-      aria-label={lineage.kind === "direct" ? "Direct benchmark lineage" : "Geographic extrapolation lineage"}
+      aria-label={
+        lineage.kind === "direct"
+          ? "Direct benchmark lineage"
+          : "Geographic extrapolation lineage"
+      }
     >
       <header>
         <div>
           <span className="eyebrow">Benchmark authority</span>
-          <h4>{lineage.kind === "direct" ? "Direct country benchmark" : "Geographic extrapolation bridge"}</h4>
+          <h4>
+            {lineage.kind === "direct"
+              ? "Direct country benchmark"
+              : "Geographic extrapolation bridge"}
+          </h4>
         </div>
         <StatusBadge tone={lineage.kind === "direct" ? "ok" : boundTone}>
           {lineage.kind === "direct" ? "direct evidence" : "derived estimate"}
@@ -606,20 +918,36 @@ function BenchmarkLineage({
         </p>
       ) : null}
       <dl className="compensation-detail-grid">
-        <DetailRow label="Role family" value={formatToken(lineage.roleFamilyCode)} />
+        <DetailRow
+          label="Role family"
+          value={formatToken(lineage.roleFamilyCode)}
+        />
         <DetailRow label="Taxonomy" value={lineage.taxonomyVersion} />
         <DetailRow label="Level" value={formatToken(lineage.seniorityLabel)} />
-        <DetailRow label="Target geography" value={formatGeography(lineage.targetGeography)} />
+        <DetailRow
+          label="Target geography"
+          value={formatGeography(lineage.targetGeography)}
+        />
         <DetailRow label="Evidence as of" value={lineage.asOfDate} />
         <DetailRow label="Fresh through" value={lineage.freshUntil} />
         <DetailRow label="Benchmark fact" value={lineage.factId} />
         {extrapolated ? (
           <>
-            <DetailRow label="Raw factor" value={formatMultiplier(extrapolated.rawFactor)} />
-            <DetailRow label="Company evidence weight" value={formatPercent(extrapolated.shrinkageWeight)} />
+            <DetailRow
+              label="Raw factor"
+              value={formatMultiplier(extrapolated.rawFactor)}
+            />
+            <DetailRow
+              label="Company evidence weight"
+              value={formatPercent(extrapolated.shrinkageWeight)}
+            />
             <DetailRow
               label="Matched companies"
-              value={plural(extrapolated.matchedCompanyCount, "company", "companies")}
+              value={plural(
+                extrapolated.matchedCompanyCount,
+                "company",
+                "companies",
+              )}
             />
             <DetailRow
               label="Review bounds"
@@ -642,24 +970,88 @@ function PostedPanel({
   readonly posted: JobPostedCompensationSummary;
   readonly fact: JobCompensationAuditPostedFact | null;
 }) {
+  const hasPostedRange =
+    posted.recordStatus === "recorded" && Boolean(posted.displayRange);
+  const parsedFact = fact && fact.parseState === "parsed_range" ? fact : null;
+  const equityMentioned =
+    fact?.warnings.some((warning) => warning.code === "equity_component") ??
+    false;
+  const amountIsEquity = parsedFact?.component === "equity";
+  const amountIsSpecifiedCash =
+    parsedFact !== null &&
+    parsedFact.component !== "unknown" &&
+    parsedFact.component !== "equity";
   return (
-    <article className="compensation-panel">
-      <header>
-        <span className="eyebrow">Posted Salary</span>
-        <b>{posted.displayRange || formatToken(posted.parseState) || "not recorded"}</b>
-        <span className={`tag ${confidenceTone(posted.confidence)}`}>{postedConfidenceText(posted)}</span>
+    <article
+      aria-label="Employer posted compensation"
+      className="compensation-panel compensation-result-card compensation-posted-card"
+    >
+      <header className="compensation-result-header">
+        <h4 className="eyebrow" data-typography="label">
+          Employer posted
+        </h4>
+        <b className="compensation-result-value">
+          {posted.displayRange ||
+            (posted.recordStatus === "recorded"
+              ? "No safe amount extracted"
+              : "Not stated")}
+        </b>
+        <StatusBadge tone={hasPostedRange ? "ok" : "muted"}>
+          {hasPostedRange ? "stated in posting" : "no posted range"}
+        </StatusBadge>
       </header>
-      <dl className="compensation-detail-grid">
-        <DetailRow label="State" value={posted.recordStatus === "recorded" ? formatToken(posted.parseState) : "not recorded"} />
-        <DetailRow label="Range" value={posted.displayRange} />
-        <DetailRow label="Component" value={posted.range ? formatToken(posted.range.component) : null} />
-        <DetailRow label="Period" value={posted.range ? formatToken(posted.range.period) : null} />
-        <DetailRow label="Source field" value={fact?.sourceField} />
-      </dl>
-      {fact && "sourceText" in fact && fact.sourceText ? (
-        <p className="meta">Posting evidence: {fact.sourceText}</p>
+      {hasPostedRange ? (
+        <p className="compensation-result-explanation">
+          {amountIsEquity
+            ? "This is the employer-stated value of the equity or stock compensation described in the posting."
+            : equityMentioned && amountIsSpecifiedCash
+              ? "This is the cash amount stated in the posting. Stock or equity is mentioned separately and is not included without its own posted value."
+              : equityMentioned
+                ? "This is the numeric compensation amount stated in the posting. Stock or equity is mentioned separately and is not included without its own posted value."
+                : "This amount comes directly from the job posting; it is not a market estimate."}
+        </p>
       ) : null}
-      <WarningList title="Posted salary warnings" warnings={fact?.warnings ?? []} />
+      {fact ? (
+        <details className="compensation-disclosure compensation-posted-evidence">
+          <summary>
+            <span className="compensation-disclosure-label">
+              <IconChevronDown aria-hidden="true" size={16} />
+              <span>View posting evidence</span>
+            </span>
+            <b>{formatToken(fact.parseState)}</b>
+          </summary>
+          <div className="compensation-disclosure-content">
+            <dl className="compensation-detail-grid">
+              <DetailRow label="Source field" value={fact.sourceField} />
+              <DetailRow
+                label="Amount type"
+                value={
+                  parsedFact?.component === "unknown"
+                    ? "numeric amount; component not specified"
+                    : formatToken(parsedFact?.component)
+                }
+              />
+              <DetailRow
+                label="Period"
+                value={formatToken(parsedFact?.period)}
+              />
+              <DetailRow
+                label="Extraction certainty"
+                value={formatToken(fact.confidence)}
+              />
+            </dl>
+            {"sourceText" in fact && fact.sourceText ? (
+              <blockquote className="compensation-posting-excerpt">
+                {fact.sourceText}
+              </blockquote>
+            ) : null}
+            <WarningList
+              title="Interpretation notes"
+              warnings={fact.warnings}
+            />
+          </div>
+        </details>
+      ) : null}
     </article>
   );
 }
@@ -671,90 +1063,150 @@ function MarketPanel({
   readonly market: JobMarketCompensationSummary;
   readonly estimate: JobCompensationAuditMarketEstimate | null;
 }) {
-  const score = estimate ? formatPercent(estimate.confidenceScore) : formatPercent(market.confidenceScore);
   const lineage = estimate?.benchmarkLineage ?? null;
+  const hasRange =
+    market.recordStatus === "recorded" &&
+    market.estimateState === "estimated_range" &&
+    Boolean(market.displayRange);
+  const evidenceCount = estimate?.evidence.length ?? 0;
+  const providerCount = estimate
+    ? new Set([
+        ...estimate.sources.map((source) => source.sourceId),
+        ...estimate.evidence.map((row) => row.sourceId),
+      ]).size
+    : finiteCount(market.sourceCount);
+  const sampleCount = optionalCount(market.sampleCount);
+  const evidenceCoverage = estimate
+    ? `${plural(evidenceCount, "evidence record")} ${evidenceCount === 1 ? "was" : "were"} reviewed across ${plural(providerCount, "provider")}${sampleCount === null ? "" : `, representing ${plural(sampleCount, "reported sample")}`}`
+    : `Detailed evidence records are unavailable in this projection${providerCount ? `; the summary records ${plural(providerCount, "provider")}` : ""}${sampleCount === null ? "" : ` and ${plural(sampleCount, "reported sample")}`}`;
+  const benchmarkKind = lineage?.kind ?? market.benchmarkKind;
+  const benchmarkBasis =
+    benchmarkKind === "extrapolated"
+      ? "Derived from a matched role-family benchmark in another geography with an auditable adjustment."
+      : benchmarkKind === "direct"
+        ? "Based on a direct benchmark for the matched role family and geography."
+        : "Based on stored reported-compensation evidence selected by the recorded match approach.";
+  const allLevelNote =
+    estimate && isCanonicalAllLevelBenchmark(estimate)
+      ? " The benchmark uses all-level evidence for this role family."
+      : "";
+  const legacyNote =
+    estimate && isLegacyMarketAssessment(estimate)
+      ? " This is a stored legacy assessment; refresh this job to use the current role and level classifier."
+      : "";
+  const outcome = hasRange
+    ? {
+        value: market.displayRange,
+        badge: `${formatToken(market.confidenceBand)} reliability`,
+        tone: confidenceTone(market.confidenceBand),
+        explanation: `${benchmarkBasis}${allLevelNote} ${evidenceCoverage}.${legacyNote}`,
+      }
+    : market.estimateState === "insufficient_evidence"
+      ? {
+          value: "No reliable market range yet",
+          badge: "range withheld",
+          tone: "warn" as const,
+          explanation:
+            estimate === null
+              ? `${evidenceCoverage}. The recorded outcome did not include a trustworthy numeric range.`
+              : evidenceCount > 0
+                ? `${evidenceCoverage}, but the evidence did not meet the threshold for a trustworthy numeric range.${legacyNote}`
+                : `Available evidence did not meet the threshold for a trustworthy numeric range. See the reasons below.${legacyNote}`,
+        }
+      : market.estimateState === "source_unavailable"
+        ? {
+            value: "Market sources unavailable",
+            badge: "sources unavailable",
+            tone: "warn" as const,
+            explanation:
+              "Current market sources could not be used. See the source status below, then refresh when current evidence is available.",
+          }
+        : market.estimateState === "unsupported"
+          ? {
+              value: "Market range unsupported",
+              badge: "unsupported input",
+              tone: "warn" as const,
+              explanation:
+                "This compensation component or input is outside the supported market model. See the reasons below.",
+            }
+          : {
+              value: "Not researched yet",
+              badge: "not researched",
+              tone: "muted" as const,
+              explanation:
+                "Refresh this job to research a role, level, and geography benchmark.",
+            };
   return (
-    <article className="compensation-panel">
-      <header>
-        <span className="eyebrow">
-          {lineage?.kind === "direct"
-            ? "Direct Market Benchmark"
-            : lineage?.kind === "extrapolated"
-              ? "Extrapolated Market Benchmark"
-              : "Reported Company-Role Market"}
-        </span>
-        <b>{market.displayRange || formatToken(market.estimateState) || "not requested"}</b>
-        <span className={`tag ${confidenceTone(market.confidenceBand)}`}>{marketConfidenceText(market)}</span>
+    <article
+      aria-label="Market salary estimate"
+      className="compensation-panel compensation-result-card compensation-market-card"
+    >
+      <header className="compensation-result-header">
+        <h4 className="eyebrow" data-typography="label">
+          Market salary estimate
+        </h4>
+        <b className="compensation-result-value">{outcome.value}</b>
+        <StatusBadge tone={outcome.tone}>{outcome.badge}</StatusBadge>
       </header>
-      <dl className="compensation-detail-grid">
-        <DetailRow label="State" value={formatToken(market.estimateState)} />
-        <DetailRow label="Benchmark type" value={lineage ? formatToken(lineage.kind) : null} />
-        <DetailRow label="Range" value={market.displayRange} />
-        <DetailRow label="Confidence interval" value={market.displayConfidenceInterval} />
-        <DetailRow label="Confidence score" value={score} />
-        <DetailRow label="Sources" value={finiteCount(market.sourceCount) ? plural(finiteCount(market.sourceCount), "source") : "0 sources"} />
-        <DetailRow
-          label="Samples"
-          value={optionalCount(market.sampleCount) === null ? null : plural(optionalCount(market.sampleCount) ?? 0, "sample")}
-        />
-        <DetailRow label="Match scope" value={estimate ? formatToken(estimate.matchScope) : null} />
-        <DetailRow label="Company tier" value={estimate ? formatToken(estimate.companyTier) : null} />
-        <DetailRow label="Component" value={market.range ? formatToken(market.range.component) : null} />
-      </dl>
+      <p className="compensation-result-explanation">{outcome.explanation}</p>
       {estimate ? (
-        <>
-          <BenchmarkLineage lineage={lineage} />
-          <SourceTrail sources={estimate.sources} />
-          <EvidenceRows rows={estimate.evidence} />
-          <FactorList factors={estimate.factors} />
-          <WarningList title="Market warnings" warnings={estimate.warnings} />
+        <div className="compensation-market-details">
           <MarketReasonLists estimate={estimate} />
-        </>
+          <EvidenceRows
+            rows={estimate.evidence}
+            sources={estimate.sources}
+            sampleCount={market.sampleCount}
+          />
+          <MarketAssessmentDetails market={market} estimate={estimate} />
+        </div>
       ) : null}
     </article>
   );
 }
 
+function RawPostedFallbackPanel({ value }: { readonly value: string }) {
+  return (
+    <article
+      aria-label="Employer posted compensation"
+      className="compensation-panel compensation-result-card compensation-posted-card"
+    >
+      <header className="compensation-result-header">
+        <h4 className="eyebrow" data-typography="label">
+          Employer posted
+        </h4>
+        <b className="compensation-result-value">{value}</b>
+        <StatusBadge tone="muted">unparsed posting value</StatusBadge>
+      </header>
+      <p className="compensation-result-explanation">
+        This value came from the job posting, but structured compensation
+        evidence is not available yet. Refresh this job to parse it.
+      </p>
+    </article>
+  );
+}
+
 function CompensationRefreshControl({ jobId }: { readonly jobId: string }) {
-  const [observationsJsonPath, setObservationsJsonPath] = useState("");
   const mutation = useRefreshCompensationMutation();
-  const path = observationsJsonPath.trim();
   const disabled = mutation.isPending;
 
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (disabled) return;
-    mutation.mutate({
-      jobId,
-      ...(path ? { observationsJsonPath: path } : {}),
-    });
-  };
-
   return (
-    <form className="compensation-refresh-control" onSubmit={submit}>
-      <Field className="compensation-refresh-path">
-        <FieldLabel htmlFor="compensation-observations-json-path">
-          Observation JSON path (optional)
-        </FieldLabel>
-        <Input
-          aria-describedby="compensation-observations-json-path-help"
-          id="compensation-observations-json-path"
-          value={observationsJsonPath}
-          placeholder="/path/to/reported-compensation.json"
-          onChange={(event) => setObservationsJsonPath(event.currentTarget.value)}
-        />
-        <FieldDescription id="compensation-observations-json-path-help">
-          Used only when refreshing this job.
-        </FieldDescription>
-      </Field>
-      <Button disabled={disabled} size="sm" type="submit" variant="outline">
+    <div className="compensation-refresh-control">
+      <Button
+        disabled={disabled}
+        size="sm"
+        type="button"
+        variant="outline"
+        onClick={() => {
+          if (!disabled) mutation.mutate({ jobId });
+        }}
+      >
         <IconRefresh aria-hidden="true" size={14} />
         <span>{disabled ? "Refreshing this job" : "Refresh this job"}</span>
       </Button>
       <span className="compensation-refresh-status" aria-live="polite">
         {mutation.isSuccess ? "refreshed" : null}
       </span>
-    </form>
+    </div>
   );
 }
 
@@ -766,7 +1218,10 @@ export function CompensationAuditSection({
 }: CompensationAuditSectionProps) {
   if (!summary && !audit && !fallbackSalary) {
     return (
-      <section className="section compensation-audit-section" aria-label="Compensation evidence">
+      <section
+        className="section compensation-audit-section"
+        aria-label="Compensation evidence"
+      >
         <div className="compensation-audit-heading">
           <h3>Compensation</h3>
           {jobId ? <CompensationRefreshControl jobId={jobId} /> : null}
@@ -779,57 +1234,113 @@ export function CompensationAuditSection({
   const effectiveSummary =
     summary ??
     (audit
-      ? {
-          projectionVersion: audit.projectionVersion,
-          legacyRawSalary: fallbackSalary ?? null,
-          warningCount: 0,
-          posted: {
-            sourceKind: "posted" as const,
-            recordStatus: audit.posted.recordStatus,
-            parseState: audit.posted.recordStatus === "recorded" ? audit.posted.fact.parseState : null,
-            confidence: audit.posted.recordStatus === "recorded" ? audit.posted.fact.confidence : "none",
-            warningCount: audit.posted.recordStatus === "recorded" ? audit.posted.fact.warnings.length : 0,
-            range: null,
-            displayRange: null,
-          },
-          market: {
-            sourceKind: "reported_company_role_market" as const,
-            recordStatus: audit.market.recordStatus,
-            benchmarkKind:
-              audit.market.recordStatus === "recorded"
-                ? audit.market.estimate.benchmarkLineage?.kind ?? null
-                : null,
-            estimateState: audit.market.recordStatus === "recorded" ? audit.market.estimate.estimateState : "not_requested",
-            confidenceBand: audit.market.recordStatus === "recorded" ? audit.market.estimate.confidenceBand : "none",
-            confidenceScore: audit.market.recordStatus === "recorded" ? audit.market.estimate.confidenceScore : null,
-            sourceCount: audit.market.recordStatus === "recorded" ? audit.market.estimate.sourceCount : 0,
-            sampleCount: audit.market.recordStatus === "recorded" ? audit.market.estimate.sampleCount : null,
-            warningCount: audit.market.recordStatus === "recorded" ? audit.market.estimate.warnings.length : 0,
-            range: null,
-            displayRange: null,
-            confidenceInterval: null,
-            displayConfidenceInterval: null,
-          },
-        }
+      ? (() => {
+          const auditPostedFact =
+            audit.posted.recordStatus === "recorded" ? audit.posted.fact : null;
+          const auditPosted = auditPostedFact
+            ? auditPostedRange(auditPostedFact)
+            : null;
+          const auditMarketEstimate =
+            audit.market.recordStatus === "recorded"
+              ? audit.market.estimate
+              : null;
+          const auditMarket = auditMarketEstimate
+            ? auditMarketRange(auditMarketEstimate)
+            : null;
+          return {
+            projectionVersion: audit.projectionVersion,
+            legacyRawSalary: fallbackSalary ?? null,
+            warningCount: 0,
+            posted: {
+              sourceKind: "posted" as const,
+              recordStatus: audit.posted.recordStatus,
+              parseState:
+                audit.posted.recordStatus === "recorded"
+                  ? audit.posted.fact.parseState
+                  : null,
+              confidence:
+                audit.posted.recordStatus === "recorded"
+                  ? audit.posted.fact.confidence
+                  : "none",
+              warningCount:
+                audit.posted.recordStatus === "recorded"
+                  ? audit.posted.fact.warnings.length
+                  : 0,
+              range: auditPosted,
+              displayRange: auditPosted?.displayRange ?? null,
+            },
+            market: {
+              sourceKind: "reported_company_role_market" as const,
+              recordStatus: audit.market.recordStatus,
+              benchmarkKind:
+                audit.market.recordStatus === "recorded"
+                  ? (audit.market.estimate.benchmarkLineage?.kind ?? null)
+                  : null,
+              estimateState:
+                audit.market.recordStatus === "recorded"
+                  ? audit.market.estimate.estimateState
+                  : "not_requested",
+              confidenceBand:
+                audit.market.recordStatus === "recorded"
+                  ? audit.market.estimate.confidenceBand
+                  : "none",
+              confidenceScore:
+                audit.market.recordStatus === "recorded"
+                  ? audit.market.estimate.confidenceScore
+                  : null,
+              sourceCount:
+                audit.market.recordStatus === "recorded"
+                  ? audit.market.estimate.sourceCount
+                  : 0,
+              sampleCount:
+                audit.market.recordStatus === "recorded"
+                  ? audit.market.estimate.sampleCount
+                  : null,
+              warningCount:
+                audit.market.recordStatus === "recorded"
+                  ? audit.market.estimate.warnings.length
+                  : 0,
+              range: auditMarket,
+              displayRange: auditMarket?.displayRange ?? null,
+              confidenceInterval: null,
+              displayConfidenceInterval: null,
+            },
+          };
+        })()
       : null);
-  const postedFact = audit?.posted.recordStatus === "recorded" ? audit.posted.fact : null;
-  const marketEstimate = audit?.market.recordStatus === "recorded" ? audit.market.estimate : null;
+  const postedFact =
+    audit?.posted.recordStatus === "recorded" ? audit.posted.fact : null;
+  const marketEstimate =
+    audit?.market.recordStatus === "recorded" ? audit.market.estimate : null;
+  const rawPostedFallback =
+    effectiveSummary?.posted.displayRange || postedFact
+      ? null
+      : effectiveSummary?.legacyRawSalary || fallbackSalary || null;
 
   return (
-    <section className="section compensation-audit-section" aria-label="Compensation evidence">
+    <section
+      className="section compensation-audit-section"
+      aria-label="Compensation evidence"
+    >
       <div className="compensation-audit-heading">
         <h3>Compensation</h3>
         {jobId ? <CompensationRefreshControl jobId={jobId} /> : null}
       </div>
-      <CompensationSummaryStrip
-        summary={effectiveSummary}
-        fallbackSalary={fallbackSalary}
-        label="Compensation summary"
-      />
       {effectiveSummary ? (
         <div className="compensation-panels">
-          <PostedPanel posted={effectiveSummary.posted} fact={postedFact} />
-          <MarketPanel market={effectiveSummary.market} estimate={marketEstimate} />
+          {rawPostedFallback ? (
+            <RawPostedFallbackPanel value={rawPostedFallback} />
+          ) : (
+            <PostedPanel posted={effectiveSummary.posted} fact={postedFact} />
+          )}
+          <MarketPanel
+            market={effectiveSummary.market}
+            estimate={marketEstimate}
+          />
+        </div>
+      ) : fallbackSalary ? (
+        <div className="compensation-panels">
+          <RawPostedFallbackPanel value={fallbackSalary} />
         </div>
       ) : null}
     </section>

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -6613,16 +6613,8 @@ input[type="radio"] {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  align-items: end;
+  align-items: center;
   justify-content: flex-end;
-}
-
-.compensation-refresh-path {
-  display: grid;
-  gap: 4px;
-  min-width: min(260px, 100%);
-  color: var(--muted-foreground);
-  font-size: var(--jh-type-body-size);
 }
 
 .compensation-refresh-status {
@@ -6630,11 +6622,6 @@ input[type="radio"] {
   color: var(--status-success);
   font-size: var(--jh-type-label-size);
   font-weight: var(--jh-type-label-weight);
-}
-
-.compensation-refresh-path input {
-  height: 30px;
-  font-size: var(--jh-type-control-size);
 }
 
 .compensation-panels {
@@ -6646,6 +6633,8 @@ input[type="radio"] {
 .compensation-panel {
   display: grid;
   min-width: 0;
+  align-content: start;
+  align-self: start;
   gap: 10px;
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -6662,6 +6651,112 @@ input[type="radio"] {
 
 .compensation-panel header b {
   min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.compensation-result-card {
+  gap: 14px;
+}
+
+.compensation-result-header {
+  display: grid !important;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 5px 10px !important;
+  align-items: start !important;
+}
+
+.compensation-result-header .eyebrow {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
+.compensation-result-value {
+  font-size: var(--jh-type-metric-size) !important;
+  font-weight: var(--jh-type-metric-weight) !important;
+  letter-spacing: normal !important;
+  line-height: var(--jh-type-metric-line-height) !important;
+}
+
+.compensation-result-explanation {
+  max-width: 64ch;
+  margin: 0;
+  color: var(--muted-foreground);
+  line-height: var(--jh-type-body-line-height);
+}
+
+.compensation-market-details,
+.compensation-reliability-explainer {
+  display: grid;
+  gap: 10px;
+}
+
+.compensation-reliability-explainer > p {
+  margin: 0;
+  border-left: 2px solid var(--status-info);
+  color: var(--muted-foreground);
+  padding-left: 10px;
+  line-height: var(--jh-type-body-line-height);
+}
+
+.compensation-disclosure {
+  min-width: 0;
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.compensation-disclosure > summary {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  cursor: pointer;
+  gap: 8px 12px;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--foreground);
+  font-size: var(--jh-type-control-size);
+  font-weight: var(--jh-type-control-weight);
+  list-style-position: inside;
+}
+
+.compensation-disclosure-label {
+  display: inline-flex;
+  min-width: 0;
+  gap: 6px;
+  align-items: center;
+}
+
+.compensation-disclosure-label > svg {
+  flex: 0 0 auto;
+  transition: transform 150ms ease;
+}
+
+.compensation-disclosure[open]
+  > summary
+  .compensation-disclosure-label
+  > svg {
+  transform: rotate(180deg);
+}
+
+.compensation-disclosure > summary b {
+  color: var(--muted-foreground);
+  font-size: var(--jh-type-label-size);
+  font-weight: var(--jh-type-label-weight);
+  text-align: right;
+}
+
+.compensation-disclosure-content {
+  display: grid;
+  gap: 12px;
+  padding-top: 12px;
+}
+
+.compensation-posting-excerpt {
+  margin: 0;
+  border-left: 2px solid var(--border);
+  color: var(--muted-foreground);
+  padding-left: 12px;
+  font-size: var(--jh-type-body-size);
+  line-height: var(--jh-type-body-line-height);
   overflow-wrap: anywhere;
 }
 
@@ -6799,32 +6894,15 @@ input[type="radio"] {
   overflow-wrap: anywhere;
 }
 
-.compensation-evidence-rows > summary {
-  display: flex;
-  width: fit-content;
-  max-width: 100%;
-  cursor: pointer;
-  gap: 8px;
-  align-items: center;
-  color: var(--muted-foreground);
-  font-size: var(--jh-type-control-size);
-  font-weight: var(--jh-type-control-weight);
-}
-
 .compensation-evidence-rows > summary b {
-  border-radius: 4px;
-  background: var(--muted);
-  color: var(--foreground);
-  padding: 1px 4px;
-  font-family: var(--font-sans);
-  font-size: var(--jh-type-control-size);
+  color: var(--muted-foreground);
 }
 
 .compensation-evidence-row-list {
   display: grid;
   gap: 8px;
   min-width: 0;
-  padding-top: 4px;
+  padding-top: 12px;
 }
 
 .compensation-evidence-row {
@@ -6909,6 +6987,10 @@ input[type="radio"] {
   color: var(--foreground);
   padding: 1px 4px;
   overflow-wrap: anywhere;
+}
+
+.compensation-warning-list li:not(:has(code)) {
+  display: list-item;
 }
 
 .compensation-warning-list span {

--- a/apps/web/src/styles/redesign-job-detail.css
+++ b/apps/web/src/styles/redesign-job-detail.css
@@ -528,10 +528,6 @@
   gap: 7px;
 }
 
-.job-detail-drawer .compensation-refresh-path {
-  min-width: min(248px, 100%);
-}
-
 .job-detail-drawer .compensation-strip {
   gap: 8px 16px;
   padding: 11px 0;
@@ -557,6 +553,8 @@
 
 .job-detail-drawer .compensation-panel {
   gap: 13px;
+  align-content: start;
+  align-self: start;
   border: 0;
   border-radius: 0;
   background: transparent;
@@ -573,6 +571,20 @@
   display: grid;
   gap: 4px;
   align-items: start;
+}
+
+.job-detail-drawer .compensation-result-header {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.job-detail-drawer .compensation-result-header .eyebrow {
+  grid-column: 1 / -1;
+}
+
+.job-detail-drawer .compensation-result-value {
+  font-size: var(--jh-type-metric-size) !important;
+  font-weight: var(--jh-type-metric-weight) !important;
+  line-height: var(--jh-type-metric-line-height) !important;
 }
 
 .job-detail-drawer .compensation-panel header b {

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -1294,9 +1294,10 @@ describe("<ApplyReviewView>", () => {
     expect(screen.getByRole("region", { name: "Compensation" })).toBeInTheDocument();
     expect(screen.getByText("EUR 112000-142000/year")).toBeInTheDocument();
     expect(screen.getByText("geographically extrapolated benchmark")).toBeInTheDocument();
-    expect(screen.getByText(/market confidence medium/i)).toBeInTheDocument();
-    expect(screen.getByText(/2 sources/i)).toBeInTheDocument();
+    expect(screen.getByText(/medium reliability/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 providers/i)).toBeInTheDocument();
     expect(screen.getByText(/7 samples/i)).toBeInTheDocument();
+    expect(screen.queryByText(/market confidence/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/dry_run/i)).not.toBeInTheDocument();
     expect(screen.getByText(/Globex needs a principal engineer/i)).toBeInTheDocument();
     const detailLink = screen.getByRole("link", {

--- a/apps/web/src/views/jobs/JobDetailDrawer.test.tsx
+++ b/apps/web/src/views/jobs/JobDetailDrawer.test.tsx
@@ -193,16 +193,11 @@ describe("<JobDetailDrawer>", () => {
     const compensation = await screen.findByRole("region", {
       name: "Compensation evidence",
     });
-    expect(
-      within(compensation).getByText("source_conflict_with_posted_salary"),
-    ).toBeInTheDocument();
+    fireEvent.click(within(compensation).getByText("How this was assessed"));
     expect(
       within(compensation).getByText(
         "Market estimate is above the posted range.",
       ),
-    ).toBeInTheDocument();
-    expect(
-      within(compensation).getByText("reported_compensation_sample"),
     ).toBeInTheDocument();
     expect(
       within(compensation).getByText(
@@ -283,9 +278,13 @@ describe("<JobDetailDrawer>", () => {
 
     renderJobDetailDrawer("https://example.com/jobs/1");
 
+    await screen.findByRole("region", { name: "Compensation evidence" });
     expect(
-      await screen.findByText("Used only when refreshing this job."),
-    ).toBeInTheDocument();
+      screen.queryByText("Observation JSON path (optional)"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByPlaceholderText("/path/to/reported-compensation.json"),
+    ).not.toBeInTheDocument();
     await user.click(
       await screen.findByRole("button", { name: "Refresh this job" }),
     );
@@ -589,7 +588,7 @@ describe("<JobDetailDrawer>", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders compensation audit range, statistical confidence, and reported sources", async () => {
+  it("leads with salary outcomes and keeps benchmark calculations expandable", async () => {
     if (
       sampleCompensationAudit.market.recordStatus !== "recorded" ||
       sampleCompensationAudit.market.estimate.benchmarkLineage?.kind !==
@@ -644,25 +643,43 @@ describe("<JobDetailDrawer>", () => {
     });
     expect(within(compensation).getByText("Compensation")).toBeInTheDocument();
     expect(
-      within(compensation).getAllByText("EUR 112000-142000/year").length,
-    ).toBeGreaterThan(0);
+      within(compensation).getByText("EUR 112000-142000/year"),
+    ).toBeInTheDocument();
     expect(
       within(compensation).getAllByText("EUR 70000-90000/year").length,
     ).toBeGreaterThan(0);
     expect(
-      within(compensation).getAllByText(/market confidence medium/i).length,
-    ).toBeGreaterThan(0);
-    expect(within(compensation).getAllByText("82%").length).toBeGreaterThan(0);
-    expect(
-      within(compensation).getAllByText(/2 sources/i).length,
-    ).toBeGreaterThan(0);
-    expect(
-      within(compensation).getAllByText(/7 samples/i).length,
-    ).toBeGreaterThan(0);
-    expect(within(compensation).getByText("Posted Salary")).toBeInTheDocument();
-    expect(
-      within(compensation).getByText("Extrapolated Market Benchmark"),
+      within(compensation).getByText("Employer posted"),
     ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText("Market salary estimate"),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getAllByText(/medium reliability/i).length,
+    ).toBeGreaterThan(0);
+    expect(
+      within(compensation).queryByText(/market confidence medium/i),
+    ).not.toBeInTheDocument();
+    expect(
+      within(compensation).queryByText(/posted confidence/i),
+    ).not.toBeInTheDocument();
+
+    const evidenceSummary = within(compensation).getByText("Evidence reviewed");
+    const evidenceDisclosure = evidenceSummary.closest("details");
+    expect(evidenceDisclosure).not.toBeNull();
+    expect(evidenceDisclosure).not.toHaveAttribute("open");
+    expect(evidenceDisclosure).toHaveTextContent("1 evidence record");
+    expect(evidenceDisclosure).toHaveTextContent("2 providers");
+    expect(evidenceDisclosure).toHaveTextContent("7 reported samples");
+
+    const assessmentSummary = within(compensation).getByText(
+      "How this was assessed",
+    );
+    const assessmentDisclosure = assessmentSummary.closest("details");
+    expect(assessmentDisclosure).not.toBeNull();
+    expect(assessmentDisclosure).not.toHaveAttribute("open");
+    fireEvent.click(assessmentSummary);
+    expect(assessmentDisclosure).toHaveAttribute("open");
     const lineage = within(compensation).getByRole("region", {
       name: "Geographic extrapolation lineage",
     });
@@ -686,18 +703,15 @@ describe("<JobDetailDrawer>", () => {
       within(compensation).getByText("exact company role"),
     ).toBeInTheDocument();
     expect(
-      within(compensation).getByText("Confidence factors"),
+      within(compensation).getByText("Reliability factors"),
     ).toBeInTheDocument();
     expect(
-      within(compensation).getByText("Reported rows match Globex directly."),
+      within(compensation).getByText(
+        "Direct reported salary evidence matched Globex; company support is 96%.",
+      ),
     ).toBeInTheDocument();
-    const evidenceSummary = within(compensation).getByText("Evidence rows");
-    const evidenceDisclosure = evidenceSummary.closest("details");
-    expect(evidenceDisclosure).not.toBeNull();
-    expect(evidenceDisclosure).not.toHaveAttribute("open");
-    expect(
-      within(evidenceDisclosure as HTMLElement).getByText("1 row"),
-    ).toBeInTheDocument();
+    fireEvent.click(evidenceSummary);
+    expect(evidenceDisclosure).toHaveAttribute("open");
     expect(
       within(evidenceDisclosure as HTMLElement).getByText(
         "Principal Platform Engineer",
@@ -716,6 +730,265 @@ describe("<JobDetailDrawer>", () => {
       "href",
       "https://www.levels.fyi/companies/globex/salaries/software-engineer",
     );
+  });
+
+  it("explains a posted cash amount and a withheld director market range without raw audit markers", async () => {
+    if (sampleCompensationAudit.market.recordStatus !== "recorded") {
+      throw new Error(
+        "sample compensation audit must include recorded market evidence",
+      );
+    }
+    if (sampleCompensationAudit.posted.recordStatus !== "recorded") {
+      throw new Error(
+        "sample compensation audit must include recorded posted evidence",
+      );
+    }
+    const baseEvidence = sampleCompensationAudit.market.estimate.evidence[0];
+    if (!baseEvidence) {
+      throw new Error(
+        "sample compensation audit must include one evidence row",
+      );
+    }
+    const evidence = Array.from({ length: 93 }, (_, index) => {
+      const isAggregate = index === 0;
+      return {
+        ...baseEvidence,
+        sourceId: isAggregate
+          ? ("levels_fyi" as const)
+          : ("euro_top_tech" as const),
+        displayName: isAggregate ? "Levels.fyi" : "Euro Top Tech",
+        sourceUrl: isAggregate
+          ? "https://www.levels.fyi/t/software-engineer/locations/spain"
+          : "https://www.eurotoptech.com/data",
+        companyName: isAggregate
+          ? "Levels.fyi market aggregate"
+          : `European company ${index}`,
+        roleTitle: isAggregate ? "Software Engineer" : "Engineering Director",
+        location: "Spain",
+        levelLabel: isAggregate ? "All levels" : "Principal / Director",
+        minimumAmount: 38_645 + index * 500,
+        maximumAmount: 120_000 + index * 3_000,
+        sampleCount: isAggregate ? null : 1,
+      };
+    });
+    const postedFact = {
+      ...sampleCompensationAudit.posted.fact,
+      parseState: "parsed_range" as const,
+      sourceField: "jobs.full_description",
+      sourceText: "Compensation: USD 243,800 annually and stock options.",
+      currency: "USD",
+      period: "year" as const,
+      component: "unknown" as const,
+      minimumAmount: 243_800,
+      maximumAmount: 243_800,
+      annualizedMinimumAmount: 243_800,
+      annualizedMaximumAmount: 243_800,
+      annualizationAssumption: "Source text states annual compensation.",
+      confidence: "high" as const,
+      parserVersion: "posted-compensation-v2",
+      warnings: [
+        {
+          code: "source_text_truncated" as const,
+          message:
+            "Only a bounded posting excerpt is stored; the excerpt below shows exactly what was parsed.",
+        },
+        {
+          code: "equity_component" as const,
+          message:
+            "The posting also mentions stock or equity; unpriced equity is not added to the displayed amount.",
+        },
+      ],
+    };
+    const estimate = {
+      ...sampleCompensationAudit.market.estimate,
+      estimateState: "insufficient_evidence" as const,
+      confidenceBand: "low" as const,
+      confidenceScore: 0.4,
+      sourceCount: 2,
+      sampleCount: null,
+      seniorityLabel: "director",
+      companyName: "DuckDuckGo",
+      normalizedCompany: "duckduckgo",
+      roleTitle: "Privacy Engineering Director",
+      normalizedRole: "privacy engineering director",
+      estimatorVersion: "company-role-reported-compensation-v3",
+      matchScope: "same_location_role_fallback" as const,
+      benchmarkLineage: null,
+      evidence,
+      sources: [
+        sampleCompensationAudit.market.estimate.sources[0]!,
+        {
+          ...sampleCompensationAudit.market.estimate.sources[1]!,
+          sourceId: "euro_top_tech" as const,
+          provenance: "public" as const,
+          displayName: "Euro Top Tech",
+          snapshotVersion: "euro-top-tech-2026",
+          sampleCount: 92,
+        },
+      ],
+      factors: [
+        {
+          name: "company" as const,
+          score: 0.45,
+          band: "low" as const,
+          reason: "Reported rows matched company DuckDuckGo.",
+        },
+        {
+          name: "role" as const,
+          score: 0.55,
+          band: "low" as const,
+          reason: "Reported rows matched role Privacy Engineering Director.",
+        },
+        {
+          name: "level" as const,
+          score: 0.75,
+          band: "medium" as const,
+          reason: "Level support: staff_plus.",
+        },
+      ],
+      insufficientReasons: [
+        {
+          code: "source_dispersion_too_high" as const,
+          message:
+            "Reported compensation rows diverged too much to emit a precise range.",
+        },
+        {
+          code: "weak_company_match" as const,
+          message: "Company match support was too weak for a range.",
+        },
+      ],
+    };
+    const compensationSummary = {
+      ...sampleCompensationSummary,
+      posted: {
+        ...sampleCompensationSummary.posted,
+        confidence: "high" as const,
+        warningCount: 2,
+        range: {
+          ...sampleCompensationSummary.posted.range!,
+          currency: "USD",
+          component: "unknown" as const,
+          minimumAmount: 243_800,
+          maximumAmount: 243_800,
+          annualizedMinimumAmount: 243_800,
+          annualizedMaximumAmount: 243_800,
+          displayRange: "USD 243800/year",
+        },
+        displayRange: "USD 243800/year",
+      },
+      market: {
+        ...sampleCompensationSummary.market,
+        benchmarkKind: null,
+        estimateState: "insufficient_evidence" as const,
+        confidenceBand: "low" as const,
+        confidenceScore: 0.4,
+        sourceCount: 2,
+        sampleCount: null,
+        range: null,
+        displayRange: null,
+        confidenceInterval: null,
+        displayConfidenceInterval: null,
+      },
+    };
+
+    server.use(
+      http.get("*/v1/jobs/:jobKey", ({ params }) =>
+        HttpResponse.json(
+          makeJobDetail(
+            {
+              ...sampleSecondaryJob,
+              jobKey: String(params["jobKey"]),
+              title: "Privacy Engineering Director",
+              company: "DuckDuckGo",
+              location: "Spain",
+              compensationSummary,
+            },
+            {
+              compensationAudit: {
+                ...sampleCompensationAudit,
+                posted: {
+                  ok: true,
+                  recordStatus: "recorded",
+                  fact: postedFact,
+                },
+                market: { ok: true, recordStatus: "recorded", estimate },
+              },
+            },
+          ),
+        ),
+      ),
+    );
+
+    renderJobDetailDrawer("job-privacy-director");
+
+    const compensation = await screen.findByRole("region", {
+      name: "Compensation evidence",
+    });
+    expect(
+      within(compensation).getByText("USD 243800/year"),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText("No reliable market range yet"),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText(
+        /93 evidence records were reviewed across 2 providers/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText("Why no range is shown"),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText(/diverged too much/i),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText(/too weak for a range/i),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText(
+        /stock or equity is mentioned separately/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).queryByText(/posted confidence/i),
+    ).not.toBeInTheDocument();
+    expect(
+      within(compensation).queryByText("source_text_truncated"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(compensation).queryByText("staff plus"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(compensation).queryByText("Observation JSON path (optional)"),
+    ).not.toBeInTheDocument();
+
+    const evidenceSummary = within(compensation).getByText("Evidence reviewed");
+    expect(evidenceSummary.closest("details")).toHaveTextContent(
+      "93 evidence records · 2 providers",
+    );
+    fireEvent.click(evidenceSummary);
+    expect(
+      within(compensation).getAllByText("Euro Top Tech").length,
+    ).toBeGreaterThan(0);
+
+    const assessmentSummary = within(compensation).getByText(
+      "How this was assessed",
+    );
+    expect(assessmentSummary.closest("details")).toHaveTextContent("director");
+    fireEvent.click(assessmentSummary);
+    expect(
+      within(compensation).getByText("Benchmark level").closest("div"),
+    ).toHaveTextContent("director");
+    expect(
+      within(compensation).getByText(
+        "No direct DuckDuckGo salary record matched; same-location role evidence provides 45% support.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(compensation).getByText(
+        /not a probability that the salary is correct/i,
+      ),
+    ).toBeInTheDocument();
   });
 
   it("shows employer requirements beside canonical requirement fit evidence", async () => {

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -28,6 +28,15 @@ Start the attached full stack with `corepack pnpm dev` when the path needs the
 API, Temporal, worker, and web app together. Confirm `GET /v1/health` reports a
 healthy worker before starting worker-backed stages.
 
+For compensation changes, the Job Detail product-path check must cover both an
+accepted range and an insufficient-evidence result. Verify that the posted
+amount and market range (or explicit no-reliable-range outcome) are the visual
+headlines; cash is not relabelled as separately mentioned equity; the inferred
+level is correct; evidence/provider counts expand into the actual salary
+evidence records and reported sample counts; reliability percentages explain
+their basis; and the normal focused refresh has no local observation-path
+input.
+
 ## Pick The Right Checklist
 
 | You changed… | Use |

--- a/docs/user/compensation-evidence.md
+++ b/docs/user/compensation-evidence.md
@@ -26,6 +26,11 @@ for comparison:
    Unknown periods are not annualized. Missing currency/period, hourly
    conversion, broad ranges, and ambiguity lower confidence and remain visible
    as warnings.
+4. **Keep cash and equity separate.** When a posting states one cash amount and
+   mentions stock or equity as an additional benefit, the cash amount remains
+   the posted figure and the unpriced equity is not folded into it. Extraction
+   certainty describes the parser only; it is not presented as doubt that the
+   employer stated the amount.
 
 ### Direct and extrapolated market benchmarks
 
@@ -58,7 +63,9 @@ for comparison:
    again after seven days.
 
 Employer-posted facts may be parsed when Discovery ingests or refreshes a job
-and are also reparsed during an explicit compensation refresh. Direct benchmark
+and are also reparsed during an explicit compensation refresh. When the
+deterministic parser changes, worker startup upgrades known older facts in
+bounded, retry-safe batches before rebuilding their read models. Direct benchmark
 discovery and geographic extrapolation run automatically at the end of
 Discover, after terminal enrichment and before terminal preparation fan-out.
 The existing explicit compensation refresh remains available for focused
@@ -71,18 +78,21 @@ passive read of persisted evidence; it does not fetch or recalculate salary.
   minimum and maximum, reported-market estimate, confidence, and warnings. A
   missing value remains visibly missing rather than being guessed.
 - `/jobs/:jobId` opens the full **Compensation evidence** section. It separates
-  the posted-salary parse from the reported company-role market estimate. A
-  direct benchmark names its exact country evidence; an extrapolated benchmark
-  shows the anchor-to-target geography bridge, every direct salary and official
-  price-level input, sample counts, company-evidence weight, raw factor,
-  supported `0.1x` to `10x` bounds, formula version, fact IDs, and freshness.
-  Parse/estimate state, range, confidence, warnings, attribution, source trail,
-  selected evidence, and matching factors remain visible alongside that
-  lineage.
+  the amount stated by the employer from the market salary estimate and leads
+  with those two decision outcomes. If the selected evidence cannot support a
+  trustworthy market range, the screen says that no reliable range is
+  available and explains why instead of surfacing a candidate span. The actual
+  evidence records, reported sample counts, and provider snapshots are
+  available under **Evidence reviewed**. Role/level matching, reliability
+  percentages, warnings, direct benchmark authority, and geographic
+  extrapolation lineage remain available under **How this was assessed**. A
+  reliability percentage is an evidence support input, not a probability that
+  the salary is correct.
 - The Job Detail workspace can still start a focused compensation refresh. The
-  Jobs toolbar can refresh the current backlog. An optional local observation
-  import can be supplied to that explicit refresh; automatic discovery does not
-  infer permission from the presence of a local file.
+  Jobs toolbar can refresh the current backlog. The normal job-detail action
+  uses configured sources and has no per-job file-path field. Advanced local
+  observation imports remain available only through the CLI or API; automatic
+  discovery does not infer permission from the presence of a local file.
 - `/apply-review` shows the persisted compensation summary as context. It is not
   an Apply readiness or approval gate.
 - `/settings` owns **Compensation sources** policy. Enabling or disabling a

--- a/workers/automation/src/jobctrl/cli.py
+++ b/workers/automation/src/jobctrl/cli.py
@@ -62,7 +62,7 @@ _TIER2_STAGE_FEATURES = {
 _projection_subscription = None
 
 
-def _bootstrap() -> None:
+def _bootstrap(*, reconcile_posted_compensation: bool = False) -> None:
     """Common setup: load env, create dirs, init DB, refresh projections.
 
     Phase 9 (S-32): the ``ProjectionBuilder`` runs an initial backfill on
@@ -77,7 +77,7 @@ def _bootstrap() -> None:
     """
     global _projection_subscription
     from jobctrl.config import load_env, ensure_dirs
-    from jobctrl.database import get_connection, init_db
+    from jobctrl.database import close_connection, get_connection, init_db
     from jobctrl.infrastructure.projections.projection_builder import (
         ProjectionBuilder,
     )
@@ -92,6 +92,26 @@ def _bootstrap() -> None:
     from jobctrl.infrastructure.observability import init_otel
 
     init_otel()
+    if reconcile_posted_compensation:
+        try:
+            from jobctrl.infrastructure.compensation import (
+                SqlitePostedCompensationRepository,
+            )
+
+            maintenance_conn = get_connection()
+            try:
+                SqlitePostedCompensationRepository(maintenance_conn).reparse_outdated_facts(
+                    tenant_id="local",
+                    parsed_at=datetime.now(timezone.utc).isoformat(),
+                )
+            finally:
+                # The worker does not need this maintenance handle again
+                # before projection bootstrap. Close it deterministically so
+                # neither a failed write nor future connection configuration
+                # can leak a lock into the long-lived worker process.
+                close_connection()
+        except Exception:  # noqa: BLE001 - retry on the next worker start
+            log.exception("Posted compensation parser reconciliation failed")
     try:
         # Pass a thread-local connection factory so the wildcard
         # subscriber (which fires on whichever thread published the
@@ -105,6 +125,15 @@ def _bootstrap() -> None:
 
             _projection_subscription = builder.subscribe_to(get_default_publisher())
     except Exception:  # noqa: BLE001 — projection refresh failure must not break boot
+        # A failed rebuild may leave SQLite inside the write transaction that
+        # contains its partial projection changes. Keeping the long-lived
+        # RPC/worker process on that handle would hold the rollback journal and
+        # block every API reader. Roll back before degrading startup so the
+        # existing projections remain readable and a later refresh can retry.
+        try:
+            get_connection().rollback()
+        except Exception:  # noqa: BLE001 - preserve the original failure
+            log.exception("ProjectionBuilder bootstrap rollback failed")
         log.exception("ProjectionBuilder backfill on bootstrap failed")
 
 
@@ -2256,7 +2285,7 @@ def worker(
     ),
 ) -> None:
     """Run the long-lived JobCtrl Temporal worker."""
-    _bootstrap()
+    _bootstrap(reconcile_posted_compensation=True)
 
     # Verify the browser this worker needs is installed before we connect to
     # Temporal and start accepting activities — a missing binary must surface

--- a/workers/automation/src/jobctrl/domain/compensation/benchmarks.py
+++ b/workers/automation/src/jobctrl/domain/compensation/benchmarks.py
@@ -144,6 +144,7 @@ _ROLE_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
             "cybersecurity",
             "information security",
             "privacy engineer",
+            "privacy engineering",
             "security",
             "trust and safety",
         ),

--- a/workers/automation/src/jobctrl/domain/compensation/market.py
+++ b/workers/automation/src/jobctrl/domain/compensation/market.py
@@ -11,7 +11,7 @@ from typing import Literal
 
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 
-ESTIMATOR_VERSION = "company-role-reported-compensation-v2"
+ESTIMATOR_VERSION = "company-role-reported-compensation-v3"
 
 MarketEstimateState = Literal[
     "not_requested",
@@ -616,11 +616,34 @@ def estimate_market_compensation(
     level_score = min(level_scores)
     location_score = min(location_scores)
     freshness_score = min(freshness_scores)
+    company_percent = round(company_score * 100)
+    role_percent = round(role_score * 100)
+    level_percent = round(level_score * 100)
+    company_reason = {
+        "exact_company_role": f"Direct reported salary rows matched {company}; company support is {company_percent}%.",
+        "company_adjacent_role": (
+            f"Direct {company} rows matched, but only for adjacent roles; company support is {company_percent}%."
+        ),
+        "tier_role_fallback": (
+            f"No direct {company} salary row matched; comparable companies provide {company_percent}% company support."
+        ),
+        "same_location_role_fallback": (
+            f"No direct {company} salary row matched; comparable roles in the same location provide "
+            f"{company_percent}% company support."
+        ),
+        "market_baseline_fallback": (
+            f"No direct {company} salary row matched; broader market evidence provides {company_percent}% company support."
+        ),
+    }.get(match_scope, f"Company evidence provides {company_percent}% support.")
+    role_reason = f"Selected salary rows provide {role_percent}% role support for {title}."
+    level_reason = (
+        f"The job title was classified as {inferred_level}; selected rows provide {level_percent}% seniority support."
+    )
     factors.extend(
         [
-            _factor("company", company_score, f"Reported rows matched company {company}."),
-            _factor("role", role_score, f"Reported rows matched role {title}."),
-            _factor("level", level_score, f"Level support: {inferred_level}."),
+            _factor("company", company_score, company_reason),
+            _factor("role", role_score, role_reason),
+            _factor("level", level_score, level_reason),
             _factor(
                 "location", location_score, "Location compatibility was evaluated but company-role evidence is primary."
             ),
@@ -1223,7 +1246,9 @@ def _level_from_title(title: str | None) -> str:
     tokens = set(_role_tokens(title))
     if {"ceo", "chief", "cio", "ciso", "coo", "cpo", "cto", "president", "vice", "vp"} & tokens:
         return "executive"
-    if {"staff", "principal", "lead", "director", "head"} & tokens:
+    if {"director", "head"} & tokens:
+        return "director"
+    if {"staff", "principal", "lead"} & tokens:
         return "staff_plus"
     if {"senior", "sr"} & tokens:
         return "senior"
@@ -1241,10 +1266,14 @@ def _level_score(expected: str | None, observed: str | None) -> float:
         return 0.5 if expected_level == "executive" else 0.75
     if expected_level == observed_level:
         return 0.95
-    if expected_level == "executive" and observed_level in {"staff_plus", "manager"}:
+    if expected_level == "executive" and observed_level in {"director", "staff_plus", "manager"}:
         return 0.45
-    if observed_level == "executive" and expected_level in {"staff_plus", "manager"}:
+    if observed_level == "executive" and expected_level in {"director", "staff_plus", "manager"}:
         return 0.45
+    if expected_level == "director" and observed_level in {"staff_plus", "manager"}:
+        return 0.82
+    if observed_level == "director" and expected_level in {"staff_plus", "manager"}:
+        return 0.82
     if expected_level == "senior" and observed_level == "staff_plus":
         return 0.82
     if expected_level == "staff_plus" and observed_level == "senior":
@@ -1261,7 +1290,9 @@ def _normalize_level(value: str | None) -> str:
         return "unknown"
     if {"ceo", "chief", "cio", "ciso", "coo", "cpo", "cto", "executive", "president", "vice", "vp"} & tokens:
         return "executive"
-    if {"staff", "principal", "lead", "director", "head", "l6", "l7", "l8"} & tokens:
+    if {"director", "head"} & tokens:
+        return "director"
+    if {"staff", "principal", "lead", "l6", "l7", "l8"} & tokens:
         return "staff_plus"
     if {"senior", "sr", "l5"} & tokens:
         return "senior"

--- a/workers/automation/src/jobctrl/domain/compensation/posted.py
+++ b/workers/automation/src/jobctrl/domain/compensation/posted.py
@@ -11,7 +11,7 @@ from typing import Literal
 
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 
-PARSER_VERSION = "posted-compensation-v1"
+PARSER_VERSION = "posted-compensation-v2"
 SOURCE_TEXT_LIMIT = 280
 
 ParseState = Literal["missing", "unparseable", "ambiguous", "parsed_range"]
@@ -154,7 +154,6 @@ def parse_posted_compensation(
         )
 
     lower = bounded.casefold()
-    component = _detect_component(lower)
     warnings.extend(_component_warnings(lower))
     currency = _detect_currency(bounded)
     if currency is None:
@@ -204,6 +203,7 @@ def parse_posted_compensation(
             source_hash=source_hash,
         )
 
+    component = _detect_component(lower, amounts)
     minimum, maximum, one_sided = _range_bounds(amounts, lower)
     if one_sided:
         warnings.append("one_sided_range")
@@ -318,18 +318,51 @@ def _period_warnings(period: CompensationPeriod) -> list[WarningCode]:
     return []
 
 
-def _detect_component(lower: str) -> CompensationComponent:
-    if re.search(r"\bbase\b|\bsalary\b|\bpay\b|\bwage\b", lower):
-        return "base_salary"
-    if re.search(r"\bote\b|on[- ]target earnings", lower):
-        return "ote"
-    if "commission" in lower:
-        return "commission"
-    if "bonus" in lower:
-        return "bonus"
-    if re.search(r"\bequity\b|\brsu\b|\bstock options?\b", lower):
+def _detect_component(lower: str, amounts: list[_Amount]) -> CompensationComponent:
+    """Bind the amount to its nearest governing compensation cue.
+
+    Description excerpts can mention multiple compensation concepts. Component
+    authority belongs to the cue governing the parsed amount, not to an
+    unrelated word elsewhere in the bounded excerpt.
+    """
+
+    anchor_start = min(amount.start for amount in amounts)
+    anchor_end = max(amount.end for amount in amounts)
+    suffix = lower[anchor_end : anchor_end + 64]
+    additive_equity = re.match(
+        r"^.{0,40}(?:\+|\bplus\b|\band\b).{0,24}\b(?:equity|rsus?|stock options?)\b",
+        suffix,
+    )
+    if additive_equity is None and re.match(
+        r"^.{0,24}\b(?:in|as)\s+(?:equity|rsus?|stock options?)\b",
+        suffix,
+    ):
         return "equity"
-    return "unknown"
+    candidates: list[tuple[int, int, CompensationComponent]] = []
+    cue_patterns: tuple[tuple[CompensationComponent, re.Pattern[str]], ...] = (
+        ("equity", re.compile(r"\b(?:equity|stock) compensation\b")),
+        ("equity", re.compile(r"\b(?:equity|rsus?|stock options?)\b")),
+        ("ote", re.compile(r"\bote\b|on[- ]target earnings")),
+        ("commission", re.compile(r"\bcommission(?:\s+compensation)?\b")),
+        ("bonus", re.compile(r"\bbonus(?:\s+compensation)?\b")),
+        (
+            "base_salary",
+            re.compile(r"\b(?:base salary|base pay|base|pay range|salary|wage|remuneration)\b"),
+        ),
+        ("unknown", re.compile(r"\b(?:total\s+)?compensation(?:\s+range)?\b")),
+    )
+    for priority, (component, pattern) in enumerate(cue_patterns):
+        for match in pattern.finditer(lower):
+            if match.end() <= anchor_start:
+                distance = anchor_start - match.end()
+            elif match.start() >= anchor_end:
+                distance = match.start() - anchor_end
+            else:
+                distance = 0
+            candidates.append((distance, priority, component))
+    if not candidates:
+        return "unknown"
+    return min(candidates)[2]
 
 
 def _component_warnings(lower: str) -> list[WarningCode]:
@@ -362,7 +395,7 @@ def _has_mixed_compensation_components(lower: str) -> bool:
 def _has_additive_component_phrase(lower: str) -> bool:
     return bool(
         re.search(
-            r"(?:\+|\bplus\b|\band\b).{0,24}\b(?:bonus|commission|equity|rsu|ote|on[- ]target earnings)\b",
+            r"(?:\+|\bplus\b|\band\b).{0,24}\b(?:bonus|commission|equity|rsu|stock options?|ote|on[- ]target earnings)\b",
             lower,
         )
     )
@@ -503,7 +536,7 @@ def _confidence(
         return "low"
     if {"hourly_period", "broad_range", "ambiguous_multiple_amounts"} & warning_set:
         return "low"
-    if warning_set:
+    if {"missing_currency", "missing_period", "monthly_period", "one_sided_range"} & warning_set:
         return "medium"
     return "high"
 

--- a/workers/automation/src/jobctrl/domain/compensation/posted.py
+++ b/workers/automation/src/jobctrl/domain/compensation/posted.py
@@ -11,7 +11,7 @@ from typing import Literal
 
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 
-PARSER_VERSION = "posted-compensation-v2"
+PARSER_VERSION = "posted-compensation-v3"
 SOURCE_TEXT_LIMIT = 280
 
 ParseState = Literal["missing", "unparseable", "ambiguous", "parsed_range"]
@@ -75,6 +75,52 @@ _DIRECT_PERIOD_SUFFIX_RE = re.compile(
     r"^\s*(?:(?:/|\bper\s+)(?:hour|hourly|hr|hrs|h|month|monthly|mo|mos|year|yearly|annum|yr|yrs)\b)",
     re.IGNORECASE,
 )
+_PERIOD_CUE_PATTERNS: tuple[
+    tuple[CompensationPeriod, int, re.Pattern[str]],
+    ...,
+] = (
+    (
+        "hour",
+        0,
+        re.compile(r"/(?:h|hr|hrs|hour)\b|\bper\s+(?:h|hr|hrs|hour|hourly)\b"),
+    ),
+    (
+        "month",
+        0,
+        re.compile(r"/(?:mo|mos|month)\b|\bper\s+(?:mo|mos|month|monthly)\b"),
+    ),
+    (
+        "year",
+        0,
+        re.compile(
+            r"/(?:yr|yrs|year)\b|\bper\s+(?:yr|yrs|year|yearly|annum)\b",
+        ),
+    ),
+    ("hour", 1, re.compile(r"\b(?:hour|hourly)\b")),
+    ("month", 1, re.compile(r"\b(?:month|monthly)\b")),
+    (
+        "year",
+        1,
+        re.compile(r"\b(?:year|yearly|annual|annually|annum)\b"),
+    ),
+)
+_BARE_PERIOD_SUFFIX_PATTERNS: tuple[tuple[CompensationPeriod, re.Pattern[str]], ...] = (
+    (
+        "hour",
+        re.compile(
+            r"^(?P<gap>[ \t]{1,3})(?:hr|hrs)\b"
+            r"(?=[ \t]*(?:$|[-–—/,.;:!?()]|[\[\]{}]|\b(?:to|through|plus|and)\b))"
+        ),
+    ),
+    (
+        "year",
+        re.compile(
+            r"^(?P<gap>[ \t]{1,3})(?:yr|yrs)\b"
+            r"(?=[ \t]*(?:$|[-–—/,.;:!?()]|[\[\]{}]|\b(?:to|through|plus|and)\b))"
+        ),
+    ),
+)
+_MAX_PERIOD_CUE_DISTANCE = 64
 
 
 @dataclass(frozen=True)
@@ -158,10 +204,9 @@ def parse_posted_compensation(
     currency = _detect_currency(bounded)
     if currency is None:
         warnings.append("missing_currency")
-    period = _detect_period(lower)
-    warnings.extend(_period_warnings(period))
-
     amounts = _extract_amounts(bounded)
+    period = _detect_period(bounded, amounts)
+    warnings.extend(_period_warnings(period))
     if not amounts:
         return _non_range_fact(
             tenant_id=tenant_id,
@@ -298,14 +343,50 @@ def _detect_currency(text: str) -> str | None:
     return None
 
 
-def _detect_period(lower: str) -> CompensationPeriod:
-    if re.search(r"(?:/(?:h|hr|hrs|hour)|\b(?:hour|hourly|hr|hrs)\b)", lower):
-        return "hour"
-    if re.search(r"(?:/(?:mo|mos|month)|\b(?:month|monthly)\b)", lower):
-        return "month"
-    if re.search(r"(/|\b)(year|yearly|annual|annually|annum|yr|yrs)\b", lower):
-        return "year"
-    return "unknown"
+def _detect_period(text: str, amounts: list[_Amount]) -> CompensationPeriod:
+    """Resolve the pay period from cues governing the parsed amount.
+
+    Compensation excerpts can contain unrelated abbreviations such as "HR".
+    A period cue therefore has authority only when it is close to one of the
+    parsed amounts. Bare abbreviations additionally remain case-sensitive so
+    human-resources prose cannot become an hourly unit after whitespace
+    normalization. Explicit slash/per forms win a same-distance tie, and
+    conflicting equally-near cues fail closed to ``unknown``.
+    """
+
+    if not amounts:
+        return "unknown"
+    lower = text.casefold()
+    candidates: list[tuple[int, int, CompensationPeriod]] = []
+    for period, priority, pattern in _PERIOD_CUE_PATTERNS:
+        for match in pattern.finditer(lower):
+            distance = min(_distance_between(match.start(), match.end(), amount) for amount in amounts)
+            if distance <= _MAX_PERIOD_CUE_DISTANCE:
+                candidates.append((distance, priority, period))
+    for amount in amounts:
+        suffix = text[amount.end :]
+        for period, pattern in _BARE_PERIOD_SUFFIX_PATTERNS:
+            if match := pattern.match(suffix):
+                candidates.append((len(match.group("gap")), 1, period))
+    if not candidates:
+        return "unknown"
+    winning_distance, winning_priority, _period = min(candidates)
+    winning_periods = {
+        period
+        for distance, priority, period in candidates
+        if distance == winning_distance and priority == winning_priority
+    }
+    if len(winning_periods) != 1:
+        return "unknown"
+    return winning_periods.pop()
+
+
+def _distance_between(start: int, end: int, amount: _Amount) -> int:
+    if end <= amount.start:
+        return amount.start - end
+    if start >= amount.end:
+        return start - amount.end
+    return 0
 
 
 def _period_warnings(period: CompensationPeriod) -> list[WarningCode]:

--- a/workers/automation/src/jobctrl/infrastructure/compensation/refresh.py
+++ b/workers/automation/src/jobctrl/infrastructure/compensation/refresh.py
@@ -37,7 +37,17 @@ def refresh_compensation_facts(
     if job_id is not None:
         job_id = canonical_job_id(str(job_id))
         row = conn.execute(
-            "SELECT job_id, url, salary, full_description, description FROM jobs WHERE tenant_id = ? AND job_id = ?",
+            """
+            SELECT jobs.job_id, jobs.url, jobs.salary,
+                   enrichments.full_description AS enrichment_description,
+                   jobs.full_description, jobs.description
+            FROM jobs
+            LEFT JOIN job_enrichments AS enrichments
+              ON enrichments.tenant_id = jobs.tenant_id
+             AND enrichments.job_id = jobs.job_id
+             AND enrichments.current_status = 'enriched'
+            WHERE jobs.tenant_id = ? AND jobs.job_id = ?
+            """,
             (tenant_id, job_id),
         ).fetchone()
         if row is None:

--- a/workers/automation/src/jobctrl/infrastructure/compensation/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/compensation/sqlite_repository.py
@@ -54,6 +54,14 @@ ADDITIVE_EQUITY_AFTER_AMOUNT_RE = re.compile(
     r"^.{0,40}(?:\+|\bplus\b|\band\b).{0,24}\b(?:equity|rsu|stock options?)\b",
     re.IGNORECASE,
 )
+OUTDATED_POSTED_PARSER_VERSIONS = (
+    "posted-compensation-v1",
+    "posted-compensation-v2",
+)
+
+
+def _parser_version_tag(parser_version: str) -> str:
+    return parser_version.removeprefix("posted-compensation-")
 
 
 class SqlitePostedCompensationRepository:
@@ -115,11 +123,11 @@ class SqlitePostedCompensationRepository:
                  AND enrichments.job_id = jobs.job_id
                  AND enrichments.current_status = 'enriched'
                 WHERE facts.tenant_id = ?
-                  AND facts.parser_version = 'posted-compensation-v1'
+                  AND facts.parser_version IN (?, ?)
                 ORDER BY jobs.url
                 LIMIT ?
                 """,
-                (tenant_id, batch_size),
+                (tenant_id, *OUTDATED_POSTED_PARSER_VERSIONS, batch_size),
             ).fetchall()
             if not rows:
                 return total
@@ -130,6 +138,9 @@ class SqlitePostedCompensationRepository:
             try:
                 for row in rows:
                     job_id = canonical_job_id(str(_maintenance_row_value(row, "job_id")))
+                    source_parser_version = str(
+                        _maintenance_row_value(row, "parser_version"),
+                    )
                     source_text, source_field = _posted_source_from_values(
                         salary=_maintenance_row_value(row, "salary"),
                         enrichment_description=_maintenance_row_value(
@@ -154,7 +165,11 @@ class SqlitePostedCompensationRepository:
                     self._save_fact_row(fact)
                     self._record_updated_event(
                         fact,
-                        idempotency_key=(f"posted-parser-upgrade:{tenant_id}:{job_id}:v1:v2"),
+                        idempotency_key=(
+                            f"posted-parser-upgrade:{tenant_id}:{job_id}:"
+                            f"{_parser_version_tag(source_parser_version)}:"
+                            f"{_parser_version_tag(PARSER_VERSION)}"
+                        ),
                         publisher=publisher,
                         commit=False,
                         suppress_missing_table=False,

--- a/workers/automation/src/jobctrl/infrastructure/compensation/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/compensation/sqlite_repository.py
@@ -8,7 +8,12 @@ import sqlite3
 from dataclasses import replace
 from typing import Any, Callable
 
-from jobctrl.domain.compensation import PostedCompensationFact, parse_posted_compensation
+from jobctrl.domain.compensation import (
+    PARSER_VERSION,
+    PostedCompensationFact,
+    parse_posted_compensation,
+)
+from jobctrl.domain.events.base import DomainEvent
 from jobctrl.domain.identifiers import JobId, canonical_job_id
 
 COMPENSATION_SOURCE_RE = re.compile(
@@ -36,6 +41,19 @@ PAY_PERIOD_RE = re.compile(
     r"(?:/(?:h|hr|hrs|hour|mo|mos|month)|\b(?:hour|hourly|hr|hrs|month|monthly|year|yearly|annual|annually|annum|yr|yrs)\b)",
     re.IGNORECASE,
 )
+GENERIC_COMPENSATION_AMOUNT_CUE_RE = re.compile(
+    r"\bcompensation(?:\s+range)?\s*(?::|-|\bis\b)?\s*$",
+    re.IGNORECASE,
+)
+EXPLICIT_COMPONENT_AMOUNT_CUE_RE = re.compile(
+    r"\b(?:(?:equity|stock)\s+compensation|bonus(?:\s+compensation)?|"
+    r"commission(?:\s+compensation)?)\s*(?::|-|\bis\b)?\s*$",
+    re.IGNORECASE,
+)
+ADDITIVE_EQUITY_AFTER_AMOUNT_RE = re.compile(
+    r"^.{0,40}(?:\+|\bplus\b|\band\b).{0,24}\b(?:equity|rsu|stock options?)\b",
+    re.IGNORECASE,
+)
 
 
 class SqlitePostedCompensationRepository:
@@ -54,6 +72,110 @@ class SqlitePostedCompensationRepository:
         if fact.job_id is None:
             raise ValueError("JobId is required to persist a posted compensation fact")
         fact = replace(fact, job_id=canonical_job_id(str(fact.job_id)))
+        self._save_fact_row(fact)
+        self._conn.commit()
+        if event_write_fence is not None:
+            event_write_fence()
+        self._record_updated_event(
+            fact,
+            idempotency_key=event_idempotency_key,
+        )
+
+    def reparse_outdated_facts(
+        self,
+        *,
+        tenant_id: str = "local",
+        parsed_at: str,
+        batch_size: int = 100,
+    ) -> int:
+        """Upgrade known older parser generations with atomic dirty events.
+
+        This is a worker-start convergence path, not a read-side repair. Each
+        bounded batch commits canonical facts and their durable events
+        together, so a crash either leaves a row eligible for retry or leaves
+        a projection-dirty event that the normal builder can fold.
+        """
+
+        if batch_size < 1:
+            raise ValueError("batch_size must be positive")
+        total = 0
+        while True:
+            rows = self._conn.execute(
+                """
+                SELECT facts.job_id, jobs.salary,
+                       enrichments.full_description AS enrichment_description,
+                       jobs.full_description, jobs.description,
+                       facts.parser_version
+                FROM job_posted_compensation_facts AS facts
+                JOIN jobs
+                  ON jobs.tenant_id = facts.tenant_id
+                 AND jobs.job_id = facts.job_id
+                LEFT JOIN job_enrichments AS enrichments
+                  ON enrichments.tenant_id = jobs.tenant_id
+                 AND enrichments.job_id = jobs.job_id
+                 AND enrichments.current_status = 'enriched'
+                WHERE facts.tenant_id = ?
+                  AND facts.parser_version = 'posted-compensation-v1'
+                ORDER BY jobs.url
+                LIMIT ?
+                """,
+                (tenant_id, batch_size),
+            ).fetchall()
+            if not rows:
+                return total
+
+            publisher = _BufferedEventPublisher()
+            savepoint = "posted_compensation_parser_upgrade"
+            self._conn.execute(f"SAVEPOINT {savepoint}")
+            try:
+                for row in rows:
+                    job_id = canonical_job_id(str(_maintenance_row_value(row, "job_id")))
+                    source_text, source_field = _posted_source_from_values(
+                        salary=_maintenance_row_value(row, "salary"),
+                        enrichment_description=_maintenance_row_value(
+                            row,
+                            "enrichment_description",
+                        ),
+                        full_description=_maintenance_row_value(
+                            row,
+                            "full_description",
+                        ),
+                        description=_maintenance_row_value(row, "description"),
+                    )
+                    fact = parse_posted_compensation(
+                        source_text,
+                        tenant_id=tenant_id,
+                        job_id=job_id,
+                        source_field=source_field,
+                        parsed_at=parsed_at,
+                    )
+                    if fact.parser_version != PARSER_VERSION:
+                        raise RuntimeError("posted parser did not emit current version")
+                    self._save_fact_row(fact)
+                    self._record_updated_event(
+                        fact,
+                        idempotency_key=(f"posted-parser-upgrade:{tenant_id}:{job_id}:v1:v2"),
+                        publisher=publisher,
+                        commit=False,
+                        suppress_missing_table=False,
+                    )
+            except BaseException:
+                self._conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+                self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+                raise
+            else:
+                self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+                self._conn.commit()
+                from jobctrl.infrastructure.events import get_default_publisher
+
+                destination = get_default_publisher()
+                for event in publisher.events:
+                    destination.publish(event)
+                total += len(rows)
+
+    def _save_fact_row(self, fact: PostedCompensationFact) -> None:
+        """Persist a fact without committing; callers own transaction scope."""
+
         self._conn.execute(
             """
             INSERT INTO job_posted_compensation_facts (
@@ -64,52 +186,25 @@ class SqlitePostedCompensationRepository:
                 source_hash, parsed_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(tenant_id, job_id) DO UPDATE SET
-                source_field                 = excluded.source_field,
-                source_text                  = excluded.source_text,
-                legacy_raw_salary            = excluded.legacy_raw_salary,
-                parse_state                  = excluded.parse_state,
-                currency                     = excluded.currency,
-                period                       = excluded.period,
-                component                    = excluded.component,
-                minimum_amount               = excluded.minimum_amount,
-                maximum_amount               = excluded.maximum_amount,
-                annualized_minimum_amount    = excluded.annualized_minimum_amount,
-                annualized_maximum_amount    = excluded.annualized_maximum_amount,
-                annualization_assumption     = excluded.annualization_assumption,
-                confidence                   = excluded.confidence,
-                warnings_json                = excluded.warnings_json,
-                parser_version               = excluded.parser_version,
-                source_hash                  = excluded.source_hash,
-                parsed_at                    = excluded.parsed_at
+                source_field = excluded.source_field,
+                source_text = excluded.source_text,
+                legacy_raw_salary = excluded.legacy_raw_salary,
+                parse_state = excluded.parse_state,
+                currency = excluded.currency,
+                period = excluded.period,
+                component = excluded.component,
+                minimum_amount = excluded.minimum_amount,
+                maximum_amount = excluded.maximum_amount,
+                annualized_minimum_amount = excluded.annualized_minimum_amount,
+                annualized_maximum_amount = excluded.annualized_maximum_amount,
+                annualization_assumption = excluded.annualization_assumption,
+                confidence = excluded.confidence,
+                warnings_json = excluded.warnings_json,
+                parser_version = excluded.parser_version,
+                source_hash = excluded.source_hash,
+                parsed_at = excluded.parsed_at
             """,
-            (
-                fact.tenant_id,
-                fact.job_id,
-                fact.source_field,
-                fact.source_text,
-                fact.legacy_raw_salary,
-                fact.parse_state,
-                fact.currency,
-                fact.period,
-                fact.component,
-                fact.minimum_amount,
-                fact.maximum_amount,
-                fact.annualized_minimum_amount,
-                fact.annualized_maximum_amount,
-                fact.annualization_assumption,
-                fact.confidence,
-                json.dumps(list(fact.warnings), sort_keys=True),
-                fact.parser_version,
-                fact.source_hash,
-                fact.parsed_at,
-            ),
-        )
-        self._conn.commit()
-        if event_write_fence is not None:
-            event_write_fence()
-        self._record_updated_event(
-            fact,
-            idempotency_key=event_idempotency_key,
+            _fact_values(fact),
         )
 
     def get_fact(self, tenant_id: str, job_id: JobId) -> PostedCompensationFact | None:
@@ -156,13 +251,32 @@ class SqlitePostedCompensationRepository:
 
     def backfill_from_jobs(self, *, tenant_id: str = "local", parsed_at: str | None = None) -> int:
         rows = self._conn.execute(
-            "SELECT job_id, salary, full_description, description FROM jobs WHERE tenant_id = ? ORDER BY url",
+            """
+            SELECT jobs.job_id, jobs.salary,
+                   enrichments.full_description AS enrichment_description,
+                   jobs.full_description, jobs.description
+            FROM jobs
+            LEFT JOIN job_enrichments AS enrichments
+              ON enrichments.tenant_id = jobs.tenant_id
+             AND enrichments.job_id = jobs.job_id
+             AND enrichments.current_status = 'enriched'
+            WHERE jobs.tenant_id = ?
+            ORDER BY jobs.url
+            """,
             (tenant_id,),
         ).fetchall()
         for row in rows:
-            source_text, source_field = posted_compensation_source_from_job(row)
+            source_text, source_field = _posted_source_from_values(
+                salary=_maintenance_row_value(row, "salary"),
+                enrichment_description=_maintenance_row_value(
+                    row,
+                    "enrichment_description",
+                ),
+                full_description=_maintenance_row_value(row, "full_description"),
+                description=_maintenance_row_value(row, "description"),
+            )
             self.parse_and_save_job_salary(
-                canonical_job_id(str(_row_value(row, "job_id"))),
+                canonical_job_id(str(_maintenance_row_value(row, "job_id"))),
                 source_text,
                 tenant_id=tenant_id,
                 source_field=source_field,
@@ -176,6 +290,9 @@ class SqlitePostedCompensationRepository:
         fact: PostedCompensationFact,
         *,
         idempotency_key: str | None = None,
+        publisher: _BufferedEventPublisher | None = None,
+        commit: bool = True,
+        suppress_missing_table: bool = True,
     ) -> None:
         try:
             from jobctrl.state import record_job_event
@@ -188,6 +305,7 @@ class SqlitePostedCompensationRepository:
                 tenant_id=fact.tenant_id,
                 message="Posted compensation fact updated",
                 occurred_at=fact.parsed_at,
+                publisher=publisher,
                 payload={
                     "jobId": str(fact.job_id),
                     "changedSections": ["posted"],
@@ -199,18 +317,44 @@ class SqlitePostedCompensationRepository:
                 },
                 idempotency_key=idempotency_key,
             )
-            self._conn.commit()
+            if commit:
+                self._conn.commit()
         except sqlite3.OperationalError:
-            return
+            if suppress_missing_table:
+                return
+            raise
 
 
 def posted_compensation_source_from_job(row: Any) -> tuple[str | None, str]:
-    salary = _nonempty_text(_job_source_row_value(row, "salary"))
-    if salary is not None:
-        return salary, "jobs.salary"
+    return _posted_source_from_values(
+        salary=_job_source_row_value(row, "salary"),
+        enrichment_description=_job_source_row_value(
+            row,
+            "enrichment_description",
+            optional=True,
+        ),
+        full_description=_job_source_row_value(row, "full_description"),
+        description=_job_source_row_value(row, "description"),
+    )
 
-    for field in ("full_description", "description"):
-        text = _nonempty_text(_job_source_row_value(row, field))
+
+def _posted_source_from_values(
+    *,
+    salary: Any,
+    enrichment_description: Any,
+    full_description: Any,
+    description: Any,
+) -> tuple[str | None, str]:
+    salary_text = _nonempty_text(salary)
+    if salary_text is not None:
+        return salary_text, "jobs.salary"
+
+    for field, value in (
+        ("job_enrichments.full_description", enrichment_description),
+        ("jobs.full_description", full_description),
+        ("jobs.description", description),
+    ):
+        text = _nonempty_text(value)
         if text is None:
             continue
         match = _compensation_source_match(text)
@@ -218,7 +362,7 @@ def posted_compensation_source_from_job(row: Any) -> tuple[str | None, str]:
             continue
         start = max(0, match.start() - 80)
         end = min(len(text), match.end() + 220)
-        return text[start:end].strip(), f"jobs.{field}"
+        return text[start:end].strip(), field
 
     return None, "jobs.salary"
 
@@ -255,18 +399,35 @@ def _compensation_source_match(text: str) -> re.Match[str] | None:
             amount_start,
             amount_end,
         )
-        if base_distance is not None and (
-            non_base_distance is None or base_distance < non_base_distance
+        if EXPLICIT_COMPONENT_AMOUNT_CUE_RE.search(window[:amount_start]):
+            return amount_match
+        if base_distance is not None and (non_base_distance is None or base_distance < non_base_distance):
+            return amount_match
+        if _is_generic_compensation_with_additive_equity(
+            window,
+            amount_start,
+            amount_end,
         ):
             return amount_match
-        if (
-            generic_candidate is None
-            and COMPENSATION_SOURCE_RE.search(window)
-            and non_base_distance is None
-        ):
+        if generic_candidate is None and COMPENSATION_SOURCE_RE.search(window) and non_base_distance is None:
             generic_candidate = amount_match
 
     return generic_candidate or keyword_match
+
+
+def _is_generic_compensation_with_additive_equity(
+    window: str,
+    amount_start: int,
+    amount_end: int,
+) -> bool:
+    prefix = window[:amount_start]
+    cue = GENERIC_COMPENSATION_AMOUNT_CUE_RE.search(prefix)
+    if cue is None:
+        return False
+    cue_context = prefix[max(0, cue.start() - 32) : cue.start()]
+    if NON_BASE_COMPENSATION_CONTEXT_RE.search(cue_context):
+        return False
+    return bool(ADDITIVE_EQUITY_AFTER_AMOUNT_RE.search(window[amount_end:]))
 
 
 def _nearest_match_distance(
@@ -286,10 +447,23 @@ def _nearest_match_distance(
     return min(distances) if distances else None
 
 
-def _job_source_row_value(row: Any, key: str) -> Any:
+def _job_source_row_value(
+    row: Any,
+    key: str,
+    *,
+    optional: bool = False,
+) -> Any:
     if isinstance(row, sqlite3.Row):
+        if optional and key not in row.keys():
+            return None
         return row[key]
-    keys = ("job_id", "salary", "full_description", "description")
+    keys = (
+        ("job_id", "salary", "enrichment_description", "full_description", "description")
+        if len(row) == 5
+        else ("job_id", "salary", "full_description", "description")
+    )
+    if optional and key not in keys:
+        return None
     return row[keys.index(key)]
 
 
@@ -345,6 +519,55 @@ def _row_value(row: sqlite3.Row | tuple[Any, ...], key: str) -> Any:
         "parsed_at",
     )
     return row[keys.index(key)]
+
+
+def _maintenance_row_value(row: sqlite3.Row | tuple[Any, ...], key: str) -> Any:
+    if isinstance(row, sqlite3.Row):
+        return row[key]
+    maintenance_keys = (
+        "job_id",
+        "salary",
+        "enrichment_description",
+        "full_description",
+        "description",
+        "parser_version",
+    )
+    return row[maintenance_keys.index(key)]
+
+
+class _BufferedEventPublisher:
+    def __init__(self) -> None:
+        self.events: list[DomainEvent] = []
+
+    def publish(self, event: DomainEvent) -> None:
+        self.events.append(event)
+
+    def subscribe(self, _event_type: str | None, _handler: Any) -> Any:
+        raise RuntimeError("buffered event publisher does not accept subscriptions")
+
+
+def _fact_values(fact: PostedCompensationFact) -> tuple[Any, ...]:
+    return (
+        fact.tenant_id,
+        fact.job_id,
+        fact.source_field,
+        fact.source_text,
+        fact.legacy_raw_salary,
+        fact.parse_state,
+        fact.currency,
+        fact.period,
+        fact.component,
+        fact.minimum_amount,
+        fact.maximum_amount,
+        fact.annualized_minimum_amount,
+        fact.annualized_maximum_amount,
+        fact.annualization_assumption,
+        fact.confidence,
+        json.dumps(list(fact.warnings), sort_keys=True),
+        fact.parser_version,
+        fact.source_hash,
+        fact.parsed_at,
+    )
 
 
 def _nullable_str(value: Any) -> str | None:

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -324,7 +324,7 @@ POSTED_COMPENSATION_WARNING_MESSAGES = {
     "bonus_component": "The source text mentions bonus compensation.",
     "broad_range": "The posted range is broad enough to reduce precision.",
     "commission_component": "The source text mentions commission compensation.",
-    "equity_component": "The source text mentions equity or stock compensation.",
+    "equity_component": "The posting mentions stock or equity compensation; review the amount type below.",
     "hourly_period": "The source text uses an hourly compensation period.",
     "missing_currency": "The parser could not identify an explicit currency.",
     "missing_period": "The parser could not identify an explicit compensation period.",
@@ -332,7 +332,7 @@ POSTED_COMPENSATION_WARNING_MESSAGES = {
     "no_amount_found": "No compensation amount could be safely extracted.",
     "one_sided_range": "The posted range is one-sided.",
     "ote_component": "The source text mentions on-target earnings.",
-    "source_text_truncated": "The stored source text was truncated to the bounded salary excerpt limit.",
+    "source_text_truncated": "Only a bounded posting excerpt is stored; the excerpt below shows exactly what was parsed.",
 }
 MARKET_COMPENSATION_WARNING_MESSAGES = {
     "benchmark_extrapolated": "The range was extrapolated from direct benchmark evidence in another geography.",

--- a/workers/automation/tests/test_compensation_benchmarks.py
+++ b/workers/automation/tests/test_compensation_benchmarks.py
@@ -34,6 +34,10 @@ def test_role_and_country_classification_is_deterministic() -> None:
     assert platform.role_family_code == "infrastructure_platform"
     assert platform.seniority_label == "principal"
 
+    privacy_director = classify_role("Privacy Engineering Director")
+    assert privacy_director.role_family_code == "security_privacy"
+    assert privacy_director.seniority_label == "director"
+
     assert resolve_country_code("Remote — Barcelona, Spain") == "ES"
     assert resolve_country_code("London / UK") == "GB"
     assert resolve_country_code("Remote") is None

--- a/workers/automation/tests/test_market_compensation_estimator.py
+++ b/workers/automation/tests/test_market_compensation_estimator.py
@@ -198,6 +198,36 @@ def test_executive_titles_use_executive_baseline_not_staff_plus_fallback() -> No
     assert "company_role_fallback" in estimate.warnings
 
 
+def test_director_title_and_same_location_fallback_are_described_truthfully() -> None:
+    estimate = estimate_market_compensation(
+        job_id=TEST_JOB_ID,
+        company="DuckDuckGo",
+        title="Privacy Engineering Director",
+        location="Spain",
+        observations=(
+            _euro_top_tech(
+                company="Euro Top Tech community",
+                role="Principal / Director Software Engineer",
+                level="Principal / Director",
+                minimum=90_000,
+                maximum=140_000,
+                location="Madrid, Spain",
+            ),
+        ),
+        estimated_at="2026-08-12T10:00:00Z",
+    )
+
+    assert estimate.seniority_label == "director"
+    assert estimate.match_scope == "same_location_role_fallback"
+    company_factor = next(factor for factor in estimate.factors if factor.name == "company")
+    level_factor = next(factor for factor in estimate.factors if factor.name == "level")
+    assert company_factor.score == 0.45
+    assert company_factor.reason == (
+        "No direct DuckDuckGo salary row matched; comparable roles in the same location provide 45% company support."
+    )
+    assert "classified as director" in level_factor.reason
+
+
 def test_employer_posted_observations_never_enter_market_estimates() -> None:
     estimate = estimate_market_compensation(
         job_id=TEST_JOB_ID,

--- a/workers/automation/tests/test_posted_compensation_parser.py
+++ b/workers/automation/tests/test_posted_compensation_parser.py
@@ -109,6 +109,69 @@ def test_parses_annual_range_with_currency_and_assumption() -> None:
     assert fact.warnings == ()
 
 
+def test_hr_prose_does_not_override_the_amount_local_annual_period() -> None:
+    fact = parse_posted_compensation(
+        (
+            "anybody (even HR managers) is able to create new integrations. "
+            "Base pay range: €94,300.00/yr - €106,950.00/yr"
+        ),
+        source_field="job_enrichments.full_description",
+        parsed_at="2026-08-12T12:00:00Z",
+    )
+
+    assert fact.parse_state == "parsed_range"
+    assert fact.period == "year"
+    assert fact.minimum_amount == 94_300
+    assert fact.maximum_amount == 106_950
+    assert fact.annualized_minimum_amount == 94_300
+    assert fact.annualized_maximum_amount == 106_950
+    assert fact.annualization_assumption == "Source text states annual compensation."
+    assert "hourly_period" not in fact.warnings
+
+
+def test_amount_adjacent_bare_period_abbreviations_remain_supported() -> None:
+    hourly = parse_posted_compensation("Base pay: $40 hrs")
+    annual = parse_posted_compensation("Base salary: $100,000 yrs")
+    hr_prose = parse_posted_compensation("HR managers benchmark base salary at $100,000 yr")
+
+    assert hourly.period == "hour"
+    assert hourly.annualized_minimum_amount == 83_200
+    assert "hourly_period" in hourly.warnings
+
+    assert annual.period == "year"
+    assert annual.annualized_minimum_amount == 100_000
+
+    assert hr_prose.period == "year"
+    assert hr_prose.annualized_minimum_amount == 100_000
+    assert "hourly_period" not in hr_prose.warnings
+
+
+def test_hr_prose_after_an_amount_is_not_treated_as_a_bare_hour_suffix() -> None:
+    for source in (
+        "Compensation budget approved: $100,000\n\nHR managers will administer this program.",
+        "Compensation budget approved: $100,000\n\nHR, benefits, and finance teams will administer this program.",
+        "Compensation budget approved: $100,000\n\nHR: Managers will administer this program.",
+    ):
+        fact = parse_posted_compensation(source)
+
+        assert fact.parse_state == "parsed_range"
+        assert fact.period == "unknown"
+        assert fact.annualized_minimum_amount is None
+        assert fact.annualized_maximum_amount is None
+        assert "missing_period" in fact.warnings
+        assert "hourly_period" not in fact.warnings
+
+
+def test_parenthesized_bare_period_abbreviations_remain_supported() -> None:
+    hourly = parse_posted_compensation("Base pay: $40 hr (depending on experience)")
+    annual = parse_posted_compensation("Base salary: $100,000 yr (base compensation)")
+
+    assert hourly.period == "hour"
+    assert hourly.annualized_minimum_amount == 83_200
+    assert annual.period == "year"
+    assert annual.annualized_minimum_amount == 100_000
+
+
 def test_parses_monthly_and_hourly_values_with_explicit_assumptions() -> None:
     monthly = parse_posted_compensation("EUR 6,000/month", parsed_at="2026-06-19T10:00:00Z")
     hourly = parse_posted_compensation("€40/hour", parsed_at="2026-06-19T10:00:00Z")

--- a/workers/automation/tests/test_posted_compensation_parser.py
+++ b/workers/automation/tests/test_posted_compensation_parser.py
@@ -199,6 +199,75 @@ def test_single_base_amount_with_variable_component_keeps_base_component() -> No
     assert "equity_component" in equity.warnings
 
 
+def test_stated_cash_compensation_is_not_relabelled_as_separate_stock_options() -> None:
+    fact = parse_posted_compensation(
+        (
+            "Compensation is transparent across the organization. "
+            "Compensation: USD 243,800 annually and stock options. "
+            + ("Privacy leadership across the global region. " * 8)
+        ),
+        source_field="jobs.full_description",
+        parsed_at="2026-08-12T10:00:00Z",
+    )
+
+    assert fact.parse_state == "parsed_range"
+    assert fact.currency == "USD"
+    assert fact.period == "year"
+    assert fact.minimum_amount == 243_800
+    assert fact.maximum_amount == 243_800
+    assert fact.component == "unknown"
+    assert fact.confidence == "high"
+    assert "equity_component" in fact.warnings
+    assert "source_text_truncated" in fact.warnings
+
+
+def test_explicit_equity_compensation_remains_equity() -> None:
+    fact = parse_posted_compensation("Equity compensation: USD 100,000/year in stock options.")
+
+    assert fact.component == "equity"
+    assert fact.confidence == "high"
+
+
+def test_nearest_amount_cue_keeps_explicit_equity_distinct_from_earlier_salary() -> None:
+    fact = parse_posted_compensation(
+        "The position offers a competitive base salary. Equity compensation: USD 100,000/year in stock options."
+    )
+
+    assert fact.parse_state == "parsed_range"
+    assert fact.minimum_amount == 100_000
+    assert fact.component == "equity"
+    assert fact.confidence == "high"
+
+
+def test_amount_denomination_in_stock_options_is_equity() -> None:
+    fact = parse_posted_compensation("USD 100,000/year in stock options.")
+
+    assert fact.parse_state == "parsed_range"
+    assert fact.component == "equity"
+
+
+def test_nearer_generic_compensation_cue_keeps_additive_stock_separate() -> None:
+    fact = parse_posted_compensation("Compensation: USD 243,800 annually and stock options.")
+
+    assert fact.parse_state == "parsed_range"
+    assert fact.component == "unknown"
+
+
+def test_equity_denomination_overrides_generic_compensation_cue() -> None:
+    stock = parse_posted_compensation("Compensation: USD 100,000/year in stock options.")
+    equity = parse_posted_compensation("Compensation: USD 100,000/year as equity.")
+
+    assert stock.component == "equity"
+    assert equity.component == "equity"
+
+
+def test_additive_equity_remains_separate_despite_later_stock_denomination() -> None:
+    fact = parse_posted_compensation("Compensation: USD 243,800/year and equity in stock options.")
+
+    assert fact.parse_state == "parsed_range"
+    assert fact.component == "unknown"
+
+
 def test_source_text_is_bounded_and_hashed() -> None:
     raw = "€80,000/year " + ("with benefits " * 80)
     fact = parse_posted_compensation(raw)

--- a/workers/automation/tests/test_posted_compensation_repository.py
+++ b/workers/automation/tests/test_posted_compensation_repository.py
@@ -148,21 +148,22 @@ def test_backfill_is_idempotent_and_preserves_legacy_salary(conn: sqlite3.Connec
     assert fact.minimum_amount == 180_000
 
 
-def _mark_fact_as_v1(
+def _mark_fact_as_legacy(
     conn: sqlite3.Connection,
     job_id: JobId,
     *,
+    parser_version: str = "posted-compensation-v1",
     component: str = "equity",
 ) -> None:
     conn.execute(
         """
         UPDATE job_posted_compensation_facts
-        SET parser_version = 'posted-compensation-v1',
+        SET parser_version = ?,
             component = ?,
             confidence = 'medium'
         WHERE tenant_id = 'local' AND job_id = ?
         """,
-        (component, job_id),
+        (parser_version, component, job_id),
     )
     conn.execute(
         "DELETE FROM job_events WHERE tenant_id = 'local' AND job_id = ?",
@@ -182,7 +183,7 @@ def test_reparse_outdated_facts_is_bounded_idempotent_and_preserves_future_rows(
     _job_url, second_id = _seed_job(
         conn,
         url="https://example.com/jobs/reparse-second",
-        salary="EUR 100,000/year",
+        salary="EUR 100,000 yrs",
     )
     _job_url, future_id = _seed_job(
         conn,
@@ -192,15 +193,20 @@ def test_reparse_outdated_facts_is_bounded_idempotent_and_preserves_future_rows(
     repo = SqlitePostedCompensationRepository(conn)
     for job_id, salary in (
         (first_id, "Compensation: USD 243,800 annually and stock options."),
-        (second_id, "EUR 100,000/year"),
+        (second_id, "EUR 100,000 yrs"),
         (future_id, "EUR 120,000/year"),
     ):
         repo.parse_and_save_job_salary(job_id, salary)
-    _mark_fact_as_v1(conn, first_id)
-    _mark_fact_as_v1(conn, second_id, component="unknown")
+    _mark_fact_as_legacy(conn, first_id)
+    _mark_fact_as_legacy(
+        conn,
+        second_id,
+        parser_version="posted-compensation-v2",
+        component="unknown",
+    )
     conn.execute(
         "UPDATE job_posted_compensation_facts SET parser_version = ? WHERE job_id = ?",
-        ("posted-compensation-v3", future_id),
+        ("posted-compensation-v4", future_id),
     )
     conn.commit()
 
@@ -221,10 +227,15 @@ def test_reparse_outdated_facts_is_bounded_idempotent_and_preserves_future_rows(
 
     first = repo.get_fact("local", first_id)
     assert first is not None
-    assert first.parser_version == "posted-compensation-v2"
+    assert first.parser_version == "posted-compensation-v3"
     assert first.component == "unknown"
     assert first.confidence == "high"
-    assert repo.get_fact("local", future_id).parser_version == "posted-compensation-v3"  # type: ignore[union-attr]
+    second = repo.get_fact("local", second_id)
+    assert second is not None
+    assert second.parser_version == "posted-compensation-v3"
+    assert second.period == "year"
+    assert second.annualized_minimum_amount == 100_000
+    assert repo.get_fact("local", future_id).parser_version == "posted-compensation-v4"  # type: ignore[union-attr]
     events = conn.execute(
         """
         SELECT job_id, idempotency_key
@@ -235,7 +246,7 @@ def test_reparse_outdated_facts_is_bounded_idempotent_and_preserves_future_rows(
         """
     ).fetchall()
     assert len(events) == 2
-    assert all(str(row["idempotency_key"]).endswith(":v1:v2") for row in events)
+    assert {":".join(str(row["idempotency_key"]).rsplit(":", 2)[-2:]) for row in events} == {"v1:v3", "v2:v3"}
 
 
 @pytest.mark.parametrize(
@@ -254,7 +265,7 @@ def test_reparse_outdated_facts_rolls_back_fact_when_event_write_fails(
     )
     repo = SqlitePostedCompensationRepository(conn)
     repo.parse_and_save_job_salary(job_id, "Compensation: USD 243,800 annually and stock options.")
-    _mark_fact_as_v1(conn, job_id)
+    _mark_fact_as_legacy(conn, job_id)
     original = state_module.record_job_event
 
     def fail_event(*_args: object, **_kwargs: object) -> None:
@@ -277,7 +288,7 @@ def test_reparse_outdated_facts_rolls_back_fact_when_event_write_fails(
 
     monkeypatch.setattr(state_module, "record_job_event", original)
     assert repo.reparse_outdated_facts(parsed_at="2026-08-12T12:01:00Z") == 1
-    assert repo.get_fact("local", job_id).parser_version == "posted-compensation-v2"  # type: ignore[union-attr]
+    assert repo.get_fact("local", job_id).parser_version == "posted-compensation-v3"  # type: ignore[union-attr]
     assert (
         conn.execute(
             "SELECT COUNT(*) FROM job_events WHERE tenant_id = 'local' AND job_id = ?",
@@ -285,6 +296,51 @@ def test_reparse_outdated_facts_rolls_back_fact_when_event_write_fails(
         ).fetchone()[0]
         == 1
     )
+
+
+def test_reparse_corrects_v2_hourly_false_positive_from_following_hr_prose(
+    conn: sqlite3.Connection,
+) -> None:
+    source = "Compensation budget approved: $100,000\n\nHR managers will administer this program."
+    _job_url, job_id = _seed_job(
+        conn,
+        url="https://example.com/jobs/reparse-following-hr-prose",
+        salary=source,
+    )
+    repo = SqlitePostedCompensationRepository(conn)
+    repo.parse_and_save_job_salary(job_id, source)
+    conn.execute(
+        """
+        UPDATE job_posted_compensation_facts
+        SET parser_version = 'posted-compensation-v2',
+            period = 'hour',
+            annualized_minimum_amount = 208000000,
+            annualized_maximum_amount = 208000000,
+            annualization_assumption = 'Hourly amounts annualized by multiplying by 2,080 work hours.',
+            confidence = 'low',
+            warnings_json = '["hourly_period"]'
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (job_id,),
+    )
+    conn.execute("DELETE FROM job_events WHERE tenant_id = 'local' AND job_id = ?", (job_id,))
+    conn.commit()
+
+    assert repo.reparse_outdated_facts(parsed_at="2026-08-12T12:00:00Z") == 1
+
+    fact = repo.get_fact("local", job_id)
+    assert fact is not None
+    assert fact.parser_version == "posted-compensation-v3"
+    assert fact.period == "unknown"
+    assert fact.annualized_minimum_amount is None
+    assert fact.annualized_maximum_amount is None
+    assert "missing_period" in fact.warnings
+    assert "hourly_period" not in fact.warnings
+    event_key = conn.execute(
+        "SELECT idempotency_key FROM job_events WHERE tenant_id = 'local' AND job_id = ?",
+        (job_id,),
+    ).fetchone()["idempotency_key"]
+    assert str(event_key).endswith(":v2:v3")
 
 
 def test_reparse_uses_accepted_enrichment_description_and_supports_tuple_rows(
@@ -309,7 +365,7 @@ def test_reparse_uses_accepted_enrichment_description_and_supports_tuple_rows(
     )
     repo = SqlitePostedCompensationRepository(conn)
     repo.parse_and_save_job_salary(job_id, "Base salary EUR 70,000/year")
-    _mark_fact_as_v1(conn, job_id)
+    _mark_fact_as_legacy(conn, job_id)
     conn.row_factory = None
 
     assert repo.reparse_outdated_facts(parsed_at="2026-08-12T12:00:00Z") == 1
@@ -432,6 +488,61 @@ def test_description_source_selection_supports_tuple_job_rows() -> None:
 
     assert source_field == "jobs.full_description"
     assert source_text == full_description
+
+
+def test_backfill_does_not_annualize_hr_prose_after_an_amount(conn: sqlite3.Connection) -> None:
+    _job_url, job_id = _seed_job(conn, salary=None)
+    full_description = "Compensation budget approved: $100,000\n\nHR managers will administer this program."
+    conn.execute(
+        "UPDATE jobs SET full_description = ? WHERE tenant_id = ? AND job_id = ?",
+        (full_description, "local", job_id),
+    )
+    conn.commit()
+
+    SqlitePostedCompensationRepository(conn).backfill_from_jobs(parsed_at="2026-08-12T10:00:00Z")
+
+    fact = SqlitePostedCompensationRepository(conn).get_fact("local", job_id)
+    assert fact is not None
+    assert fact.source_field == "jobs.full_description"
+    assert fact.parse_state == "parsed_range"
+    assert fact.period == "unknown"
+    assert fact.annualized_minimum_amount is None
+    assert fact.annualized_maximum_amount is None
+    assert "missing_period" in fact.warnings
+    assert "hourly_period" not in fact.warnings
+
+
+@pytest.mark.parametrize(
+    "hr_prose",
+    (
+        "HR, benefits, and finance teams will administer this program.",
+        "HR: Managers will administer this program.",
+    ),
+)
+def test_backfill_does_not_annualize_punctuated_hr_prose_after_an_amount(
+    conn: sqlite3.Connection,
+    hr_prose: str,
+) -> None:
+    url_suffix = "comma" if "," in hr_prose else "colon"
+    _job_url, job_id = _seed_job(
+        conn,
+        url=f"https://example.com/jobs/following-hr-{url_suffix}",
+        salary=None,
+    )
+    conn.execute(
+        "UPDATE jobs SET full_description = ? WHERE tenant_id = ? AND job_id = ?",
+        (f"Compensation budget approved: $100,000\n\n{hr_prose}", "local", job_id),
+    )
+    conn.commit()
+
+    SqlitePostedCompensationRepository(conn).backfill_from_jobs(parsed_at="2026-08-12T10:00:00Z")
+
+    fact = SqlitePostedCompensationRepository(conn).get_fact("local", job_id)
+    assert fact is not None
+    assert fact.period == "unknown"
+    assert fact.annualized_minimum_amount is None
+    assert "missing_period" in fact.warnings
+    assert "hourly_period" not in fact.warnings
 
 
 def test_backfill_persists_mixed_component_two_amount_text_as_ambiguous(

--- a/workers/automation/tests/test_posted_compensation_repository.py
+++ b/workers/automation/tests/test_posted_compensation_repository.py
@@ -6,6 +6,7 @@ import uuid
 from pathlib import Path
 
 import pytest
+import jobctrl.state as state_module
 
 from jobctrl.database import init_db
 from jobctrl.domain.compensation import parse_posted_compensation
@@ -132,8 +133,12 @@ def test_backfill_is_idempotent_and_preserves_legacy_salary(conn: sqlite3.Connec
     assert repo.backfill_from_jobs(parsed_at="2026-06-19T10:00:00Z") == 1
     assert repo.backfill_from_jobs(parsed_at="2026-06-19T10:00:00Z") == 1
 
-    rows = conn.execute("SELECT * FROM job_posted_compensation_facts WHERE tenant_id = ? AND job_id = ?", ("local", job_id)).fetchall()
-    salary = conn.execute("SELECT salary FROM jobs WHERE tenant_id = ? AND job_id = ?", ("local", job_id)).fetchone()["salary"]
+    rows = conn.execute(
+        "SELECT * FROM job_posted_compensation_facts WHERE tenant_id = ? AND job_id = ?", ("local", job_id)
+    ).fetchall()
+    salary = conn.execute("SELECT salary FROM jobs WHERE tenant_id = ? AND job_id = ?", ("local", job_id)).fetchone()[
+        "salary"
+    ]
     fact = repo.get_fact("local", job_id)
 
     assert len(rows) == 1
@@ -143,13 +148,190 @@ def test_backfill_is_idempotent_and_preserves_legacy_salary(conn: sqlite3.Connec
     assert fact.minimum_amount == 180_000
 
 
+def _mark_fact_as_v1(
+    conn: sqlite3.Connection,
+    job_id: JobId,
+    *,
+    component: str = "equity",
+) -> None:
+    conn.execute(
+        """
+        UPDATE job_posted_compensation_facts
+        SET parser_version = 'posted-compensation-v1',
+            component = ?,
+            confidence = 'medium'
+        WHERE tenant_id = 'local' AND job_id = ?
+        """,
+        (component, job_id),
+    )
+    conn.execute(
+        "DELETE FROM job_events WHERE tenant_id = 'local' AND job_id = ?",
+        (job_id,),
+    )
+    conn.commit()
+
+
+def test_reparse_outdated_facts_is_bounded_idempotent_and_preserves_future_rows(
+    conn: sqlite3.Connection,
+) -> None:
+    _job_url, first_id = _seed_job(
+        conn,
+        url="https://example.com/jobs/reparse-first",
+        salary="Compensation: USD 243,800 annually and stock options.",
+    )
+    _job_url, second_id = _seed_job(
+        conn,
+        url="https://example.com/jobs/reparse-second",
+        salary="EUR 100,000/year",
+    )
+    _job_url, future_id = _seed_job(
+        conn,
+        url="https://example.com/jobs/reparse-future",
+        salary="EUR 120,000/year",
+    )
+    repo = SqlitePostedCompensationRepository(conn)
+    for job_id, salary in (
+        (first_id, "Compensation: USD 243,800 annually and stock options."),
+        (second_id, "EUR 100,000/year"),
+        (future_id, "EUR 120,000/year"),
+    ):
+        repo.parse_and_save_job_salary(job_id, salary)
+    _mark_fact_as_v1(conn, first_id)
+    _mark_fact_as_v1(conn, second_id, component="unknown")
+    conn.execute(
+        "UPDATE job_posted_compensation_facts SET parser_version = ? WHERE job_id = ?",
+        ("posted-compensation-v3", future_id),
+    )
+    conn.commit()
+
+    assert (
+        repo.reparse_outdated_facts(
+            parsed_at="2026-08-12T12:00:00Z",
+            batch_size=1,
+        )
+        == 2
+    )
+    assert (
+        repo.reparse_outdated_facts(
+            parsed_at="2026-08-12T12:01:00Z",
+            batch_size=1,
+        )
+        == 0
+    )
+
+    first = repo.get_fact("local", first_id)
+    assert first is not None
+    assert first.parser_version == "posted-compensation-v2"
+    assert first.component == "unknown"
+    assert first.confidence == "high"
+    assert repo.get_fact("local", future_id).parser_version == "posted-compensation-v3"  # type: ignore[union-attr]
+    events = conn.execute(
+        """
+        SELECT job_id, idempotency_key
+        FROM job_events
+        WHERE event_type = 'CompensationFactsUpdated'
+          AND idempotency_key LIKE 'posted-parser-upgrade:%'
+        ORDER BY job_id
+        """
+    ).fetchall()
+    assert len(events) == 2
+    assert all(str(row["idempotency_key"]).endswith(":v1:v2") for row in events)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    (sqlite3.OperationalError("event table unavailable"), KeyboardInterrupt()),
+)
+def test_reparse_outdated_facts_rolls_back_fact_when_event_write_fails(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: BaseException,
+) -> None:
+    _job_url, job_id = _seed_job(
+        conn,
+        url=f"https://example.com/jobs/reparse-failure-{type(failure).__name__}",
+        salary="Compensation: USD 243,800 annually and stock options.",
+    )
+    repo = SqlitePostedCompensationRepository(conn)
+    repo.parse_and_save_job_salary(job_id, "Compensation: USD 243,800 annually and stock options.")
+    _mark_fact_as_v1(conn, job_id)
+    original = state_module.record_job_event
+
+    def fail_event(*_args: object, **_kwargs: object) -> None:
+        raise failure
+
+    monkeypatch.setattr(state_module, "record_job_event", fail_event)
+    with pytest.raises(type(failure)):
+        repo.reparse_outdated_facts(parsed_at="2026-08-12T12:00:00Z")
+
+    failed = repo.get_fact("local", job_id)
+    assert failed is not None
+    assert failed.parser_version == "posted-compensation-v1"
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM job_events WHERE tenant_id = 'local' AND job_id = ?",
+            (job_id,),
+        ).fetchone()[0]
+        == 0
+    )
+
+    monkeypatch.setattr(state_module, "record_job_event", original)
+    assert repo.reparse_outdated_facts(parsed_at="2026-08-12T12:01:00Z") == 1
+    assert repo.get_fact("local", job_id).parser_version == "posted-compensation-v2"  # type: ignore[union-attr]
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM job_events WHERE tenant_id = 'local' AND job_id = ?",
+            (job_id,),
+        ).fetchone()[0]
+        == 1
+    )
+
+
+def test_reparse_uses_accepted_enrichment_description_and_supports_tuple_rows(
+    conn: sqlite3.Connection,
+) -> None:
+    _job_url, job_id = _seed_job(
+        conn,
+        url="https://example.com/jobs/enriched-reparse",
+        salary=None,
+    )
+    conn.execute(
+        "UPDATE jobs SET full_description = ? WHERE job_id = ?",
+        ("Base salary EUR 70,000/year", job_id),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            tenant_id, job_id, current_status, full_description, updated_at
+        ) VALUES ('local', ?, 'enriched', ?, '2026-08-12T11:00:00Z')
+        """,
+        (job_id, "Compensation: USD 243,800 annually and stock options."),
+    )
+    repo = SqlitePostedCompensationRepository(conn)
+    repo.parse_and_save_job_salary(job_id, "Base salary EUR 70,000/year")
+    _mark_fact_as_v1(conn, job_id)
+    conn.row_factory = None
+
+    assert repo.reparse_outdated_facts(parsed_at="2026-08-12T12:00:00Z") == 1
+
+    conn.row_factory = sqlite3.Row
+    fact = repo.get_fact("local", job_id)
+    assert fact is not None
+    assert fact.source_field == "job_enrichments.full_description"
+    assert fact.currency == "USD"
+    assert fact.minimum_amount == 243_800
+    assert fact.component == "unknown"
+
+
 def test_backfill_records_missing_fact_without_erasing_blank_salary(conn: sqlite3.Connection) -> None:
     _job_url, job_id = _seed_job(conn, salary=None)
     repo = SqlitePostedCompensationRepository(conn)
 
     repo.backfill_from_jobs(parsed_at="2026-06-19T10:00:00Z")
     fact = repo.get_fact("local", job_id)
-    salary = conn.execute("SELECT salary FROM jobs WHERE tenant_id = ? AND job_id = ?", ("local", job_id)).fetchone()["salary"]
+    salary = conn.execute("SELECT salary FROM jobs WHERE tenant_id = ? AND job_id = ?", ("local", job_id)).fetchone()[
+        "salary"
+    ]
 
     assert fact is not None
     assert fact.parse_state == "missing"
@@ -173,9 +355,7 @@ def test_backfill_prefers_numeric_compensation_excerpt_over_earlier_generic_cue(
     )
     conn.commit()
 
-    SqlitePostedCompensationRepository(conn).backfill_from_jobs(
-        parsed_at="2026-06-19T10:00:00Z"
-    )
+    SqlitePostedCompensationRepository(conn).backfill_from_jobs(parsed_at="2026-06-19T10:00:00Z")
 
     fact = SqlitePostedCompensationRepository(conn).get_fact("local", job_id)
     assert fact is not None
@@ -187,12 +367,68 @@ def test_backfill_prefers_numeric_compensation_excerpt_over_earlier_generic_cue(
     assert fact.annualized_maximum_amount == 95_000
 
 
+def test_backfill_selects_cash_compensation_with_additive_stock_after_distant_generic_cue(
+    conn: sqlite3.Connection,
+) -> None:
+    _job_url, job_id = _seed_job(conn, salary=None)
+    full_description = (
+        "Our compensation philosophy rewards impact across the company. "
+        + ("Lead privacy engineering strategy across global product teams. " * 8)
+        + "Compensation: USD 243,800 annually and stock options."
+    )
+    conn.execute(
+        "UPDATE jobs SET full_description = ? WHERE tenant_id = ? AND job_id = ?",
+        (full_description, "local", job_id),
+    )
+    conn.commit()
+
+    SqlitePostedCompensationRepository(conn).backfill_from_jobs(parsed_at="2026-08-12T10:00:00Z")
+
+    fact = SqlitePostedCompensationRepository(conn).get_fact("local", job_id)
+    assert fact is not None
+    assert fact.source_field == "jobs.full_description"
+    assert fact.parse_state == "parsed_range"
+    assert fact.currency == "USD"
+    assert fact.period == "year"
+    assert fact.component == "unknown"
+    assert fact.annualized_minimum_amount == 243_800
+    assert fact.annualized_maximum_amount == 243_800
+    assert fact.confidence == "high"
+    assert "equity_component" in fact.warnings
+
+
+def test_backfill_selects_explicit_equity_amount_over_earlier_salary_sentence(
+    conn: sqlite3.Connection,
+) -> None:
+    _job_url, job_id = _seed_job(conn, salary=None)
+    full_description = (
+        "The position offers a competitive base salary. "
+        + ("Lead privacy engineering strategy across global product teams. " * 8)
+        + "Equity compensation: USD 100,000/year in stock options."
+    )
+    conn.execute(
+        "UPDATE jobs SET full_description = ? WHERE tenant_id = ? AND job_id = ?",
+        (full_description, "local", job_id),
+    )
+    conn.commit()
+
+    SqlitePostedCompensationRepository(conn).backfill_from_jobs(parsed_at="2026-08-12T10:00:00Z")
+
+    fact = SqlitePostedCompensationRepository(conn).get_fact("local", job_id)
+    assert fact is not None
+    assert fact.source_field == "jobs.full_description"
+    assert fact.parse_state == "parsed_range"
+    assert fact.currency == "USD"
+    assert fact.period == "year"
+    assert fact.component == "equity"
+    assert fact.annualized_minimum_amount == 100_000
+    assert fact.annualized_maximum_amount == 100_000
+
+
 def test_description_source_selection_supports_tuple_job_rows() -> None:
     full_description = "Base salary €80,000 - €95,000 per year"
 
-    source_text, source_field = posted_compensation_source_from_job(
-        ("job-id", None, full_description, "")
-    )
+    source_text, source_field = posted_compensation_source_from_job(("job-id", None, full_description, ""))
 
     assert source_field == "jobs.full_description"
     assert source_text == full_description
@@ -206,7 +442,9 @@ def test_backfill_persists_mixed_component_two_amount_text_as_ambiguous(
 
     repo.backfill_from_jobs(parsed_at="2026-06-19T10:00:00Z")
     fact = repo.get_fact("local", job_id)
-    salary = conn.execute("SELECT salary FROM jobs WHERE tenant_id = ? AND job_id = ?", ("local", job_id)).fetchone()["salary"]
+    salary = conn.execute("SELECT salary FROM jobs WHERE tenant_id = ? AND job_id = ?", ("local", job_id)).fetchone()[
+        "salary"
+    ]
 
     assert salary == "Base €90k/year plus bonus €10k/year"
     assert fact is not None
@@ -224,10 +462,20 @@ def test_parse_and_save_job_salary_updates_fact_after_rediscovery_preserves_raw_
     repo = SqlitePostedCompensationRepository(conn)
 
     repo.parse_and_save_job_salary(job_id, "€80,000/year", parsed_at="2026-06-19T10:00:00Z")
-    conn.execute("UPDATE jobs SET salary = COALESCE(NULLIF(?, ''), salary) WHERE tenant_id = ? AND job_id = ?", ("", "local", job_id))
-    repo.parse_and_save_job_salary(job_id, conn.execute("SELECT salary FROM jobs WHERE tenant_id = ? AND job_id = ?", ("local", job_id)).fetchone()["salary"])
+    conn.execute(
+        "UPDATE jobs SET salary = COALESCE(NULLIF(?, ''), salary) WHERE tenant_id = ? AND job_id = ?",
+        ("", "local", job_id),
+    )
+    repo.parse_and_save_job_salary(
+        job_id,
+        conn.execute("SELECT salary FROM jobs WHERE tenant_id = ? AND job_id = ?", ("local", job_id)).fetchone()[
+            "salary"
+        ],
+    )
 
-    salary = conn.execute("SELECT salary FROM jobs WHERE tenant_id = ? AND job_id = ?", ("local", job_id)).fetchone()["salary"]
+    salary = conn.execute("SELECT salary FROM jobs WHERE tenant_id = ? AND job_id = ?", ("local", job_id)).fetchone()[
+        "salary"
+    ]
     fact = repo.get_fact("local", job_id)
 
     assert salary == "€80,000/year"

--- a/workers/automation/tests/test_preflight.py
+++ b/workers/automation/tests/test_preflight.py
@@ -8,6 +8,7 @@ the bundled headless-shell core.
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -223,3 +224,102 @@ def test_worker_command_aborts_before_temporal_when_browser_missing(
     normalized = " ".join(result.output.split())
     assert "Worker preflight failed" in normalized
     assert "JOBCTRL_SKIP_BROWSER_PREFLIGHT=1" in normalized
+
+
+def test_bootstrap_still_refreshes_and_subscribes_when_posted_reconciliation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr("jobctrl.config.load_env", lambda: calls.append("env"))
+    monkeypatch.setattr("jobctrl.config.ensure_dirs", lambda: calls.append("dirs"))
+    monkeypatch.setattr("jobctrl.database.init_db", lambda: calls.append("db"))
+    monkeypatch.setattr("jobctrl.database.close_connection", lambda: calls.append("close"))
+    monkeypatch.setattr("jobctrl.infrastructure.observability.init_otel", lambda: calls.append("otel"))
+
+    class FailingPostedRepository:
+        def __init__(self, _conn: object) -> None:
+            pass
+
+        def reparse_outdated_facts(self, **_kwargs: object) -> int:
+            calls.append("reconcile")
+            raise sqlite3.OperationalError("maintenance unavailable")
+
+    class RecordingBuilder:
+        def __init__(self, **_kwargs: object) -> None:
+            calls.append("builder")
+
+        def refresh(self) -> int:
+            calls.append("refresh")
+            return 0
+
+        def subscribe_to(self, _publisher: object) -> object:
+            calls.append("subscribe")
+            return object()
+
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.compensation.SqlitePostedCompensationRepository",
+        FailingPostedRepository,
+    )
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.projections.projection_builder.ProjectionBuilder",
+        RecordingBuilder,
+    )
+    monkeypatch.setattr("jobctrl.database.get_connection", lambda: object())
+    monkeypatch.setattr(cli, "_projection_subscription", None)
+
+    cli._bootstrap(reconcile_posted_compensation=True)
+
+    assert calls == [
+        "env",
+        "dirs",
+        "db",
+        "otel",
+        "reconcile",
+        "close",
+        "builder",
+        "refresh",
+        "subscribe",
+    ]
+
+
+def test_bootstrap_rolls_back_failed_projection_refresh_before_rpc_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    class RecordingConnection:
+        def rollback(self) -> None:
+            calls.append("rollback")
+
+    connection = RecordingConnection()
+
+    class FailingBuilder:
+        def __init__(self, **_kwargs: object) -> None:
+            calls.append("builder")
+
+        def refresh(self) -> int:
+            calls.append("refresh")
+            raise ValueError("malformed legacy projection evidence")
+
+    monkeypatch.setattr("jobctrl.config.load_env", lambda: calls.append("env"))
+    monkeypatch.setattr("jobctrl.config.ensure_dirs", lambda: calls.append("dirs"))
+    monkeypatch.setattr("jobctrl.database.init_db", lambda: calls.append("db"))
+    monkeypatch.setattr("jobctrl.infrastructure.observability.init_otel", lambda: calls.append("otel"))
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.projections.projection_builder.ProjectionBuilder",
+        FailingBuilder,
+    )
+    monkeypatch.setattr("jobctrl.database.get_connection", lambda: connection)
+
+    cli._bootstrap()
+
+    assert calls == [
+        "env",
+        "dirs",
+        "db",
+        "otel",
+        "builder",
+        "refresh",
+        "rollback",
+    ]

--- a/workers/automation/tests/test_projection_builder.py
+++ b/workers/automation/tests/test_projection_builder.py
@@ -751,8 +751,99 @@ def test_posted_parser_reconciliation_rebuilds_settled_list_and_detail_projectio
     audit = json.loads(rebuilt["compensation_audit_json"])
     assert list_summary["posted"]["range"]["component"] == "unknown"
     assert detail_summary["posted"]["range"]["component"] == "unknown"
-    assert audit["posted"]["fact"]["parserVersion"] == "posted-compensation-v2"
+    assert audit["posted"]["fact"]["parserVersion"] == "posted-compensation-v3"
     assert audit["posted"]["fact"]["component"] == "unknown"
+
+
+def test_posted_parser_reconciliation_corrects_hr_prose_period_in_settled_projections(
+    conn: sqlite3.Connection,
+) -> None:
+    source_text = (
+        "anybody (even HR managers) is able to create new integrations. Base pay range: €94,300.00/yr - €106,950.00/yr"
+    )
+    job_id = _seed_job(
+        conn,
+        "https://example.com/posted-parser-hr-period-upgrade",
+        salary=source_text,
+    )
+    posted_repo = SqlitePostedCompensationRepository(conn)
+    posted_repo.parse_and_save_job_salary(
+        job_id,
+        source_text,
+        parsed_at="2026-08-12T10:00:00Z",
+    )
+    conn.execute(
+        """
+        UPDATE job_posted_compensation_facts
+        SET parser_version = 'posted-compensation-v2',
+            period = 'hour',
+            annualized_minimum_amount = 196144000,
+            annualized_maximum_amount = 222456000,
+            annualization_assumption = 'Hourly amounts annualized by multiplying by 2,080 work hours.',
+            confidence = 'low',
+            warnings_json = '["hourly_period"]'
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (str(LOCAL_TENANT), str(job_id)),
+    )
+    conn.commit()
+
+    builder = ProjectionBuilder(conn_factory=lambda: conn)
+    assert builder.refresh() == 1
+    settled_watermark = SqliteEventWatermarkRepository(conn).get(PROJECTION_NAME)
+    initial = conn.execute(
+        """
+        SELECT list.compensation_summary_json,
+               detail.compensation_summary_json AS detail_summary_json,
+               detail.compensation_audit_json
+        FROM job_list_projections AS list
+        JOIN job_detail_projections AS detail
+          ON detail.tenant_id = list.tenant_id
+         AND detail.job_id = list.job_id
+        WHERE list.tenant_id = ? AND list.job_id = ?
+        """,
+        (str(LOCAL_TENANT), str(job_id)),
+    ).fetchone()
+    assert initial is not None
+    assert json.loads(initial["compensation_summary_json"])["posted"]["displayRange"] == ("EUR 94300-106950/hour")
+    assert json.loads(initial["detail_summary_json"])["posted"]["displayRange"] == ("EUR 94300-106950/hour")
+    assert json.loads(initial["compensation_audit_json"])["posted"]["fact"]["parserVersion"] == (
+        "posted-compensation-v2"
+    )
+
+    assert (
+        posted_repo.reparse_outdated_facts(
+            parsed_at="2026-08-12T11:00:00Z",
+        )
+        == 1
+    )
+    assert builder.refresh() == 1
+    assert SqliteEventWatermarkRepository(conn).get(PROJECTION_NAME) > settled_watermark
+
+    rebuilt = conn.execute(
+        """
+        SELECT list.compensation_summary_json,
+               detail.compensation_summary_json AS detail_summary_json,
+               detail.compensation_audit_json
+        FROM job_list_projections AS list
+        JOIN job_detail_projections AS detail
+          ON detail.tenant_id = list.tenant_id
+         AND detail.job_id = list.job_id
+        WHERE list.tenant_id = ? AND list.job_id = ?
+        """,
+        (str(LOCAL_TENANT), str(job_id)),
+    ).fetchone()
+    assert rebuilt is not None
+    list_summary = json.loads(rebuilt["compensation_summary_json"])
+    detail_summary = json.loads(rebuilt["detail_summary_json"])
+    audit = json.loads(rebuilt["compensation_audit_json"])
+    assert list_summary["posted"]["displayRange"] == "EUR 94300-106950/year"
+    assert detail_summary["posted"]["displayRange"] == "EUR 94300-106950/year"
+    assert audit["posted"]["fact"]["period"] == "year"
+    assert audit["posted"]["fact"]["annualizedMinimumAmount"] == 94_300
+    assert audit["posted"]["fact"]["annualizedMaximumAmount"] == 106_950
+    assert audit["posted"]["fact"]["parserVersion"] == "posted-compensation-v3"
+    assert "hourly_period" not in {warning["code"] for warning in audit["posted"]["fact"]["warnings"]}
 
 
 def test_projection_suppresses_historical_posted_as_market_rows(

--- a/workers/automation/tests/test_projection_builder.py
+++ b/workers/automation/tests/test_projection_builder.py
@@ -672,6 +672,89 @@ def test_projects_compensation_summary_and_audit_json(conn: sqlite3.Connection) 
     assert "/Users/" not in json.dumps(audit)
 
 
+def test_posted_parser_reconciliation_rebuilds_settled_list_and_detail_projections(
+    conn: sqlite3.Connection,
+) -> None:
+    job_id = _seed_job(
+        conn,
+        "https://example.com/posted-parser-upgrade",
+        salary="Compensation: USD 243,800 annually and stock options.",
+    )
+    posted_repo = SqlitePostedCompensationRepository(conn)
+    posted_repo.parse_and_save_job_salary(
+        job_id,
+        "Compensation: USD 243,800 annually and stock options.",
+        parsed_at="2026-08-12T10:00:00Z",
+    )
+    conn.execute(
+        """
+        UPDATE job_posted_compensation_facts
+        SET parser_version = 'posted-compensation-v1',
+            component = 'equity',
+            confidence = 'medium'
+        WHERE tenant_id = ? AND job_id = ?
+        """,
+        (str(LOCAL_TENANT), str(job_id)),
+    )
+    conn.commit()
+
+    builder = ProjectionBuilder(conn_factory=lambda: conn)
+    assert builder.refresh() == 1
+    settled_watermark = SqliteEventWatermarkRepository(conn).get(PROJECTION_NAME)
+    initial = conn.execute(
+        """
+        SELECT list.compensation_summary_json,
+               detail.compensation_summary_json AS detail_summary_json,
+               detail.compensation_audit_json
+        FROM job_list_projections AS list
+        JOIN job_detail_projections AS detail
+          ON detail.tenant_id = list.tenant_id
+         AND detail.job_id = list.job_id
+        WHERE list.tenant_id = ? AND list.job_id = ?
+        """,
+        (str(LOCAL_TENANT), str(job_id)),
+    ).fetchone()
+    assert initial is not None
+    initial_list = json.loads(initial["compensation_summary_json"])
+    initial_detail = json.loads(initial["detail_summary_json"])
+    initial_audit = json.loads(initial["compensation_audit_json"])
+    assert initial_list["projectionVersion"] == 3
+    assert initial_detail["projectionVersion"] == 3
+    assert initial_list["posted"]["range"]["component"] == "equity"
+    assert initial_audit["posted"]["fact"]["parserVersion"] == "posted-compensation-v1"
+
+    assert (
+        posted_repo.reparse_outdated_facts(
+            parsed_at="2026-08-12T11:00:00Z",
+        )
+        == 1
+    )
+    assert builder.refresh() == 1
+    assert SqliteEventWatermarkRepository(conn).get(PROJECTION_NAME) > settled_watermark
+
+    rebuilt = conn.execute(
+        """
+        SELECT list.compensation_summary_json,
+               detail.compensation_summary_json AS detail_summary_json,
+               detail.compensation_audit_json
+        FROM job_list_projections AS list
+        JOIN job_detail_projections AS detail
+          ON detail.tenant_id = list.tenant_id
+         AND detail.job_id = list.job_id
+        WHERE list.tenant_id = ? AND list.job_id = ?
+        """,
+        (str(LOCAL_TENANT), str(job_id)),
+    ).fetchone()
+    assert rebuilt is not None
+    list_summary = json.loads(rebuilt["compensation_summary_json"])
+    detail_summary = json.loads(rebuilt["detail_summary_json"])
+    audit = json.loads(rebuilt["compensation_audit_json"])
+    assert list_summary["posted"]["range"]["component"] == "unknown"
+    assert detail_summary["posted"]["range"]["component"] == "unknown"
+    assert audit["posted"]["fact"]["parserVersion"] == "posted-compensation-v2"
+    assert audit["posted"]["fact"]["component"] == "unknown"
+
+
 def test_projection_suppresses_historical_posted_as_market_rows(
     conn: sqlite3.Connection,
 ) -> None:


### PR DESCRIPTION
## Summary

- make employer-posted salary and market salary the two primary Job Detail outcomes
- show a trustworthy numeric market range when one exists, or a state-specific explanation when it does not
- distinguish posted cash, explicitly priced equity, and separately mentioned unpriced equity without presenting extraction certainty as employer confidence
- bind a posted pay period to the salary amount so unrelated HR prose cannot turn annual compensation into an hourly figure
- move providers, evidence records, reported sample counts, match support, warnings, and geographic lineage into expandable details
- remove the per-job observation JSON path control while retaining configured-source refresh behavior
- classify director roles separately from staff/principal and add the privacy-engineering role-family alias
- upgrade persisted posted-compensation v1 and v2 facts to v3 at worker start with bounded, atomic fact/event batches and automatic list/detail projection convergence
- keep API reads available if a projection bootstrap fails by rolling back partial projection writes and releasing the rollback journal
- document the automatic benchmark lifecycle, decision-first UI, evidence/sample distinction, upgrade behavior, and compensation QA gate

## Why

The previous detail view elevated internal audit markers while hiding the actual market decision. It also labeled an employer-stated amount with posted confidence, could misclassify generic cash-plus-stock wording as equity, treated director roles as staff-plus, and exposed a local observation file path that normal users should never need.

The persisted parser-version upgrade is required so existing jobs receive the corrected component and pay-period semantics without a manual per-job refresh. Amount-local period ownership also prevents prose such as HR managers from being mistaken for an hourly unit while preserving explicit and safely delimited salary abbreviations.

## Validation

- full Python matrix: 3,612 passed, 2 skipped
- focused posted parser, repository, and projection suite: 66 passed
- parser corpus covers annual `/yr`, explicit hourly forms, bare `hr/hrs/yr/yrs`, parenthetical suffixes, and uppercase `HR`, `HR,`, and `HR:` prose boundaries
- disposable v2-to-v3 replay proves canonical, list, detail, and audit convergence, event uniqueness, rollback safety, future-version preservation, and idempotency
- `corepack pnpm check`
- `corepack pnpm web:test` — 2,016 tests passed
- focused compensation/API/projection suites — 163 Python, 73 web, and 27 API tests passed before the final period-boundary additions
- isolated Jobs drawer Playwright — 4 tests passed, including mobile layout and focused refresh
- live Job Detail API and rendered browser verification — `EUR 94300-106950/year`, with no `/hour` marker
- populated exact-v8 API restart probe — four consecutive Jobs reads and detail returned HTTP 200; refresh returned HTTP 202; no rollback journal remained
- `corepack pnpm docs:build`
- Ruff check and format check
- `git diff --check`
- independent Tier-3 review: PASS, 0 findings
- independent Tier-3 QA: PASS, 0 findings

## Checklist

- [x] External contributor commits include a DCO `Signed-off-by:` trailer when applicable.
- [x] Relevant local checks are listed above.
- [x] No secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths are included.