### PR TITLE
fix(release): accept canonical capture JobIds

### DIFF
--- a/scripts/distribution-build.mjs
+++ b/scripts/distribution-build.mjs
@@ -2188,6 +2188,23 @@ export function extensionCaptureSmokeHeaders(token) {
   };
 }
 
+export function extensionCaptureSmokeJobId(result) {
+  invariant(result?.ok === true, "extension capture smoke did not import the fixture job");
+  invariant(
+    typeof result.jobKey === "string"
+      && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(result.jobKey),
+    "extension capture smoke did not return a canonical JobId",
+  );
+  return result.jobKey;
+}
+
+export function assertPersistedExtensionCaptureSmokeJob(detail, { jobId, jobUrl }) {
+  invariant(
+    detail?.ok === true && detail.job?.jobKey === jobId && detail.job?.url === jobUrl,
+    "extracted API did not resolve the captured JobId to the workflow-imported offline fixture job",
+  );
+}
+
 async function submitExtensionCaptureFixture(plan, { captureId, jobUrl, captureHtml }) {
   const pairing = await requireJsonResponse(
     `${plan.apiOrigin}/v1/extension/pairing-token`,
@@ -2213,8 +2230,8 @@ async function submitExtensionCaptureFixture(plan, { captureId, jobUrl, captureH
     },
     "extension saved-HTML capture smoke",
   );
-  invariant(result?.ok === true && result.jobKey === jobUrl, "extension capture smoke did not return the imported fixture job");
-  return { itemId: result.itemId, jobKey: result.jobKey, importedAt: result.importedAt };
+  const jobId = extensionCaptureSmokeJobId(result);
+  return { itemId: result.itemId, jobKey: jobId, importedAt: result.importedAt };
 }
 
 async function waitForApiWorkflow(plan, workflowType) {
@@ -2232,9 +2249,13 @@ async function waitForApiWorkflow(plan, workflowType) {
   throw new Error(`${workflowType} did not reach a succeeded API projection: ${JSON.stringify(last).slice(-2000)}`);
 }
 
-async function requirePersistedJob(plan, jobUrl) {
-  const jobs = await requireJsonResponse(`${plan.apiOrigin}/v1/jobs`, { method: "GET" }, "persisted jobs smoke");
-  invariant(JSON.stringify(jobs).includes(jobUrl), "extracted API did not return the workflow-imported offline fixture job");
+async function requirePersistedJob(plan, jobId, jobUrl) {
+  const detail = await requireJsonResponse(
+    `${plan.apiOrigin}/v1/jobs/${encodeURIComponent(jobId)}`,
+    { method: "GET" },
+    "persisted captured job smoke",
+  );
+  assertPersistedExtensionCaptureSmokeJob(detail, { jobId, jobUrl });
   return true;
 }
 
@@ -2602,7 +2623,7 @@ print(json.dumps({"pdfPath": str(pdf_path), "pdfBytes": len(pdf_bytes)}, sort_ke
     );
     const workflowEventTypes = new Set((workflowDetailEvidence.events ?? []).map((event) => event.eventType));
     invariant(workflowEventTypes.has("WorkflowStarted") && workflowEventTypes.has("WorkflowCompleted"), "manual-capture workflow history is missing started/completed events");
-    await requirePersistedJob(runtimePlan, offlineFixtureUrl);
+    await requirePersistedJob(runtimePlan, captureEvidence.jobKey, offlineFixtureUrl);
     firstTemporalDescription = await describeTemporalWorkflow(runtimePlan, workflowEvidence.workflowId);
     invariant(
       workflowDetailEvidence.temporalRunId === firstTemporalDescription.runId,
@@ -2741,7 +2762,7 @@ with sync_playwright() as playwright:
     );
     invariant(secondStack.apiHealth.dbIdentity === firstStack.apiHealth.dbIdentity, "runtime restart changed the JobCtrl DB identity");
     invariant(secondStack.apiHealth.worker.heartbeat.pid === secondStack.worker.pid, "runtime restart health does not identify the fresh worker");
-    await requirePersistedJob(runtimePlan, offlineFixtureUrl);
+    await requirePersistedJob(runtimePlan, captureEvidence.jobKey, offlineFixtureUrl);
     const persistedWorkflow = await requireJsonResponse(
       `${runtimePlan.apiOrigin}/v1/workflow-runs/${encodeURIComponent(workflowEvidence.workflowId)}`,
       { method: "GET" },

--- a/scripts/distribution-build.test.mjs
+++ b/scripts/distribution-build.test.mjs
@@ -20,7 +20,9 @@ import {
   createExtractedRuntimeStackPlan,
   createDeterministicZip,
   createDeterministicTarGz,
+  assertPersistedExtensionCaptureSmokeJob,
   extensionCaptureSmokeHeaders,
+  extensionCaptureSmokeJobId,
   normalizeInstalledPythonMetadata,
   loadNativeLauncherToolchain,
   nativeLauncherLifecycleSmokeRequirement,
@@ -538,6 +540,31 @@ test("extension capture smoke uses the real bearer plus Chrome extension caller 
     origin: "chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "sec-fetch-site": "cross-site",
   });
+});
+
+test("extension capture smoke accepts the canonical JobId returned by the API", () => {
+  const jobId = "40000000-0000-4000-8000-000000000001";
+  assert.equal(extensionCaptureSmokeJobId({ ok: true, jobKey: jobId }), jobId);
+  assert.throws(
+    () => extensionCaptureSmokeJobId({ ok: true, jobKey: "https://example.test/jobs/distribution-smoke" }),
+    /did not return a canonical JobId/,
+  );
+});
+
+test("extension capture smoke resolves the returned JobId to the imported fixture URL", () => {
+  const jobId = "40000000-0000-4000-8000-000000000001";
+  const jobUrl = "https://example.test/jobs/distribution-smoke";
+  assert.doesNotThrow(() => assertPersistedExtensionCaptureSmokeJob(
+    { ok: true, job: { jobKey: jobId, url: jobUrl } },
+    { jobId, jobUrl },
+  ));
+  assert.throws(
+    () => assertPersistedExtensionCaptureSmokeJob(
+      { ok: true, job: { jobKey: jobId, url: "https://example.test/jobs/wrong" } },
+      { jobId, jobUrl },
+    ),
+    /did not resolve the captured JobId/,
+  );
 });
 
 test("successful distribution CLI invocation accepts the option separator and always persists build-result.json", async (context) => {

--- a/scripts/distribution-homebrew.render.bundle.mjs
+++ b/scripts/distribution-homebrew.render.bundle.mjs
@@ -10784,6 +10784,20 @@ function extensionCaptureSmokeHeaders(token) {
     "sec-fetch-site": "cross-site"
   };
 }
+function extensionCaptureSmokeJobId(result) {
+  invariant3(result?.ok === true, "extension capture smoke did not import the fixture job");
+  invariant3(
+    typeof result.jobKey === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(result.jobKey),
+    "extension capture smoke did not return a canonical JobId"
+  );
+  return result.jobKey;
+}
+function assertPersistedExtensionCaptureSmokeJob(detail, { jobId, jobUrl }) {
+  invariant3(
+    detail?.ok === true && detail.job?.jobKey === jobId && detail.job?.url === jobUrl,
+    "extracted API did not resolve the captured JobId to the workflow-imported offline fixture job"
+  );
+}
 async function submitExtensionCaptureFixture(plan, { captureId, jobUrl, captureHtml }) {
   const pairing = await requireJsonResponse(
     `${plan.apiOrigin}/v1/extension/pairing-token`,
@@ -10809,8 +10823,8 @@ async function submitExtensionCaptureFixture(plan, { captureId, jobUrl, captureH
     },
     "extension saved-HTML capture smoke"
   );
-  invariant3(result?.ok === true && result.jobKey === jobUrl, "extension capture smoke did not return the imported fixture job");
-  return { itemId: result.itemId, jobKey: result.jobKey, importedAt: result.importedAt };
+  const jobId = extensionCaptureSmokeJobId(result);
+  return { itemId: result.itemId, jobKey: jobId, importedAt: result.importedAt };
 }
 async function waitForApiWorkflow(plan, workflowType) {
   let last = null;
@@ -10826,9 +10840,13 @@ async function waitForApiWorkflow(plan, workflowType) {
   }
   throw new Error(`${workflowType} did not reach a succeeded API projection: ${JSON.stringify(last).slice(-2e3)}`);
 }
-async function requirePersistedJob(plan, jobUrl) {
-  const jobs = await requireJsonResponse(`${plan.apiOrigin}/v1/jobs`, { method: "GET" }, "persisted jobs smoke");
-  invariant3(JSON.stringify(jobs).includes(jobUrl), "extracted API did not return the workflow-imported offline fixture job");
+async function requirePersistedJob(plan, jobId, jobUrl) {
+  const detail = await requireJsonResponse(
+    `${plan.apiOrigin}/v1/jobs/${encodeURIComponent(jobId)}`,
+    { method: "GET" },
+    "persisted captured job smoke"
+  );
+  assertPersistedExtensionCaptureSmokeJob(detail, { jobId, jobUrl });
   return true;
 }
 async function describeTemporalWorkflow(plan, workflowId) {
@@ -11193,7 +11211,7 @@ print(json.dumps({"pdfPath": str(pdf_path), "pdfBytes": len(pdf_bytes)}, sort_ke
     );
     const workflowEventTypes = new Set((workflowDetailEvidence.events ?? []).map((event) => event.eventType));
     invariant3(workflowEventTypes.has("WorkflowStarted") && workflowEventTypes.has("WorkflowCompleted"), "manual-capture workflow history is missing started/completed events");
-    await requirePersistedJob(runtimePlan, offlineFixtureUrl);
+    await requirePersistedJob(runtimePlan, captureEvidence.jobKey, offlineFixtureUrl);
     firstTemporalDescription = await describeTemporalWorkflow(runtimePlan, workflowEvidence.workflowId);
     invariant3(
       workflowDetailEvidence.temporalRunId === firstTemporalDescription.runId,
@@ -11332,7 +11350,7 @@ with sync_playwright() as playwright:
     );
     invariant3(secondStack.apiHealth.dbIdentity === firstStack.apiHealth.dbIdentity, "runtime restart changed the JobCtrl DB identity");
     invariant3(secondStack.apiHealth.worker.heartbeat.pid === secondStack.worker.pid, "runtime restart health does not identify the fresh worker");
-    await requirePersistedJob(runtimePlan, offlineFixtureUrl);
+    await requirePersistedJob(runtimePlan, captureEvidence.jobKey, offlineFixtureUrl);
     const persistedWorkflow = await requireJsonResponse(
       `${runtimePlan.apiOrigin}/v1/workflow-runs/${encodeURIComponent(workflowEvidence.workflowId)}`,
       { method: "GET" },

--- a/scripts/distribution-homebrew.render.bundle.mjs.sha256
+++ b/scripts/distribution-homebrew.render.bundle.mjs.sha256
@@ -1,2 +1,2 @@
-156b3d8ec71db3cc6a45dc7af24e8182e02780be067a71332e353098b39a525b  distribution-homebrew.render.bundle.mjs
+06bca1af194a1a0febd7ff26a579f3596fa025edd43ddec75fe523b17d0fd8d1  distribution-homebrew.render.bundle.mjs
 9be48ff9788de9019949ff648926aba81d270ca21a9f86a4b18d7a8f1760d4d7  distribution-release-authority-bundles.NOTICE.txt

--- a/scripts/distribution-release.finalizer.bundle.mjs
+++ b/scripts/distribution-release.finalizer.bundle.mjs
@@ -10777,6 +10777,20 @@ function extensionCaptureSmokeHeaders(token) {
     "sec-fetch-site": "cross-site"
   };
 }
+function extensionCaptureSmokeJobId(result) {
+  invariant3(result?.ok === true, "extension capture smoke did not import the fixture job");
+  invariant3(
+    typeof result.jobKey === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(result.jobKey),
+    "extension capture smoke did not return a canonical JobId"
+  );
+  return result.jobKey;
+}
+function assertPersistedExtensionCaptureSmokeJob(detail, { jobId, jobUrl }) {
+  invariant3(
+    detail?.ok === true && detail.job?.jobKey === jobId && detail.job?.url === jobUrl,
+    "extracted API did not resolve the captured JobId to the workflow-imported offline fixture job"
+  );
+}
 async function submitExtensionCaptureFixture(plan, { captureId, jobUrl, captureHtml }) {
   const pairing = await requireJsonResponse(
     `${plan.apiOrigin}/v1/extension/pairing-token`,
@@ -10802,8 +10816,8 @@ async function submitExtensionCaptureFixture(plan, { captureId, jobUrl, captureH
     },
     "extension saved-HTML capture smoke"
   );
-  invariant3(result?.ok === true && result.jobKey === jobUrl, "extension capture smoke did not return the imported fixture job");
-  return { itemId: result.itemId, jobKey: result.jobKey, importedAt: result.importedAt };
+  const jobId = extensionCaptureSmokeJobId(result);
+  return { itemId: result.itemId, jobKey: jobId, importedAt: result.importedAt };
 }
 async function waitForApiWorkflow(plan, workflowType) {
   let last = null;
@@ -10819,9 +10833,13 @@ async function waitForApiWorkflow(plan, workflowType) {
   }
   throw new Error(`${workflowType} did not reach a succeeded API projection: ${JSON.stringify(last).slice(-2e3)}`);
 }
-async function requirePersistedJob(plan, jobUrl) {
-  const jobs = await requireJsonResponse(`${plan.apiOrigin}/v1/jobs`, { method: "GET" }, "persisted jobs smoke");
-  invariant3(JSON.stringify(jobs).includes(jobUrl), "extracted API did not return the workflow-imported offline fixture job");
+async function requirePersistedJob(plan, jobId, jobUrl) {
+  const detail = await requireJsonResponse(
+    `${plan.apiOrigin}/v1/jobs/${encodeURIComponent(jobId)}`,
+    { method: "GET" },
+    "persisted captured job smoke"
+  );
+  assertPersistedExtensionCaptureSmokeJob(detail, { jobId, jobUrl });
   return true;
 }
 async function describeTemporalWorkflow(plan, workflowId) {
@@ -11186,7 +11204,7 @@ print(json.dumps({"pdfPath": str(pdf_path), "pdfBytes": len(pdf_bytes)}, sort_ke
     );
     const workflowEventTypes = new Set((workflowDetailEvidence.events ?? []).map((event) => event.eventType));
     invariant3(workflowEventTypes.has("WorkflowStarted") && workflowEventTypes.has("WorkflowCompleted"), "manual-capture workflow history is missing started/completed events");
-    await requirePersistedJob(runtimePlan, offlineFixtureUrl);
+    await requirePersistedJob(runtimePlan, captureEvidence.jobKey, offlineFixtureUrl);
     firstTemporalDescription = await describeTemporalWorkflow(runtimePlan, workflowEvidence.workflowId);
     invariant3(
       workflowDetailEvidence.temporalRunId === firstTemporalDescription.runId,
@@ -11325,7 +11343,7 @@ with sync_playwright() as playwright:
     );
     invariant3(secondStack.apiHealth.dbIdentity === firstStack.apiHealth.dbIdentity, "runtime restart changed the JobCtrl DB identity");
     invariant3(secondStack.apiHealth.worker.heartbeat.pid === secondStack.worker.pid, "runtime restart health does not identify the fresh worker");
-    await requirePersistedJob(runtimePlan, offlineFixtureUrl);
+    await requirePersistedJob(runtimePlan, captureEvidence.jobKey, offlineFixtureUrl);
     const persistedWorkflow = await requireJsonResponse(
       `${runtimePlan.apiOrigin}/v1/workflow-runs/${encodeURIComponent(workflowEvidence.workflowId)}`,
       { method: "GET" },

--- a/scripts/distribution-release.finalizer.bundle.mjs.sha256
+++ b/scripts/distribution-release.finalizer.bundle.mjs.sha256
@@ -1,2 +1,2 @@
-2c42faae04f53b032a895b1fa6402a662b7f610635f303f426e3648426aabd88  distribution-release.finalizer.bundle.mjs
+055f5939ca1bc02c3bea208ce2609d84b3216087621512bdcfacd44b15afe76b  distribution-release.finalizer.bundle.mjs
 9be48ff9788de9019949ff648926aba81d270ca21a9f86a4b18d7a8f1760d4d7  distribution-release-authority-bundles.NOTICE.txt


### PR DESCRIPTION
## What

- accept the canonical lowercase UUID `JobId` returned by extension capture import
- resolve that exact identity through the job-detail route and bind it to the imported fixture URL before and after runtime restart
- add regression coverage for the canonical-ID and identity-to-URL invariants
- regenerate and re-hash both tracked release-authority bundles

## Why

The protected v0.1.0 unsigned-candidate build exposed a stale distribution smoke assertion that still expected the legacy URL-as-job-key contract. The API has returned canonical exact-v7 JobIds since the identity migration, so release preparation stopped before signing or publication even though the product path was correct.

## Validation

- `corepack pnpm scripts:test` — 142/142 passed
- `node --test scripts/distribution-build.test.mjs scripts/distribution-release.test.mjs scripts/distribution-homebrew.test.mjs` — 64/64 passed
- `corepack pnpm distribution:audit` — passed
- `python3 scripts/release_check.py --strict-prompt --release-tag v0.1.0` — passed
- exact local unsigned `prepare` — passed, including capture, persistence, and worker/API/Temporal restart smoke
- both release-authority checksum manifests — passed
- `git diff --check` — passed
- independent reviewer gate — PASS, 0 findings
- independent QA gate — PASS, 0 findings