### PR TITLE
fix(release): recover immutable PyPI publication

### DIFF
--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -24,7 +24,7 @@ on:
         type: choice
         options: [stable, prerelease]
       pypi_recovery_only:
-        description: Rebuild and publish PyPI from immutable v2.0.7 on main without signing or release publication
+        description: Rebuild and publish PyPI from an explicitly supported immutable release on main without signing or release publication
         required: false
         default: false
         type: boolean
@@ -89,7 +89,10 @@ jobs:
           if [[ "$PYPI_RECOVERY_ONLY" = true ]]; then
             test "$GITHUB_EVENT_NAME" = workflow_dispatch
             test "$GITHUB_REF" = refs/heads/main
-            test "$RELEASE_TAG" = v2.0.7
+            case "$RELEASE_TAG" in
+              v2.0.7|v0.1.0) ;;
+              *) echo "unsupported immutable PyPI recovery tag: $RELEASE_TAG" >&2; exit 1 ;;
+            esac
             test "$RELEASE_CHANNEL" = stable
           else
             test "$GITHUB_REF" = "refs/tags/$RELEASE_TAG"
@@ -1243,7 +1246,7 @@ jobs:
           gh release verify "$RELEASE_TAG"
 
   pypi-recovery-preflight:
-    name: Prove immutable v2.0.7 release before PyPI recovery
+    name: Prove an explicitly supported immutable release before PyPI recovery
     needs: resolve
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.pypi_recovery_only == true }}
     runs-on: ubuntu-24.04
@@ -1258,7 +1261,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          test "$RELEASE_TAG" = v2.0.7
+          case "$RELEASE_TAG" in
+            v2.0.7|v0.1.0) ;;
+            *) echo "unsupported immutable PyPI recovery tag: $RELEASE_TAG" >&2; exit 1 ;;
+          esac
           tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')"
           test "$tag_sha" = "$RELEASE_REF"
           main_relation="$(gh api "repos/$GITHUB_REPOSITORY/compare/$RELEASE_REF...main" --jq '.status')"
@@ -1423,7 +1429,20 @@ jobs:
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
 
       - name: Set up only the exact locked release-build dependencies
-        run: uv --project workers/automation sync --python 3.12.13 --locked --no-default-groups --only-group release-build --no-install-project
+        env:
+          PYPI_RECOVERY_ONLY: ${{ inputs.pypi_recovery_only || false }}
+        run: |
+          set -euo pipefail
+          if [[ "$PYPI_RECOVERY_ONLY" = true && "$RELEASE_TAG" = v0.1.0 ]]; then
+            # The immutable v0.1.0 source records P8D even though its
+            # pyproject declares seven days. Reproduce that exact lock input;
+            # --locked still forbids dependency or checksum changes.
+            grep -Fqx 'exclude-newer = "7 days"' workers/automation/pyproject.toml
+            grep -Fqx 'exclude-newer-span = "P8D"' workers/automation/uv.lock
+            UV_EXCLUDE_NEWER="8 days" uv --project workers/automation sync --python 3.12.13 --locked --no-default-groups --only-group release-build --no-install-project
+          else
+            uv --project workers/automation sync --python 3.12.13 --locked --no-default-groups --only-group release-build --no-install-project
+          fi
 
       - name: Build exact fixed-epoch PyPI distributions without isolation
         run: |

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -346,6 +346,20 @@ especially §§11–14. This is a release precondition, not permission to publis
   Remove those two temporary branch policies immediately after the run reaches
   a terminal state and verify both environments again admit only `v*` tags.
   Do not change the policies of `release-signing` or `release-publication`.
