### PR TITLE
chore(release): cut over installer to v0.1.0

### DIFF
--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 
 # P6 renders these from the signed publication. Empty pins fail closed.
 # BEGIN JOBCTRL RELEASE PINS
-INSTALLER_URL="https://releases.jobctrl.dev/v1/artifacts/2.0.8-92770fe5fcc99e73c0a06e73315acbb7b506a7af-darwin-arm64/jobctrl-installer"
-INSTALLER_SHA256="be91015004c63d0f26f9ed6891d70e393058e99cc975cd4737a4e907a8229ccb"
-INSTALLER_VERSION="2.0.8"
+INSTALLER_URL="https://releases.jobctrl.dev/v1/artifacts/0.1.0-d01764c815d2aaa589ce29261274f1b255f322d4-darwin-arm64/jobctrl-installer"
+INSTALLER_SHA256="17cf5f6eb2d5af23cd58ac66720f130731a00c749691dac1d33e2d1d33086c33"
+INSTALLER_VERSION="0.1.0"
 # END JOBCTRL RELEASE PINS
 
 usage() {

--- a/scripts/get
+++ b/scripts/get
@@ -4,9 +4,9 @@ set -euo pipefail
 
 # P6 renders these from the signed publication. Empty pins fail closed.
 # BEGIN JOBCTRL RELEASE PINS
-INSTALLER_URL="https://releases.jobctrl.dev/v1/artifacts/2.0.8-92770fe5fcc99e73c0a06e73315acbb7b506a7af-darwin-arm64/jobctrl-installer"
-INSTALLER_SHA256="be91015004c63d0f26f9ed6891d70e393058e99cc975cd4737a4e907a8229ccb"
-INSTALLER_VERSION="2.0.8"
+INSTALLER_URL="https://releases.jobctrl.dev/v1/artifacts/0.1.0-d01764c815d2aaa589ce29261274f1b255f322d4-darwin-arm64/jobctrl-installer"
+INSTALLER_SHA256="17cf5f6eb2d5af23cd58ac66720f130731a00c749691dac1d33e2d1d33086c33"
+INSTALLER_VERSION="0.1.0"
 # END JOBCTRL RELEASE PINS
 
 usage() {

--- a/scripts/get.test.mjs
+++ b/scripts/get.test.mjs
@@ -157,9 +157,9 @@ test("local fixture mode cannot select a network release and the released path c
     assert.equal(local.status, 1);
     assert.match(local.stderr, /cannot use --release-url/);
     const source = readFileSync(GET, "utf8");
-    assert.match(source, /^INSTALLER_URL="https:\/\/releases\.jobctrl\.dev\/v1\/artifacts\/2\.0\.8-92770fe5fcc99e73c0a06e73315acbb7b506a7af-darwin-arm64\/jobctrl-installer"$/m);
-    assert.match(source, /^INSTALLER_SHA256="be91015004c63d0f26f9ed6891d70e393058e99cc975cd4737a4e907a8229ccb"$/m);
-    assert.match(source, /^INSTALLER_VERSION="2\.0\.8"$/m);
+    assert.match(source, /^INSTALLER_URL="https:\/\/releases\.jobctrl\.dev\/v1\/artifacts\/0\.1\.0-d01764c815d2aaa589ce29261274f1b255f322d4-darwin-arm64\/jobctrl-installer"$/m);
+    assert.match(source, /^INSTALLER_SHA256="17cf5f6eb2d5af23cd58ac66720f130731a00c749691dac1d33e2d1d33086c33"$/m);
+    assert.match(source, /^INSTALLER_VERSION="0\.1\.0"$/m);
     assert.doesNotMatch(source, /^INSTALLER_URL=""$/m);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });


### PR DESCRIPTION
## Summary

- replace both canonical installer copies with the immutable `v0.1.0` release asset
- pin the signed `0.1.0-d01764c...` build and its published native installer digest
- update the transport regression to require those exact public pins

## Why

The signed release is immutable and live, but the docs site still serves the prior `2.0.8` installer pins. This separate post-release cutover deploys the exact verified release bytes without changing the release tag or assets.

## Verification

- immutable `install.sh` matches `SHA256SUMS`: `5adb9cdeeefc77bda235af995ff4dc5bdb8da6852fc000652c31e8ffa208c876`
- `cmp` confirms both repository installer copies match the release asset byte-for-byte
- `node scripts/get.test.mjs`
- `node scripts/check-install-asset.mjs`
- `python3 scripts/release_check.py --strict-prompt`
- `corepack pnpm docs:build`
- `corepack pnpm docs:check:runtime`
- `git diff --check`