### PR TITLE
fix(release): satisfy Homebrew formula stanza order

### DIFF
--- a/packaging/homebrew/Formula/jobctrl.rb.tmpl
+++ b/packaging/homebrew/Formula/jobctrl.rb.tmpl
@@ -12,9 +12,9 @@ class Jobctrl < Formula
 
   url "{{ARTIFACT_URL}}"
   version "{{APP_VERSION}}"
-  version_scheme 1
   sha256 "{{ARTIFACT_SHA256}}"
   license "AGPL-3.0-only"
+  version_scheme 1
 
   JOBCTRL_BUILD_ID = "{{BUILD_ID}}"
   JOBCTRL_MANIFEST_SHA256 = "{{MANIFEST_SHA256}}"

--- a/scripts/distribution-homebrew.test.mjs
+++ b/scripts/distribution-homebrew.test.mjs
@@ -71,6 +71,11 @@ test("Homebrew render uses the exact signed curl ZIP identity without a toolchai
   assert.equal(validateRenderedHomebrewFormula({ formula: rendered.formula, descriptor: stableDescriptor(), descriptorRaw, signatureRaw, descriptorUrl }), true);
   assert.match(rendered.formula, /url "https:\/\/releases\.jobctrl\.dev\/v1\/artifacts\/stable-build-0000042\/jobctrl-2\.0\.0-darwin-arm64\.zip"/);
   assert.match(rendered.formula, /^\s*version_scheme 1$/m);
+  assert.match(
+    rendered.formula,
+    /  version "2\.0\.0"\n  sha256 "a{64}"\n  license "AGPL-3\.0-only"\n  version_scheme 1/,
+    "the canonical formula header must follow Homebrew's audited stanza order",
+  );
   assert.match(rendered.formula, /JOBCTRL_MANIFEST_SHA256 = "b{64}"/);
   assert.match(rendered.formula, /JOBCTRL_BUILD_ID = "stable-build-0000042"/);
   assert.match(rendered.formula, /resource "jobctrl-release-descriptor"/);


### PR DESCRIPTION
## What changed

- order the canonical formula stanzas as `version`, `sha256`, `license`, then `version_scheme`
- pin the complete audited header order in the Homebrew renderer regression

## Why

The protected v0.1.0 release run failed closed during `brew audit --strict --formula` before stable pointer, tap, GitHub Release, or PyPI promotion. Homebrew reported that `sha256` and `license` must precede `version_scheme`.

## Validation

- `node --test scripts/distribution-homebrew.test.mjs` (5 passed)
- exact signed draft-candidate render followed by `brew audit --strict --formula` (passed)
- `corepack pnpm scripts:test` (142 passed)
- `python3 scripts/release_check.py --strict-prompt --release-tag v0.1.0`
- `corepack pnpm distribution:audit`
- `git diff --check`

The failed release left the stable pointer at sequence 2 and did not publish the tap, GitHub Release, or PyPI 0.1.0.