+- **Immutable `v0.1.0` PyPI recovery.** Release run `31605551963` successfully
+  published the signed sequence-3 R2 pointer, Homebrew formula, and immutable
+  GitHub Release before the PyPI builder found that the tagged `pyproject.toml`
+  declares a seven-day dependency cutoff while its immutable `uv.lock` records
+  `P8D`. The OIDC publisher did not run. Preserve that tag and release. The
+  recovery workflow dispatched from `main` may admit only the explicitly
+  supported immutable `v2.0.7` and `v0.1.0` releases, must reverify the exact
+  ancestral immutable release before dependencies execute, and for `v0.1.0`
+  must require those exact mismatched records before setting
+  `UV_EXCLUDE_NEWER="8 days"`. `uv --locked` remains mandatory, so the recovery
+  reproduces the tagged lock input without changing dependency versions or
+  checksums. All native signing, R2, pointer, Homebrew, and GitHub publication
+  jobs remain skipped. Main and future release tags must instead carry the
+  regenerated `P7D` lock metadata and pass the static parity regression.
 - **Published `v2.0.8` security release.** The signed workflow published
   `v2.0.8` from audited commit
   `92770fe5fcc99e73c0a06e73315acbb7b506a7af` in workflow run

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -903,7 +903,8 @@ test("release workflows use protected manual signing, artifact handoff, candidat
   const recovery = releaseJob("pypi-recovery-preflight");
   assert.match(recovery, /github\.event_name == 'workflow_dispatch' && inputs\.pypi_recovery_only == true/);
   for (const marker of [
-    'test "$RELEASE_TAG" = v2.0.7',
+    'v2.0.7|v0.1.0',
+    'unsupported immutable PyPI recovery tag',
     "compare/$RELEASE_REF...main",
     "isDraft",
     "isPrerelease",
@@ -911,6 +912,11 @@ test("release workflows use protected manual signing, artifact handoff, candidat
     'gh release verify "$RELEASE_TAG"',
   ]) assert.ok(recovery.includes(marker), `recovery must prove ${marker}`);
   assert.doesNotMatch(recovery, /\baws\b|git push|gh release (?:create|edit|upload)/);
+  assert.match(pypiBuild, /PYPI_RECOVERY_ONLY: \$\{\{ inputs\.pypi_recovery_only \|\| false \}\}/);
+  assert.match(pypiBuild, /\[\[ "\$PYPI_RECOVERY_ONLY" = true && "\$RELEASE_TAG" = v0\.1\.0 \]\]/);
+  assert.match(pypiBuild, /grep -Fqx 'exclude-newer = "7 days"' workers\/automation\/pyproject\.toml/);
+  assert.match(pypiBuild, /grep -Fqx 'exclude-newer-span = "P8D"' workers\/automation\/uv\.lock/);
+  assert.match(pypiBuild, /UV_EXCLUDE_NEWER="8 days" uv --project workers\/automation sync/);
 });
 
 test("release lineage allows main to advance without loosening exact tag identity", async () => {

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -1084,7 +1084,7 @@ def _release_distribution_findings(root: Path) -> list[str]:
         "immutable-releases": "does not fail closed unless immutable GitHub Releases are enabled",
         "gh release verify-asset": "does not compare post-lock release assets to local trusted bytes",
         "gh release verify \"$RELEASE_TAG\"": "does not verify the immutable release attestation",
-        "Prove immutable v2.0.7 release before PyPI recovery": "does not isolate read-only immutable-release recovery preflight",
+        "Prove an explicitly supported immutable release before PyPI recovery": "does not isolate read-only immutable-release recovery preflight",
         "uses: ./.github/workflows/sync-homebrew-tap.yml": "does not call the artifact-only Homebrew promotion workflow",
         "tap_name=\"jobctrl/release-smoke-${GITHUB_RUN_ID}\"": "does not isolate the temporary verification tap by release run",
         "brew tap-new --no-git \"$tap_name\"": "does not create an isolated temporary tap for formula verification without CI Git side effects",
@@ -1393,7 +1393,8 @@ def _release_distribution_findings(root: Path) -> list[str]:
         for marker in (
             "needs: resolve",
             "inputs.pypi_recovery_only == true",
-            'test "$RELEASE_TAG" = v2.0.7',
+            'v2.0.7|v0.1.0',
+            'unsupported immutable PyPI recovery tag',
             'compare/$RELEASE_REF...main',
             'commits/$RELEASE_TAG',
             "targetCommitish",
@@ -1499,6 +1500,10 @@ def _pypi_release_workflow_findings(workflow: str) -> list[str]:
             "needs: pypi-resolve",
             "if: ${{ !cancelled() && needs.pypi-resolve.result == 'success' }}",
             "SOURCE_DATE_EPOCH:",
+            'PYPI_RECOVERY_ONLY: ${{ inputs.pypi_recovery_only || false }}',
+            'grep -Fqx \'exclude-newer = "7 days"\' workers/automation/pyproject.toml',
+            'grep -Fqx \'exclude-newer-span = "P8D"\' workers/automation/uv.lock',
+            'UV_EXCLUDE_NEWER="8 days" uv --project workers/automation sync',
             "uv --project workers/automation sync --python 3.12.13 --locked --no-default-groups --only-group release-build --no-install-project",
             "uv --project workers/automation run --python 3.12.13 --no-sync python -m build --no-isolation workers/automation",
             "jobctrl-pypi-distributions-",
@@ -1581,6 +1586,10 @@ def _pypi_build_backend_findings(root: Path) -> list[str]:
         findings.append(
             f"{PYTHON_PROJECT_PATH}: release-build group must contain only build==1.4.3 and hatchling==1.29.0"
         )
+    if not re.search(r'(?m)^exclude-newer\s*=\s*"7 days"\s*$', pyproject_text):
+        findings.append(
+            f"{PYTHON_PROJECT_PATH}: broad dependency cutoff must remain exactly seven days"
+        )
     try:
         lock_text = lock_path.read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -1597,6 +1606,10 @@ def _pypi_build_backend_findings(root: Path) -> list[str]:
     ]
     if len(build_blocks) != 1 or not re.search(r'(?m)^version\s*=\s*"1\.4\.3"\s*$', build_blocks[0]):
         findings.append(f"{PYTHON_LOCK_PATH}: must lock build==1.4.3 for release-build")
+    if not re.search(r'(?m)^exclude-newer-span\s*=\s*"P7D"\s*$', lock_text):
+        findings.append(
+            f"{PYTHON_LOCK_PATH}: relative dependency cutoff must match the seven-day pyproject policy"
+        )
     return findings
 
 

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -854,6 +854,11 @@ def test_pypi_workflow_keeps_build_verification_outside_oidc_publication() -> No
     assert "verify-pypi-gate" not in build
     assert "JOBCTRL_RELEASE_PUBLIC_KEY" not in build
     assert "JOBCTRL_RELEASE_KEY_ID" not in build
+    assert "PYPI_RECOVERY_ONLY: ${{ inputs.pypi_recovery_only || false }}" in build
+    assert '[[ "$PYPI_RECOVERY_ONLY" = true && "$RELEASE_TAG" = v0.1.0 ]]' in build
+    assert 'grep -Fqx \'exclude-newer = "7 days"\'' in build
+    assert 'grep -Fqx \'exclude-newer-span = "P8D"\'' in build
+    assert 'UV_EXCLUDE_NEWER="8 days" uv --project workers/automation sync' in build
     sync = "uv --project workers/automation sync --python 3.12.13 --locked --no-default-groups --only-group release-build --no-install-project"
     build_command = "uv --project workers/automation run --python 3.12.13 --no-sync python -m build --no-isolation workers/automation"
     assert sync in build
@@ -907,9 +912,26 @@ def test_pypi_no_isolation_backend_is_exactly_pinned_and_locked() -> None:
     assert 'requires = ["hatchling==1.29.0"]' in pyproject
     assert '"hatchling==1.29.0"' in pyproject
     assert 'release-build = ["build==1.4.3", "hatchling==1.29.0"]' in pyproject
+    assert 'exclude-newer = "7 days"' in pyproject
+    assert 'exclude-newer-span = "P7D"' in lock
     assert 'name = "build"\nversion = "1.4.3"' in lock
     assert 'name = "hatchling"\nversion = "1.29.0"' in lock
     assert release_check._pypi_build_backend_findings(release_check.ROOT) == []
+
+
+def test_pypi_lock_cutoff_span_must_match_the_pyproject_policy(tmp_path: Path) -> None:
+    pyproject = (release_check.ROOT / release_check.PYTHON_PROJECT_PATH).read_text(
+        encoding="utf-8"
+    )
+    lock = (release_check.ROOT / release_check.PYTHON_LOCK_PATH).read_text(
+        encoding="utf-8"
+    ).replace('exclude-newer-span = "P7D"', 'exclude-newer-span = "P8D"', 1)
+    _write(tmp_path / release_check.PYTHON_PROJECT_PATH, pyproject)
+    _write(tmp_path / release_check.PYTHON_LOCK_PATH, lock)
+
+    findings = release_check._pypi_build_backend_findings(tmp_path)
+
+    assert any("relative dependency cutoff must match" in item for item in findings)
 
 
 def test_pypi_workflow_static_contract_is_clean() -> None:

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -14,8 +14,8 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P8D"
+exclude-newer = "2026-08-05T14:42:31.107051Z"
+exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
 claude-agent-sdk = "2026-07-10T00:00:00Z"


### PR DESCRIPTION
## What changed

- regenerate the main Python lock so its relative cutoff matches the seven-day pyproject policy
- add a static parity gate for future release locks
- admit the immutable v0.1.0 release to the read-only PyPI recovery lane
- reproduce only v0.1.0's exact historical P8D lock input while retaining `uv --locked`
- record the failed-build boundary and non-mutating recovery contract

## Why

Release run 31605551963 successfully published the signed sequence-3 R2 pointer, verified Homebrew formula, and immutable GitHub v0.1.0 Release. Its PyPI builder then failed before OIDC because the tagged pyproject declares a seven-day cutoff but the tagged lock records P8D. The immutable tag and release must remain unchanged.

## Safety

Recovery is dispatched from main, accepts only explicitly supported immutable v2.0.7 or v0.1.0, proves exact tag/main ancestry and the immutable GitHub attestation before dependencies execute, and skips signing, R2, pointer, Homebrew, and GitHub publication. The v0.1.0 override is enabled only after proving the exact P7D/P8D mismatch; `--locked` still prevents dependency or checksum drift.

## Validation

- exact `git archive v0.1.0` + pinned uv 0.11.7 recovery sync + fixed-epoch wheel/sdist build
- clean main P7D `uv sync --locked` with pinned uv 0.11.7
- `corepack pnpm scripts:test` (142 passed)
- targeted release-check Python tests (55 passed)
- strict v0.1.0 release check
- distribution audit
- docs build (9,651 references) and runtime check
- `git diff --check`