### PR TITLE
fix(web): repair pipeline stage evidence layout

### DIFF
--- a/apps/web/e2e/tests/route-visual-qa.spec.ts
+++ b/apps/web/e2e/tests/route-visual-qa.spec.ts
@@ -9,6 +9,7 @@ import {
   sampleJob,
   sampleResumeTemplateListResponse,
 } from "../../src/test/fixtures/projections.js";
+import { pipelinesDiscoveringSnapshot } from "../../src/views/pipelines/PipelinesView.fixtures.js";
 
 type Density = "compact" | "regular" | "comfy";
 
@@ -1829,6 +1830,128 @@ test("density modes, focus rings, filters, forms, and destructive controls remai
     role: null,
   });
 });
+test("Crawl sources keeps provider traversal separate from exact outcomes", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1491, height: 1245 });
+  await page.route("**/v1/pipeline/operations", async (route) => {
+    await route.fulfill({ json: pipelinesDiscoveringSnapshot });
+  });
+  await page.goto("/pipelines");
+
+  const crawl = page.getByRole("region", { name: "Crawl sources stage" });
+  const trigger = crawl.getByRole("button", { name: /Crawl sources/i });
+  await expect(trigger).toBeVisible({ timeout: 30_000 });
+  await trigger.click();
+
+  const content = crawl.locator(".pipeline-stage-row__content");
+  const provider = content.locator(".pipeline-stage-row__provider-progress");
+  const outcomes = content.locator(".pipeline-stage-row__outcomes");
+  await expect(provider).toBeVisible();
+  await expect(outcomes).toBeVisible();
+
+  const desktop = await content.evaluate((element) => {
+    const provider = element.querySelector<HTMLElement>(
+      ".pipeline-stage-row__provider-progress",
+    );
+    const outcomes = element.querySelector<HTMLElement>(
+      ".pipeline-stage-row__outcomes",
+    );
+    if (!provider || !outcomes) {
+      throw new Error("Expected both stage detail panels.");
+    }
+    const providerRect = provider.getBoundingClientRect();
+    const outcomesRect = outcomes.getBoundingClientRect();
+    return {
+      providerRight: providerRect.right,
+      outcomesLeft: outcomesRect.left,
+      overlaps:
+        providerRect.left < outcomesRect.right &&
+        providerRect.right > outcomesRect.left &&
+        providerRect.top < outcomesRect.bottom &&
+        providerRect.bottom > outcomesRect.top,
+    };
+  });
+  expect(desktop.overlaps).toBe(false);
+  expect(desktop.providerRight).toBeLessThanOrEqual(desktop.outcomesLeft + 1);
+
+  await page.setViewportSize({ width: 720, height: 900 });
+  const mobile = await content.evaluate((element) => {
+    const provider = element.querySelector<HTMLElement>(
+      ".pipeline-stage-row__provider-progress",
+    );
+    const outcomes = element.querySelector<HTMLElement>(
+      ".pipeline-stage-row__outcomes",
+    );
+    if (!provider || !outcomes) {
+      throw new Error("Expected both stage detail panels.");
+    }
+    const providerRect = provider.getBoundingClientRect();
+    const outcomesRect = outcomes.getBoundingClientRect();
+    return {
+      providerBottom: providerRect.bottom,
+      outcomesTop: outcomesRect.top,
+      overlaps:
+        providerRect.left < outcomesRect.right &&
+        providerRect.right > outcomesRect.left &&
+        providerRect.top < outcomesRect.bottom &&
+        providerRect.bottom > outcomesRect.top,
+    };
+  });
+  expect(mobile.overlaps).toBe(false);
+  expect(mobile.providerBottom).toBeLessThanOrEqual(mobile.outcomesTop + 1);
+});
+
+test("busy replacement guidance keeps its title readable without an action", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1491, height: 1245 });
+  await page.route("**/v1/pipeline/operations", async (route) => {
+    await route.fulfill({
+      json: {
+        ...pipelinesDiscoveringSnapshot,
+        execution: {
+          ...pipelinesDiscoveringSnapshot.execution,
+          workflowStatus: "succeeded",
+          phase: "draining",
+          finishedAt: "2026-07-14T12:04:00.000Z",
+        },
+        capacity: {
+          ...pipelinesDiscoveringSnapshot.capacity,
+          activeSlots: 1,
+          availableSlots: 3,
+          slotSaturation: 0.25,
+        },
+        activeItems: [],
+        activeItemsTotal: 0,
+        activeItemsTruncated: false,
+        activeStageCounts: [],
+      },
+    });
+  });
+  await page.goto("/pipelines");
+
+  const alert = page.getByRole("alert").filter({
+    hasText: "This Discover run has ended",
+  });
+  const title = alert.locator('[data-slot="alert-title"]');
+  await expect(title).toBeVisible({ timeout: 30_000 });
+  await expect(
+    alert.getByRole("link", { name: "Set up a new Discover run" }),
+  ).toHaveCount(0);
+
+  const geometry = await title.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return {
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth,
+      width: rect.width,
+    };
+  });
+  expect(geometry.width).toBeGreaterThan(100);
+  expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth + 1);
+});
+
 test("Profile and Preferences subjects share one expandable-card hierarchy", async ({
   page,
 }) => {

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
@@ -532,10 +532,12 @@ function applyModelValue(model: string): (typeof APPLY_MODEL_OPTIONS)[number] {
 
 export interface StageTriggerPanelProps {
   readonly stagePanels?: Partial<Record<PipelineRunStage, ReactNode>>;
+  readonly stageRunBlockReasons?: Partial<Record<PipelineRunStage, string>>;
 }
 
 export function StageTriggerPanel({
   stagePanels = {},
+  stageRunBlockReasons = {},
 }: StageTriggerPanelProps = {}) {
   const { featureFlags } = usePorts();
   const runAvailability = getApiCapabilityAvailability(
@@ -543,6 +545,7 @@ export function StageTriggerPanel({
     "runPipelineStages",
   );
   const unavailableReasonId = useId();
+  const blockedReasonId = useId();
   const runStages = useRunPipelineStagesMutation();
   const [submittedStage, setSubmittedStage] = useState<Stage | null>(null);
   const [submittedAt, setSubmittedAt] = useState<number | null>(null);
@@ -556,6 +559,7 @@ export function StageTriggerPanel({
   )
     ? persistedActiveStage
     : "discover";
+  const stageRunBlockReason = stageRunBlockReasons[activeStage] ?? null;
   const config = useStageTriggerStore((state) => state.configs[activeStage]);
   const setActiveStage = useStageTriggerStore((state) => state.setActiveStage);
   const patchStageConfig = useStageTriggerStore(
@@ -638,7 +642,7 @@ export function StageTriggerPanel({
 
   const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!runAvailability.available) return;
+    if (!runAvailability.available || stageRunBlockReason) return;
     const workerSnapshot = await health.refetch();
     if (workerSnapshot.data?.worker.status !== "healthy") return;
     setSubmittedStage(activeStage);
@@ -1018,10 +1022,17 @@ export function StageTriggerPanel({
       <div className="stage-trigger-actions">
         <Button
           aria-describedby={
-            runAvailability.available ? undefined : unavailableReasonId
+            !runAvailability.available
+              ? unavailableReasonId
+              : stageRunBlockReason
+                ? blockedReasonId
+                : undefined
           }
           disabled={
-            runStages.isPending || workerUnhealthy || !runAvailability.available
+            runStages.isPending ||
+            workerUnhealthy ||
+            !runAvailability.available ||
+            Boolean(stageRunBlockReason)
           }
           type="submit"
         >
@@ -1056,6 +1067,15 @@ export function StageTriggerPanel({
             Pipeline runs require the local app. <a href="/runs">Review bundled runs</a>
             {" or "}
             <a href={LOCAL_INSTALL_GUIDE_URL}>install JobCtrl</a>.
+          </span>
+        ) : stageRunBlockReason ? (
+          <span
+            className="status-line"
+            data-typography="body"
+            id={blockedReasonId}
+            role="status"
+          >
+            {stageRunBlockReason}
           </span>
         ) : workerUnhealthy ? (
           <span

--- a/apps/web/src/contexts/pipeline/components/pipelineOperationsDisplay.tsx
+++ b/apps/web/src/contexts/pipeline/components/pipelineOperationsDisplay.tsx
@@ -60,6 +60,33 @@ export function formatSeconds(value: number): string {
   return `${(value / 3_600).toFixed(value < 36_000 ? 1 : 0)} hr`;
 }
 
+function pausedEtaReasonLabel(
+  reason: Extract<PipelineEta, { status: "paused" }>["reason"],
+): string {
+  switch (reason) {
+    case "no_dispatch":
+      return "No recent dispatch activity";
+    case "budget_exceeded":
+      return "Budget limit reached";
+    case "blocked":
+      return "Work is blocked";
+    case "worker_unavailable":
+      return "Worker unavailable";
+  }
+}
+
+export function etaStatusLabel(eta: PipelineEta): string {
+  return eta.status === "paused" ? "No ETA" : sentenceCase(eta.status);
+}
+
+export function etaReasonLabel(
+  eta: Extract<PipelineEta, { status: "paused" | "stale" | "unavailable" }>,
+): string {
+  return eta.status === "paused"
+    ? pausedEtaReasonLabel(eta.reason)
+    : sentenceCase(eta.reason);
+}
+
 export function etaLabel(eta: PipelineEta): string {
   switch (eta.status) {
     case "available":
@@ -67,7 +94,7 @@ export function etaLabel(eta: PipelineEta): string {
     case "calibrating":
       return `Calibrating · ${eta.completedSamples}/${eta.minimumSamples}`;
     case "paused":
-      return `Paused · ${sentenceCase(eta.reason)}`;
+      return `No ETA · ${pausedEtaReasonLabel(eta.reason)}`;
     case "stale":
       return `Stale · ${sentenceCase(eta.reason)}`;
     case "unavailable":
@@ -168,7 +195,7 @@ export function CohortDetails({ cohort, label }: { readonly cohort: PipelineExec
 
 export function EtaDetails({ eta, label }: { readonly eta: PipelineEta; readonly label: string }) {
   const facts: Fact[] = [
-    { label: "Status", value: sentenceCase(eta.status) },
+    { label: "Status", value: etaStatusLabel(eta) },
     ...(eta.status === "available"
       ? [
           { label: "Low", value: formatSeconds(eta.lowSeconds) },
@@ -187,7 +214,7 @@ export function EtaDetails({ eta, label }: { readonly eta: PipelineEta; readonly
         ]
       : []),
     ...(eta.status === "paused" || eta.status === "stale" || eta.status === "unavailable"
-      ? [{ label: "Reason", value: sentenceCase(eta.reason) }]
+      ? [{ label: "Reason", value: etaReasonLabel(eta) }]
       : []),
     { label: "As of", value: formatDateTime(eta.asOf) },
   ];

--- a/apps/web/src/styles/redesign-pipelines.css
+++ b/apps/web/src/styles/redesign-pipelines.css
@@ -152,9 +152,13 @@
 }
 
 .pipeline-recovery-alert {
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr);
   gap: 4px 18px;
   padding-right: 16px;
+}
+
+.pipeline-recovery-alert:has([data-slot="alert-action"]) {
+  grid-template-columns: minmax(0, 1fr) auto;
 }
 
 .pipeline-recovery-alert [data-slot="alert-action"] {
@@ -329,9 +333,26 @@
   text-align: right;
 }
 
+.pipeline-stage-row__provider-progress {
+  grid-column: 1;
+  grid-row: 4;
+  min-width: 0;
+  padding-top: var(--jh-internal-gap);
+  border-top: 1px solid var(--border);
+}
+
+.pipeline-stage-row__provider-progress h4,
+.pipeline-stage-row__provider-progress p {
+  margin: 0;
+}
+
+.pipeline-stage-row__provider-progress h4 {
+  margin-bottom: calc(var(--jh-internal-gap) / 2);
+}
+
 .pipeline-stage-row__outcomes {
   grid-column: 2;
-  grid-row: 1 / span 3;
+  grid-row: 1 / span 4;
   min-width: 0;
   padding-left: var(--jh-panel-padding);
   border-left: 1px solid var(--border);
@@ -853,9 +874,13 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .pipeline-stage-row__provider-progress,
   .pipeline-stage-row__outcomes {
     grid-column: 1;
     grid-row: auto;
+  }
+
+  .pipeline-stage-row__outcomes {
     padding-top: var(--jh-internal-gap);
     padding-left: 0;
     border-top: 1px solid var(--border);

--- a/apps/web/src/views/pipelines/PipelinesView.test.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.test.tsx
@@ -135,6 +135,16 @@ describe("PipelinesView", () => {
     expect(
       within(crawl).getByRole("heading", { name: "Provider traversal" }),
     ).toBeInTheDocument();
+    expect(
+      within(crawl)
+        .getByRole("heading", { name: "Provider traversal" })
+        .closest("section"),
+    ).toHaveClass("pipeline-stage-row__provider-progress");
+    expect(
+      within(crawl)
+        .getByRole("heading", { name: "Exact outcomes" })
+        .closest("section"),
+    ).toHaveClass("pipeline-stage-row__outcomes");
     expect(crawl).toHaveTextContent(
       "Indeed · 3 pages completed; provider total unavailable · 42 raw listings seen · 9 jobs emitted · more pages available",
     );
@@ -725,6 +735,15 @@ describe("PipelinesView", () => {
       ...pipelinesCompletedWithIssuesSnapshot,
       activeItemsTotal: 0,
       activeItemsTruncated: false,
+      capacity: {
+        ...pipelinesCompletedWithIssuesSnapshot.capacity,
+        activeSlots: 0,
+        availableSlots:
+          pipelinesCompletedWithIssuesSnapshot.capacity.status === "available"
+            ? pipelinesCompletedWithIssuesSnapshot.capacity.configuredSlots
+            : 0,
+        slotSaturation: 0,
+      },
     }));
     const runPipelineStages = vi.fn();
     useStageTriggerStore.getState().setActiveStage("apply");
@@ -792,6 +811,207 @@ describe("PipelinesView", () => {
 
     expect(screen.queryByRole("button", { name: "Stop discovery" })).not.toBeInTheDocument();
   });
+
+  it("explains that a closed draining run needs a new Discover run instead of resume", async () => {
+    const user = userEvent.setup();
+    const runPipelineStages = vi.fn();
+    useStageTriggerStore.getState().setActiveStage("apply");
+    const pipelineOperations = vi.fn(async () => ({
+      ...pipelinesDiscoveringSnapshot,
+      execution: {
+        ...pipelinesDiscoveringSnapshot.execution!,
+        workflowStatus: "succeeded" as const,
+        phase: "draining" as const,
+        finishedAt: "2026-07-14T12:04:00.000Z",
+      },
+      capacity: {
+        ...pipelinesDiscoveringSnapshot.capacity,
+        activeSlots: 0,
+        availableSlots:
+          pipelinesDiscoveringSnapshot.capacity.status === "available"
+            ? pipelinesDiscoveringSnapshot.capacity.configuredSlots
+            : 0,
+        slotSaturation: 0,
+      },
+      stages: pipelinesDiscoveringSnapshot.stages.map((stage) =>
+        stage.stage === "source_family"
+          ? {
+              ...stage,
+              eta: {
+                status: "paused" as const,
+                reason: "no_dispatch" as const,
+                asOf: stage.asOf,
+              },
+            }
+          : stage,
+      ),
+      activeItems: [],
+      activeItemsTotal: 0,
+      activeItemsTruncated: false,
+      activeStageCounts: [],
+      overallEta: {
+        status: "paused" as const,
+        reason: "no_dispatch" as const,
+        asOf: pipelinesDiscoveringSnapshot.generatedAt,
+      },
+    }));
+    renderWithProviders(<PipelinesView />, {
+      ports: buildTestPorts({ api: { pipelineOperations, runPipelineStages } }),
+    });
+    await screen.findByRole("heading", { name: "Live pipeline" });
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("This Discover run has ended");
+    expect(alert).toHaveTextContent("there is no paused workflow to resume");
+    const restart = within(alert).getByRole("link", {
+      name: "Set up a new Discover run",
+    });
+    expect(restart).toHaveAttribute("href", "#pipeline-actions");
+
+    const crawl = screen.getByRole("region", { name: "Crawl sources stage" });
+    expect(
+      within(crawl).getByRole("button", { name: /Crawl sources/i }),
+    ).toHaveTextContent("No ETA · No recent dispatch activity");
+
+    await user.click(
+      screen.getByRole("button", { name: /Overall completion estimate/i }),
+    );
+    expect(screen.getByLabelText("Overall ETA facts")).toHaveTextContent(
+      "StatusNo ETA",
+    );
+
+    await user.click(restart);
+    expect(runPipelineStages).not.toHaveBeenCalled();
+    expect(screen.getByRole("tab", { name: "Discover" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(
+      await screen.findByRole("button", { name: "Run Discover" }),
+    ).toBeEnabled();
+  });
+
+  it("blocks a manually selected replacement Discover run while shared work is active", async () => {
+    const user = userEvent.setup();
+    const runPipelineStages = vi.fn();
+    useStageTriggerStore.getState().setActiveStage("apply");
+    const pipelineOperations = vi.fn(async () => ({
+      ...pipelinesDiscoveringSnapshot,
+      execution: {
+        ...pipelinesDiscoveringSnapshot.execution!,
+        workflowStatus: "succeeded" as const,
+        phase: "draining" as const,
+        finishedAt: "2026-07-14T12:04:00.000Z",
+      },
+      capacity: {
+        ...pipelinesDiscoveringSnapshot.capacity,
+        activeSlots: 1,
+        availableSlots:
+          pipelinesDiscoveringSnapshot.capacity.status === "available"
+            ? pipelinesDiscoveringSnapshot.capacity.configuredSlots - 1
+            : 0,
+        slotSaturation:
+          pipelinesDiscoveringSnapshot.capacity.status === "available"
+            ? 1 / pipelinesDiscoveringSnapshot.capacity.configuredSlots
+            : 0,
+      },
+      activeItems: [],
+      activeItemsTotal: 0,
+      activeItemsTruncated: false,
+      activeStageCounts: [],
+    }));
+    renderWithProviders(<PipelinesView />, {
+      ports: buildTestPorts({ api: { pipelineOperations, runPipelineStages } }),
+    });
+    await screen.findByRole("heading", { name: "Live pipeline" });
+
+    expect(
+      screen.queryByRole("link", { name: "Set up a new Discover run" }),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Discover" }));
+
+    const runDiscover = screen.getByRole("button", { name: "Run Discover" });
+    expect(runDiscover).toBeDisabled();
+    expect(runDiscover).toHaveAccessibleDescription(
+      "Wait for active pipeline work to finish before starting a new Discover run.",
+    );
+    await user.click(runDiscover);
+    expect(runPipelineStages).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      capacity: "busy",
+      label: "failed with busy capacity",
+      snapshot: pipelinesFailedHistorySnapshot,
+    },
+    {
+      capacity: "unavailable",
+      label: "failed with unavailable capacity",
+      snapshot: pipelinesFailedHistorySnapshot,
+    },
+    {
+      capacity: "busy",
+      label: "completed with issues and busy capacity",
+      snapshot: pipelinesCompletedWithIssuesSnapshot,
+    },
+    {
+      capacity: "unavailable",
+      label: "completed with issues and unavailable capacity",
+      snapshot: pipelinesCompletedWithIssuesSnapshot,
+    },
+  ])(
+    "blocks the manual Discover bypass for a $label replacement run",
+    async ({ capacity, snapshot }) => {
+      const user = userEvent.setup();
+      const runPipelineStages = vi.fn();
+      useStageTriggerStore.getState().setActiveStage("apply");
+      const pipelineOperations = vi.fn(async () => ({
+        ...snapshot,
+        capacity:
+          capacity === "unavailable"
+            ? pipelinesUnavailableTelemetrySnapshot.capacity
+            : {
+                ...snapshot.capacity,
+                activeSlots: 1,
+                availableSlots:
+                  snapshot.capacity.status === "available"
+                    ? snapshot.capacity.configuredSlots - 1
+                    : 0,
+                slotSaturation:
+                  snapshot.capacity.status === "available"
+                    ? 1 / snapshot.capacity.configuredSlots
+                    : 0,
+              },
+        activeItems: [],
+        activeItemsTotal: 0,
+        activeItemsTruncated: false,
+        activeStageCounts: [],
+      }));
+      renderWithProviders(<PipelinesView />, {
+        ports: buildTestPorts({
+          api: { pipelineOperations, runPipelineStages },
+        }),
+      });
+      await screen.findByRole("heading", { name: "Live pipeline" });
+
+      expect(
+        screen.queryByRole("link", { name: "Set up a new Discover run" }),
+      ).not.toBeInTheDocument();
+      await user.click(screen.getByRole("tab", { name: "Discover" }));
+      const runDiscover = screen.getByRole("button", {
+        name: "Run Discover",
+      });
+      expect(runDiscover).toBeDisabled();
+      expect(runDiscover).toHaveAccessibleDescription(
+        capacity === "unavailable"
+          ? "Shared runtime capacity must be available before starting a new Discover run."
+          : "Wait for active pipeline work to finish before starting a new Discover run.",
+      );
+      await user.click(runDiscover);
+      expect(runPipelineStages).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps source-family progress separate from exactly two reconciliation ledgers", async () => {
     await renderPipelineOperations(pipelinesThreeSourceSixStepSnapshot);

--- a/apps/web/src/views/pipelines/PipelinesView.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.tsx
@@ -18,6 +18,8 @@ import { CancelWorkflowRunButton } from "../../contexts/pipeline/components/Canc
 import { StageTriggerPanel } from "../../contexts/pipeline/components/StageTriggerPanel.js";
 import {
   etaLabel,
+  etaReasonLabel,
+  etaStatusLabel,
   formatSeconds,
   safeOperationalIdentifier,
   sentenceCase,
@@ -178,6 +180,32 @@ function canSafelyPrepareNewDiscoverRun(
   );
 }
 
+function executionNeedsReplacement(
+  execution: NonNullable<PipelineOperationsSnapshot["execution"]>,
+): boolean {
+  return (
+    execution.phase === "failed" ||
+    execution.phase === "completed_with_issues" ||
+    (execution.phase === "draining" &&
+      execution.workflowStatus !== "in_progress")
+  );
+}
+
+function discoverRunBlockReason(
+  snapshot: PipelineOperationsSnapshot,
+): string | null {
+  const execution = snapshot.execution;
+  const needsReplacementGuard =
+    (execution ? executionNeedsReplacement(execution) : false) ||
+    snapshot.projectionCoverage?.status === "incomplete";
+  if (!needsReplacementGuard) return null;
+  if (canSafelyPrepareNewDiscoverRun(snapshot)) return null;
+  if (snapshot.capacity.status !== "available") {
+    return "Shared runtime capacity must be available before starting a new Discover run.";
+  }
+  return "Wait for active pipeline work to finish before starting a new Discover run.";
+}
+
 function PipelineStatus({
   children,
   status,
@@ -336,7 +364,7 @@ function EtaLedger({
 }) {
   return (
     <InspectorLedger aria-label={label} className="pipeline-compact-ledger">
-      <InspectorLedgerItem label="Status" value={sentenceCase(eta.status)} />
+      <InspectorLedgerItem label="Status" value={etaStatusLabel(eta)} />
       {eta.status === "available" ? (
         <>
           <InspectorLedgerItem label="Low" value={formatSeconds(eta.lowSeconds)} />
@@ -366,7 +394,7 @@ function EtaLedger({
       {eta.status === "paused" ||
       eta.status === "stale" ||
       eta.status === "unavailable" ? (
-        <InspectorLedgerItem label="Reason" value={sentenceCase(eta.reason)} />
+        <InspectorLedgerItem label="Reason" value={etaReasonLabel(eta)} />
       ) : null}
       <InspectorLedgerItem label="As of" value={formatDateTime(eta.asOf)} />
     </InspectorLedger>
@@ -756,7 +784,7 @@ function PipelineStageRow({
               </div>
             ) : null}
             {providerProgress ? (
-              <section className="pipeline-stage-row__outcomes">
+              <section className="pipeline-stage-row__provider-progress">
                 <h4 data-typography="component-title">Provider traversal</h4>
                 <p data-typography="body">{providerProgressLabel(providerProgress)}</p>
               </section>
@@ -842,17 +870,30 @@ function PipelineExecutionNotice({
   if (!projectionReady(snapshot)) return null;
 
   const execution = snapshot.execution;
+  if (!execution) return null;
+
+  if (!executionNeedsReplacement(execution)) return null;
+  const isClosedDraining =
+    execution.phase === "draining" &&
+    execution.workflowStatus !== "in_progress";
+  let copy: ExecutionFailureCopy;
   if (
-    !execution ||
-    (execution.phase !== "failed" &&
-      execution.phase !== "completed_with_issues")
+    execution.phase === "failed" ||
+    execution.phase === "completed_with_issues"
   ) {
+    copy = executionFailureCopy(execution.phase, execution.errorCode);
+  } else if (isClosedDraining) {
+    copy = {
+      title: "This Discover run has ended",
+      description:
+        "The selected workflow is closed, so there is no paused workflow to resume. Use Set up a new Discover run to continue the remaining work once shared runtime capacity is idle.",
+    };
+  } else {
     return null;
   }
 
-  const copy = executionFailureCopy(execution.phase, execution.errorCode);
   const activityCopy = failedExecutionActivityCopy(snapshot.activeItemsTotal);
-  const canStartNewRun = snapshot.activeItemsTotal === 0;
+  const canStartNewRun = canSafelyPrepareNewDiscoverRun(snapshot);
   return (
     <div className="pipeline-recovery-notice">
       <Alert
@@ -1740,6 +1781,7 @@ function PipelineWorkspace({
   const canStartFromIncompleteHistory =
     snapshot.projectionCoverage?.status === "incomplete" &&
     canSafelyPrepareNewDiscoverRun(snapshot);
+  const discoverBlockReason = discoverRunBlockReason(snapshot);
 
   return (
     <RouteWorkspace
@@ -1797,7 +1839,15 @@ function PipelineWorkspace({
             aria-label="Pipeline action tools"
             className="pipelines-workspace__controls"
             id="pipeline-actions"
-            primary={<StageTriggerPanel />}
+            primary={
+              <StageTriggerPanel
+                stageRunBlockReasons={
+                  discoverBlockReason
+                    ? { discover: discoverBlockReason }
+                    : {}
+                }
+              />
+            }
             role="group"
           />
         ) : null}

--- a/docs/architecture/pipeline/operations.md
+++ b/docs/architecture/pipeline/operations.md
@@ -202,7 +202,10 @@ A failed execution is never treated as proof that the runtime is idle. The UI
 uses `activeItemsTotal` as a three-state recovery gate: a positive value reports
 remaining work, `null` reports that the inventory is unavailable, and exactly
 zero permits **Set up a new Discover run**. That action only selects and focuses
-the Discover launch controls; it never dispatches work implicitly.
+the Discover launch controls; it never dispatches work implicitly. The same
+fresh zero-active-slot guard disables direct Discover submission for failed,
+completed-with-issues, closed-draining, and incomplete-history replacement
+runs, so selecting the action tab cannot bypass recovery safety.
 
 `reconciled_not_found` is a provisional verdict: the worker could not find the
 exact recorded Temporal run in the history store it could currently reach. The
@@ -382,8 +385,12 @@ per-stage and source-family ranges can price their already-known scoped backlog
 before closure. Every estimate still withholds a number when telemetry is stale,
 a worker is unavailable, work is budget-blocked, or shared contention is
 unbounded. Non-numeric `calibrating`, `paused`, `stale`, and `unavailable`
-states are part of the contract. An available low/high range is a current
-projection estimate, not a completion promise.
+states are part of the contract. The web surface presents a `paused` estimate
+as **No ETA** plus the bounded reason so it cannot be mistaken for the Temporal
+workflow's lifecycle state. In particular, `no_dispatch` means the estimator
+has not observed recent dispatch activity; it is not a resumable workflow
+command. An available low/high range is a current projection estimate, not a
+completion promise.
 
 ## Persistence Map
 

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -451,6 +451,12 @@ Pipelines component tests, and the live browser path together. The live pass
 must compare the operations response with the rendered workspace so shared-pool
 telemetry cannot be mistaken for selected-run proof.
 
+When source-family provider traversal is present, expand **Crawl sources** at a
+desktop viewport and assert that its traversal evidence and exact-outcomes
+ledger have disjoint layout rectangles. Repeat below the responsive breakpoint
+and assert that traversal finishes above the outcomes ledger. This is the
+regression guard for multiple evidence blocks sharing one stage detail row.
+
 Also cover the retry and terminal edge cases. A successful fanout retry with
 `attempt > 1` must restore exact membership and steps without inventing a queue
 timestamp. A failed attempt that is waiting to retry, or a later attempt that is

--- a/docs/user/normal-flows.md
+++ b/docs/user/normal-flows.md
@@ -183,9 +183,14 @@ from that current-execution flow. Capacity details include configured and active
 slots, internal parallelism when applicable, and approximate task-queue pollers,
 backlog, age, add rate, and dispatch rate. The execution inspector shows cohort
 membership and remaining work, read-model freshness, and the bounded active-work
-inventory. Treat ETA as an observed range: calibrating, paused, stale,
-unavailable, and no-work states are deliberately explicit rather than replaced
-by a guessed finish time.
+inventory. Treat ETA as an observed range: calibrating, no recent dispatch,
+stale, unavailable, and no-work states are deliberately explicit rather than
+replaced by a guessed finish time. An
+unavailable ETA does not mean that the workflow itself is paused.
+When a closed run leaves work behind, **Set up a new Discover run** becomes
+available only after the live operations snapshot proves that shared runtime
+capacity is idle. The Discover run control follows the same guard, so selecting
+the tab directly cannot bypass it.
 
 ### Workers, Activity Slots, And Queue Backlog
 


### PR DESCRIPTION
## Summary

- give provider traversal and exact outcomes separate responsive layout regions so expanded Crawl sources evidence cannot overlap
- present estimator `paused` states as `No ETA` with a specific reason, and explain that a closed Discover workflow requires a new run rather than a resume action
- gate every replacement Discover entry path on fresh idle-capacity evidence, including failed, completed-with-issues, closed-draining, and incomplete-history states
- keep recovery alerts readable with or without an action, and document the user-facing and architecture contracts

## Validation

- `corepack pnpm --filter @jobctrl/web exec vitest run src/views/pipelines/PipelinesView.test.tsx src/contexts/pipeline/components/StageTriggerPanel.test.tsx` — 61 passed
- `corepack pnpm web:check`
- `corepack pnpm web:build`
- focused Chromium route QA — 2 passed at 1491x1245 and 720x900
- `corepack pnpm docs:build` — 9,651 references across 359 files
- independent reviewer gate: PASS
- independent QA gate: PASS

## Checklist

- [x] External contributor commits include a DCO `Signed-off-by:` trailer when required.
- [x] I ran the relevant local checks and listed them above.
- [x] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.
