### PR TITLE
fix(pipeline): recover terminal stage failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,10 @@ evidence, qualifications, and the complete capability matrix.
   approximate task-queue pressure, read-model freshness, and active work. An
   active Discover run can be stopped there. A failed run reports whether work
   remains before offering to set up a replacement run; setup never starts work
-  by itself. Runs keeps the durable workflow history; Jobs and route-level
+  by itself. Exact Temporal-history recovery prevents a closed run from staying
+  visible as active work. An exhausted attempt budget is shown as a retryable
+  failure reason, and Retry resets that budget. Runs keeps the durable workflow
+  history; Jobs and route-level
   detail workspaces keep record-specific evidence and actions adjacent.
 - Inspect Discover, preparation, and Apply through the same Runs vocabulary,
   timeline, terminal-state rules, and cancellation control. Repeated cancel

--- a/apps/api/src/pipeline-operations.ts
+++ b/apps/api/src/pipeline-operations.ts
@@ -256,8 +256,16 @@ export function buildPipelineOperationsSnapshot(
   const runtimeAttribution = buildSelectedRuntimeAttribution(db, tenantId, selected, telemetry);
   const projectionCoverage = loadProjectionCoverage(db, tenantId, selected);
   const selectedCapacity = buildCapacity(telemetry, internalParallelism(selected.row));
-  const currentCounts = stageCountsForCohort(selected.current, selected.steps);
-  const sweepCounts = stageCountsForCohort(selected.sweep, selected.steps);
+  const currentCounts = stageCountsForCohort(
+    selected.current,
+    selected.steps,
+    selected.row.status,
+  );
+  const sweepCounts = stageCountsForCohort(
+    selected.sweep,
+    selected.steps,
+    selected.row.status,
+  );
   const globalCounts = globalStageCounts(db, tenantId, selected);
   const globalRetryability = loadGlobalRetryability(db, tenantId, selected);
   const sourceFamilies = sourceFamilyProgress(
@@ -558,7 +566,7 @@ function phaseFor(
   steps: PipelineStepRow[],
   membershipClosed: boolean,
 ): DiscoveryExecutionSummary["phase"] {
-  if (status === "in_progress" || status === "starting") return "discovering";
+  if (isActiveWorkflowStatus(status)) return "discovering";
   if (status === "canceled") return "canceled";
   if (status === "failed" || status === "timed_out" || status === "terminated") return "failed";
   if (status === "succeeded" || status === "dry_run_complete") {
@@ -996,10 +1004,11 @@ function internalParallelism(row: WorkflowRow): number | null {
 function stageCountsForCohort(
   cohortValue: Cohort,
   steps: PipelineStepRow[],
+  discoverWorkflowStatus: string,
 ): Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts> {
   const counts = new Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>();
   counts.set("source_planning", projectionCounts(steps.filter((step) => step.step_kind === "source_planning")));
-  counts.set("source_family", sourceFamilyCounts(steps));
+  counts.set("source_family", sourceFamilyCounts(steps, discoverWorkflowStatus));
   counts.set("reconciliation", reconciliationCounts(steps));
   counts.set("pdf_render", pdfCounts(cohortValue, steps));
   for (const stage of JOB_STAGES) {
@@ -1008,10 +1017,17 @@ function stageCountsForCohort(
   return counts;
 }
 
-function sourceFamilyCounts(steps: PipelineStepRow[]): PipelineStageCounts {
+function sourceFamilyCounts(
+  steps: PipelineStepRow[],
+  discoverWorkflowStatus: string,
+): PipelineStageCounts {
   const families = steps.filter((step) => step.step_kind === "source_family");
   const planned = maxDetailCount(steps.filter((step) => step.step_kind === "source_planning"));
-  return projectionCounts(families, planned);
+  return projectionCounts(
+    families,
+    planned,
+    isActiveWorkflowStatus(discoverWorkflowStatus) ? "waiting" : "unknown",
+  );
 }
 
 function reconciliationCounts(steps: PipelineStepRow[]): PipelineStageCounts {
@@ -1058,7 +1074,11 @@ function pdfCounts(cohortValue: Cohort, steps: PipelineStepRow[]): PipelineStage
   return counts;
 }
 
-function projectionCounts(rows: PipelineStepRow[], expectedEligible?: number | null): PipelineStageCounts {
+function projectionCounts(
+  rows: PipelineStepRow[],
+  expectedEligible?: number | null,
+  unobservedState: "waiting" | "unknown" = "unknown",
+): PipelineStageCounts {
   const counts = emptyCounts();
   const expected = expectedEligible ?? rows.length;
   counts.eligible = Math.max(expected, rows.length);
@@ -1066,7 +1086,7 @@ function projectionCounts(rows: PipelineStepRow[], expectedEligible?: number | n
     addPipelineStepState(counts, row.state);
   }
   const known = outcomeSum(counts);
-  if (known < counts.eligible) counts.unknown += counts.eligible - known;
+  if (known < counts.eligible) counts[unobservedState] += counts.eligible - known;
   return counts;
 }
 
@@ -1473,7 +1493,7 @@ function sourceFamilyProgress(
   const sourcePlanRows = selected.steps.filter((step) => step.step_kind === "source_planning");
   if (sourceRows.length === 0 && sourcePlanRows.length === 0) return null;
   const planned = Math.max(maxDetailCount(sourcePlanRows) ?? 0, sourceRows.length);
-  const counts = projectionCounts(sourceRows, planned);
+  const counts = sourceFamilyCounts(selected.steps, selected.row.status);
   const providerProgress = sourceRows.some(
     (step) => step.item_key === "family:jobspy" && step.state === "running",
   )
@@ -2227,6 +2247,10 @@ function memberPreparationWorkflowFailed(
 
 function isFailedTerminalWorkflowStatus(status: string | undefined): boolean {
   return status === "failed" || status === "canceled" || status === "timed_out" || status === "terminated";
+}
+
+function isActiveWorkflowStatus(status: string | undefined): boolean {
+  return status === "in_progress" || status === "starting";
 }
 
 function isTerminalWorkflowStatus(status: string | undefined): boolean {

--- a/apps/api/src/pipeline-operations.ts
+++ b/apps/api/src/pipeline-operations.ts
@@ -25,7 +25,7 @@ import { readLlmSpendHealth } from "./worker-health.js";
 const DEFAULT_TENANT = "local";
 const ETA_SAMPLE_LIMIT = 50;
 const ETA_SAMPLE_WINDOW_MS = 14 * 24 * 60 * 60 * 1_000;
-const CURRENT_DISCOVERY_EXECUTION_DECODER_VERSION = 2;
+const CURRENT_DISCOVERY_EXECUTION_DECODER_VERSION = 3;
 
 const JOB_STAGES = ["enrich", "score", "tailor", "cover"] as const;
 const OPERATIONAL_STAGES = [
@@ -1136,7 +1136,7 @@ function addStageState(counts: PipelineStageCounts, state: string | null): void 
       counts.failed += 1;
       break;
     case "exhausted":
-      counts.exhausted += 1;
+      counts.failed += 1;
       break;
     case "canceled":
       counts.canceled += 1;

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -57,6 +57,7 @@ import type {
   ScoringKeywordAggregationResponse,
   SettingsResponse,
   Stage,
+  StageFailureReason,
   StageState,
   StageSummary,
   VoicePassAudit,
@@ -2526,6 +2527,13 @@ export function readSettingsConfig(
 
 function rowToJobSummary(row: JobListProjectionRow, db?: SqliteDatabase): JobSummary {
   const jobKey = requireCanonicalJobId(row.job_id);
+  const currentStagePresentation = publicStagePresentation(
+    row.current_state,
+    row.current_error_code,
+    row.current_error_message,
+    row.current_next_action,
+    true,
+  );
   return {
     jobKey,
     url: nullableString(row.url) ?? "",
@@ -2553,10 +2561,11 @@ function rowToJobSummary(row: JobListProjectionRow, db?: SqliteDatabase): JobSum
     scoreStaleness: parseScoreStaleness(row),
     currentStage: (isStage(row.current_stage) ? row.current_stage : "discover") as Stage,
     currentSubstage: (isStage(row.current_substage) ? row.current_substage : row.current_stage) as Stage,
-    currentState: (isStageState(row.current_state) ? row.current_state : "pending") as StageState,
-    errorCode: row.current_error_code,
-    errorMessage: row.current_error_message,
-    nextAction: row.current_next_action,
+    currentState: currentStagePresentation.state,
+    errorCode: currentStagePresentation.errorCode,
+    errorMessage: currentStagePresentation.errorMessage,
+    failureReason: currentStagePresentation.failureReason,
+    nextAction: currentStagePresentation.nextAction,
     artifactCount: Number(row.artifact_count ?? 0),
     applyStatus: row.apply_status,
     appliedAt: row.applied_at,
@@ -4500,9 +4509,18 @@ function parseStages(stagesJson: string | undefined): StageSummary[] {
     const stage = String(item.stage ?? "");
     if (!isStage(stage)) continue;
     const state = String(item.state ?? "pending");
+    const presentation = publicStagePresentation(
+      state,
+      nullableString(item.error_code),
+      nullableString(item.error_message),
+      nullableString(item.next_action),
+      item.retryable === undefined || item.retryable === null
+        ? true
+        : Boolean(item.retryable),
+    );
     byStage.set(stage, {
       stage,
-      state: isStageState(state) ? (state as StageState) : "pending",
+      state: presentation.state,
       attemptCount: Number(item.attempt_count ?? 0),
       maxAttempts:
         item.max_attempts === null || item.max_attempts === undefined
@@ -4512,11 +4530,12 @@ function parseStages(stagesJson: string | undefined): StageSummary[] {
       updatedAt: nullableString(item.updated_at),
       finishedAt: nullableString(item.finished_at),
       durationMs: nullableNumber(item.duration_ms),
-      errorCode: nullableString(item.error_code),
-      errorMessage: nullableString(item.error_message),
-      retryable: item.retryable === undefined || item.retryable === null ? true : Boolean(item.retryable),
+      errorCode: presentation.errorCode,
+      errorMessage: presentation.errorMessage,
+      failureReason: presentation.failureReason,
+      retryable: presentation.retryable,
       blockedBy: Array.isArray(item.blocked_by) ? item.blocked_by.map((it) => String(it)) : [],
-      nextAction: nullableString(item.next_action),
+      nextAction: presentation.nextAction,
       applyUrlOutcome: parseApplyUrlOutcome(item.apply_url_outcome),
     });
   }
@@ -4548,6 +4567,7 @@ function reconcileStageRetryability(
   if (retryability.size === 0) return stages;
   return stages.map((stage) => {
     if (!["failed", "exhausted"].includes(stage.state)) return stage;
+    if (stage.failureReason === "attempt_budget_exhausted") return stage;
     if (stage.stage === "enrich") return { ...stage, retryable: true };
     if (retryability.get(stage.stage) !== false) return stage;
     return { ...stage, retryable: false, nextAction: null };
@@ -4663,8 +4683,12 @@ function jobSqlFilter(query: JobListQuery): { where: string; params: SqliteValue
     params.push(query.stage);
   }
   if (query.state) {
-    clauses.push("job_list_projections.current_state = ?");
-    params.push(query.state);
+    if (query.state === "failed") {
+      clauses.push("job_list_projections.current_state IN ('failed', 'exhausted')");
+    } else {
+      clauses.push("job_list_projections.current_state = ?");
+      params.push(query.state);
+    }
   }
   if (query.applyStatus === "applied") {
     clauses.push("(job_list_projections.applied_at IS NOT NULL OR LOWER(COALESCE(job_list_projections.apply_status, '')) = 'applied')");
@@ -6120,6 +6144,40 @@ function isStageState(value: unknown): value is StageState {
     value === "canceled" ||
     value === "stale"
   );
+}
+
+function publicStagePresentation(
+  rawState: unknown,
+  errorCode: string | null,
+  errorMessage: string | null,
+  nextAction: string | null,
+  retryable: boolean,
+): {
+  state: StageState;
+  errorCode: string | null;
+  errorMessage: string | null;
+  failureReason: StageFailureReason | null;
+  nextAction: string | null;
+  retryable: boolean;
+} {
+  if (rawState === "exhausted") {
+    return {
+      state: "failed",
+      errorCode,
+      errorMessage,
+      failureReason: "attempt_budget_exhausted",
+      nextAction: "Retry to reset the attempt budget.",
+      retryable: true,
+    };
+  }
+  return {
+    state: isStageState(rawState) ? rawState : "pending",
+    errorCode,
+    errorMessage,
+    failureReason: null,
+    nextAction,
+    retryable,
+  };
 }
 
 function stringField(value: unknown): string {

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -196,13 +196,22 @@ function resetResolvedJobStage(
   if (stage === "enrich") {
     resetEnrichmentAggregate(db, LOCAL_TENANT, job.jobId);
   }
+  const current = getRow<{ state: string }>(
+    db,
+    `SELECT state
+       FROM job_stage_states
+      WHERE tenant_id = ? AND job_id = ? AND stage = ?
+      LIMIT 1`,
+    [LOCAL_TENANT, job.jobId, stage],
+  );
+  const resetAttempts = options.resetAttempts || current?.state === "exhausted";
   const stageOptions: Parameters<typeof upsertStageStateById>[5] = {
     retryable: true,
     clearTiming: true,
     clearMetadata: true,
     skipValidation: true,
   };
-  if (options.resetAttempts) {
+  if (resetAttempts) {
     stageOptions.attemptCount = 0;
   }
   upsertStageStateById(db, LOCAL_TENANT, job.jobId, stage, "pending", stageOptions);
@@ -216,7 +225,7 @@ function resetResolvedJobStage(
     eventType: "StageReset",
     level: "info",
     message: `Retry reset requested for ${stage}`,
-    payload: { reset_attempts: options.resetAttempts },
+    payload: { reset_attempts: resetAttempts },
   });
   return { jobUrl: job.jobUrl, stage: getStageStateById(db, LOCAL_TENANT, job.jobId, stage) };
 }
@@ -1695,7 +1704,7 @@ function getStageState(db: SqliteDatabase, jobUrl: string, stage: Stage): StageS
   }
   return {
     stage,
-    state: isStageState(row.state) ? row.state : "pending",
+    state: row.state === "exhausted" ? "failed" : isStageState(row.state) ? row.state : "pending",
     attemptCount: Number(row.attempt_count ?? 0),
     maxAttempts: nullableNumber(row.max_attempts) ?? DEFAULT_MAX_ATTEMPTS[stage],
     startedAt: nullableString(row.started_at),
@@ -1704,9 +1713,18 @@ function getStageState(db: SqliteDatabase, jobUrl: string, stage: Stage): StageS
     durationMs: nullableNumber(row.duration_ms),
     errorCode: nullableString(row.error_code),
     errorMessage: nullableString(row.error_message),
-    retryable: row.retryable === null || row.retryable === undefined ? true : Boolean(row.retryable),
+    failureReason: row.state === "exhausted" ? "attempt_budget_exhausted" : null,
+    retryable:
+      row.state === "exhausted"
+        ? true
+        : row.retryable === null || row.retryable === undefined
+          ? true
+          : Boolean(row.retryable),
     blockedBy: parseStringArray(nullableString(row.blocked_by_json)),
-    nextAction: nullableString(row.next_action),
+    nextAction:
+      row.state === "exhausted"
+        ? "Retry to reset the attempt budget."
+        : nullableString(row.next_action),
   };
 }
 
@@ -1741,7 +1759,8 @@ function currentFailedStage(db: SqliteDatabase, jobUrl: string): Stage | null {
         (row) =>
           STAGES.includes(row.stage) &&
           ["failed", "exhausted"].includes(row.state) &&
-          (row.stage === "enrich" ||
+          (row.state === "exhausted" ||
+            row.stage === "enrich" ||
             (row.retryable !== 0 &&
               latestStageRetryableOverride(db, jobUrl, row.stage) !== false)),
       )
@@ -1892,7 +1911,7 @@ function getStageStateById(db: SqliteDatabase, tenantId: string, jobId: string, 
   }
   return {
     stage,
-    state: isStageState(row.state) ? row.state : "pending",
+    state: row.state === "exhausted" ? "failed" : isStageState(row.state) ? row.state : "pending",
     attemptCount: Number(row.attempt_count ?? 0),
     maxAttempts: nullableNumber(row.max_attempts) ?? DEFAULT_MAX_ATTEMPTS[stage],
     startedAt: nullableString(row.started_at),
@@ -1901,9 +1920,18 @@ function getStageStateById(db: SqliteDatabase, tenantId: string, jobId: string, 
     durationMs: nullableNumber(row.duration_ms),
     errorCode: nullableString(row.error_code),
     errorMessage: nullableString(row.error_message),
-    retryable: row.retryable === null || row.retryable === undefined ? true : Boolean(row.retryable),
+    failureReason: row.state === "exhausted" ? "attempt_budget_exhausted" : null,
+    retryable:
+      row.state === "exhausted"
+        ? true
+        : row.retryable === null || row.retryable === undefined
+          ? true
+          : Boolean(row.retryable),
     blockedBy: parseStringArray(nullableString(row.blocked_by_json)),
-    nextAction: nullableString(row.next_action),
+    nextAction:
+      row.state === "exhausted"
+        ? "Retry to reset the attempt budget."
+        : nullableString(row.next_action),
   };
 }
 
@@ -1932,7 +1960,8 @@ function currentFailedStageById(db: SqliteDatabase, tenantId: string, jobId: str
         (row) =>
           STAGES.includes(row.stage) &&
           ["failed", "exhausted"].includes(row.state) &&
-          (row.stage === "enrich" ||
+          (row.state === "exhausted" ||
+            row.stage === "enrich" ||
             (row.retryable !== 0 &&
               latestStageRetryableOverrideById(db, tenantId, jobId, row.stage) !== false)),
       )

--- a/apps/api/test/pipeline-operations.test.ts
+++ b/apps/api/test/pipeline-operations.test.ts
@@ -375,6 +375,50 @@ describe("pipeline operations read model", () => {
     });
   });
 
+  it("reports a planned unscheduled source family as waiting while discovery is active", () => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "in_progress" });
+    insertStep(fixture, {
+      stepKind: "source_planning",
+      itemKey: "plan",
+      state: "succeeded",
+      detailCount: 2,
+    });
+    insertStep(fixture, {
+      stepKind: "source_family",
+      itemKey: "family:jobspy",
+      state: "running",
+    });
+
+    const active = snapshot(fixture);
+    expect(active.sourceFamilies).toMatchObject({
+      planned: 2,
+      counts: { eligible: 2, waiting: 1, processing: 1, unknown: 0 },
+    });
+    expect(stage(active, "source_family", "current_execution").currentExecution).toMatchObject({
+      eligible: 2,
+      waiting: 1,
+      processing: 1,
+      unknown: 0,
+    });
+
+    fixture.db.prepare(
+      `UPDATE pipeline_step_projections
+          SET state = 'succeeded', finished_at = ?, duration_ms = 60000
+        WHERE tenant_id = 'local'
+          AND discover_workflow_id = ?
+          AND discover_run_id = ?
+          AND step_kind = 'source_family'
+          AND item_key = 'family:jobspy'`,
+    ).run(NOW.toISOString(), DISCOVER_WORKFLOW_ID, DISCOVER_RUN_ID);
+    insertExecution(fixture, { status: "succeeded" });
+
+    expect(snapshot(fixture).sourceFamilies).toMatchObject({
+      planned: 2,
+      counts: { eligible: 2, waiting: 0, succeeded: 1, unknown: 1 },
+    });
+  });
+
   it("projects exact-run JobStreaming traversal facts without provider cursors", () => {
     const fixture = createFixture();
     insertExecution(fixture, { status: "in_progress" });

--- a/apps/api/test/pipeline-operations.test.ts
+++ b/apps/api/test/pipeline-operations.test.ts
@@ -455,7 +455,7 @@ describe("pipeline operations read model", () => {
     expect(snapshot(fixture).sourceFamilies?.providerProgress).toBeUndefined();
   });
 
-  it("uses every bucket exactly once for the current execution stage scope", () => {
+  it("folds attempt exhaustion into the public failed outcome", () => {
     const fixture = createFixture();
     insertExecution(fixture, { status: "in_progress" });
     const states = [
@@ -485,8 +485,8 @@ describe("pipeline operations read model", () => {
       succeeded: 1,
       skipped: 1,
       blocked: 1,
-      failed: 1,
-      exhausted: 1,
+      failed: 2,
+      exhausted: 0,
       canceled: 1,
       needsVerification: 1,
       stale: 1,
@@ -1337,7 +1337,7 @@ function insertReadyRecoveryCheckpoints(fixture: Fixture): void {
          decoder_version, history_event_id, expected_membership_count,
          persisted_membership_count, expected_step_count, persisted_step_count,
          key_digest, last_error_code, updated_at
-       ) VALUES ('local', ?, ?, 'ready', 'native', 2, 100, ?, ?, ?, ?, ?, NULL, ?)`,
+       ) VALUES ('local', ?, ?, 'ready', 'native', 3, 100, ?, ?, ?, ?, ?, NULL, ?)`,
     ).run(
       execution.workflow_id,
       execution.temporal_run_id,
@@ -1375,7 +1375,7 @@ function insertRecoveryCheckpoint(
     DISCOVER_WORKFLOW_ID,
     DISCOVER_RUN_ID,
     input.state,
-    input.decoderVersion ?? 2,
+    input.decoderVersion ?? 3,
     input.expectedMembershipCount,
     input.persistedMembershipCount,
     input.expectedStepCount,

--- a/apps/api/test/qa-seed.ts
+++ b/apps/api/test/qa-seed.ts
@@ -1117,7 +1117,7 @@ function seedPipelineOperations(db: Database.Database, dbPath: string): void {
       decoder_version, history_event_id, expected_membership_count,
       persisted_membership_count, expected_step_count, persisted_step_count,
       key_digest, last_error_code, updated_at
-    ) VALUES ('local', ?, ?, 'ready', 'native', 2, 107, ?, ?, ?, ?, ?, NULL, ?)`,
+    ) VALUES ('local', ?, ?, 'ready', 'native', 3, 107, ?, ?, ?, ?, ?, NULL, ?)`,
   ).run(
     discoverWorkflowId,
     discoverRunId,

--- a/apps/api/test/read-model-v7.test.ts
+++ b/apps/api/test/read-model-v7.test.ts
@@ -216,6 +216,47 @@ describe("exact-v7 read model job ids", () => {
     expect(schemaManifest(db, EXACT_V8_SCHEMA_MANIFEST.version)).toEqual(before);
   });
 
+  it("projects attempt exhaustion as a retryable failure reason", () => {
+    const db = seededDatabase();
+    db.prepare(
+      `INSERT INTO job_stage_states (
+         tenant_id, job_id, stage, state, attempt_count, max_attempts,
+         updated_at, finished_at, retryable, version
+       ) VALUES ('local', ?, ?, 'succeeded', 1, 3, ?, ?, 0, 1)`,
+    ).run(JOB_ID, "discover", NOW, NOW);
+    db.prepare(
+      `INSERT INTO job_stage_states (
+         tenant_id, job_id, stage, state, attempt_count, max_attempts,
+         updated_at, finished_at, retryable, version
+       ) VALUES ('local', ?, ?, 'succeeded', 1, 3, ?, ?, 0, 1)`,
+    ).run(JOB_ID, "enrich", NOW, NOW);
+    db.prepare(
+      `UPDATE job_stage_states
+          SET state = 'exhausted', attempt_count = 3, max_attempts = 3,
+              retryable = 0, error_code = 'TAILOR_QUALITY_GATE',
+              error_message = 'No acceptable candidate', next_action = NULL
+        WHERE tenant_id = 'local' AND job_id = ? AND stage = 'score'`,
+    ).run(JOB_ID);
+
+    const jobs = listJobs(db, activeJobQuery);
+    const failedJobs = listJobs(db, { ...activeJobQuery, state: "failed" });
+    const score = getJobDetail(db, JOB_ID)?.stages.find((stage) => stage.stage === "score");
+
+    expect(jobs.items[0]).toMatchObject({
+      currentState: "failed",
+      errorCode: "TAILOR_QUALITY_GATE",
+      errorMessage: "No acceptable candidate",
+      failureReason: "attempt_budget_exhausted",
+      nextAction: "Retry to reset the attempt budget.",
+    });
+    expect(failedJobs.items.map((job) => job.jobKey)).toContain(JOB_ID);
+    expect(score).toMatchObject({
+      state: "failed",
+      retryable: true,
+      failureReason: "attempt_budget_exhausted",
+    });
+  });
+
   it("filters hidden and deleted jobs and uses only tenant-scoped events and audit rows", () => {
     const db = seededDatabase();
 

--- a/apps/api/test/write-model-state.test.ts
+++ b/apps/api/test/write-model-state.test.ts
@@ -114,6 +114,48 @@ describe("exact-v7 write-model stage state", () => {
     expect(row).toEqual({ state: "pending", metadata_json: null });
   });
 
+  it("makes an exhausted stage retryable by resetting its attempt budget", () => {
+    const fixture = createFixture();
+    fixture.db.prepare(
+      `INSERT INTO jobs (tenant_id, job_id, url, title, discovered_at)
+       VALUES ('local', ?, ?, 'Platform Engineer', ?)`,
+    ).run(JOB_ID, JOB_URL, "2026-07-31T09:00:00.000Z");
+    fixture.db.prepare(
+      `INSERT INTO job_stage_states (
+         tenant_id, job_id, stage, state, attempt_count, max_attempts,
+         updated_at, retryable, error_code, error_message
+       ) VALUES ('local', ?, 'tailor', 'exhausted', 3, 3, ?, 0,
+                 'TAILOR_QUALITY_GATE', 'No acceptable candidate')`,
+    ).run(JOB_ID, "2026-07-31T09:00:00.000Z");
+
+    const retried = retryFailedJobs(fixture.db, {
+      allMatching: false,
+      jobKeys: [JOB_ID],
+    });
+    const row = fixture.db.prepare(
+      `SELECT state, attempt_count, retryable, error_code, error_message
+         FROM job_stage_states
+        WHERE tenant_id = 'local' AND job_id = ? AND stage = 'tailor'`,
+    ).get(JOB_ID);
+    const event = fixture.db.prepare(
+      `SELECT payload_json FROM job_events
+        WHERE tenant_id = 'local' AND job_id = ? AND event_type = 'StageReset'`,
+    ).get(JOB_ID) as { payload_json: string };
+
+    expect(retried).toMatchObject({
+      count: 1,
+      targets: [{ jobUrl: JOB_URL, stage: "tailor" }],
+    });
+    expect(row).toMatchObject({
+      state: "pending",
+      attempt_count: 0,
+      retryable: 1,
+      error_code: null,
+      error_message: null,
+    });
+    expect(JSON.parse(event.payload_json)).toMatchObject({ reset_attempts: true });
+  });
+
   it("resets and queues failed stages by tenant and JobId while retaining URL responses", () => {
     const fixture = createFixture();
     fixture.db.prepare(

--- a/apps/web/src/contexts/pipeline/components/StageBadge.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageBadge.test.tsx
@@ -35,6 +35,16 @@ describe("<StageBadge>", () => {
     );
   });
 
+  it("renders the persisted exhausted marker as a public failed state", () => {
+    render(<StageBadge state="exhausted" />);
+
+    expect(screen.queryByText("exhausted")).not.toBeInTheDocument();
+    expect(screen.getByText("failed")).toHaveAttribute(
+      "data-status-tone",
+      "danger",
+    );
+  });
+
   it.each([
     ["pending", "clock"],
     ["queued", "clock"],

--- a/apps/web/src/contexts/pipeline/components/StageBadge.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageBadge.tsx
@@ -19,10 +19,11 @@ export function StageBadge(props: StageBadgeProps): JSX.Element {
       </Badge>
     );
   }
-  const tone: StageStateTone = stageStateTone(props.state);
+  const publicState = props.state === "exhausted" ? "failed" : props.state;
+  const tone: StageStateTone = stageStateTone(publicState);
   return (
-    <StatusBadge icon={stageStateIcon(props.state)} tone={tone}>
-      {props.state}
+    <StatusBadge icon={stageStateIcon(publicState)} tone={tone}>
+      {publicState}
     </StatusBadge>
   );
 }

--- a/apps/web/src/contexts/pipeline/components/StageTimeline.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTimeline.tsx
@@ -268,6 +268,9 @@ function stageLabel(stage: StageSummary["stage"]): string {
 function stageDiagnostics(stage: StageSummary): Array<[string, string]> {
   const diagnostics: Array<[string, string]> = [];
   if (["failed", "exhausted", "blocked", "skipped"].includes(stage.state)) {
+    if (stage.failureReason === "attempt_budget_exhausted") {
+      diagnostics.push(["failure reason", "attempt budget exhausted"]);
+    }
     if (stage.errorCode) diagnostics.push(["code", stage.errorCode]);
     if (stage.errorMessage) diagnostics.push(["message", stage.errorMessage]);
     if (stage.state !== "skipped" && (stage.attemptCount || stage.maxAttempts)) {

--- a/apps/web/src/contexts/pipeline/components/every-stage-state-has-badge.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/every-stage-state-has-badge.test.tsx
@@ -35,7 +35,7 @@ describe("stage-state parity (the second-most important test in the app)", () =>
     it(`<StageBadge state> renders a non-default tone for kind=${kind}`, () => {
       const state = serializedFor(kind) as StageState;
       render(<StageBadge state={state} />);
-      const badge = screen.getByText(state);
+      const badge = screen.getByText(kind === "Exhausted" ? "failed" : state);
       expect(badge).toHaveAttribute("data-slot", "status-badge");
       expect(badge.getAttribute("data-status-tone")).toMatch(TONE_PATTERN);
     });

--- a/apps/web/src/views/jobs/JobsView.tsx
+++ b/apps/web/src/views/jobs/JobsView.tsx
@@ -7,7 +7,7 @@ import {
   type JobSortField,
   type JobSummary,
   type SavedTableView,
-  STAGE_STATES,
+  USER_FACING_STAGE_STATES,
 } from "@jobctrl/contracts";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import type { UseMutationResult } from "@tanstack/react-query";
@@ -424,7 +424,7 @@ export function JobsView() {
       const nextStage =
         firstAllowedValue(next.current_stage, JOB_TABLE_STAGE_FILTERS) ?? "all";
       const nextState =
-        firstAllowedValue(next.current_state, STAGE_STATES) ?? "all";
+        firstAllowedValue(next.current_state, USER_FACING_STAGE_STATES) ?? "all";
       const applyFilter = firstAllowedValue(next.apply_status, [
         "applied",
       ] as const);

--- a/apps/web/src/views/jobs/columns.tsx
+++ b/apps/web/src/views/jobs/columns.tsx
@@ -1,6 +1,6 @@
 import { type MouseEvent, useRef } from "react";
 import type { RowSelectionState } from "@tanstack/react-table";
-import { STAGE_STATES } from "@jobctrl/contracts";
+import { USER_FACING_STAGE_STATES } from "@jobctrl/contracts";
 
 import { ApplyRunBadge } from "../../contexts/apply/components/ApplyRunBadge.js";
 import { isApplyRunStatus } from "../../contexts/apply/lib/apply-run-status.js";
@@ -819,12 +819,17 @@ export function jobColumns(
       getFilterValue: (row) => row.currentState,
       getFilterSearchValue: (row) =>
         `${row.currentSubstage} ${row.currentState}`,
-      filterValues: STAGE_STATES,
+      filterValues: USER_FACING_STAGE_STATES,
       render: (row) => (
         <TitleStack
           primary={<StageBadge state={row.currentState} />}
           secondary={
-            <span data-typography="metadata">{row.currentSubstage} stage</span>
+            <span data-typography="metadata">
+              {row.currentSubstage} stage
+              {row.failureReason === "attempt_budget_exhausted"
+                ? " · attempt budget exhausted"
+                : ""}
+            </span>
           }
         />
       ),

--- a/apps/web/src/views/pipelines/PipelinesView.test.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.test.tsx
@@ -222,7 +222,7 @@ describe("PipelinesView", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps terminal outcomes honest and exposes every exact stage-state count", async () => {
+  it("keeps terminal outcomes honest and exposes every public stage-state count", async () => {
     const user = userEvent.setup();
     await renderPipelineOperations(pipelinesMixedFailureSnapshot);
 
@@ -243,11 +243,57 @@ describe("PipelinesView", () => {
     expect(outcomes).toHaveTextContent("Skipped0");
     expect(outcomes).toHaveTextContent("Blocked1");
     expect(outcomes).toHaveTextContent("Failed1");
-    expect(outcomes).toHaveTextContent("Exhausted0");
+    expect(outcomes).not.toHaveTextContent("Exhausted");
     expect(outcomes).toHaveTextContent("Canceled1");
     expect(outcomes).toHaveTextContent("Needs verification1");
     expect(outcomes).toHaveTextContent("Stale0");
     expect(outcomes).toHaveTextContent("Unknown0");
+  });
+
+  it("renders a closed timed-out crawl as a terminal failure instead of active work", async () => {
+    const user = userEvent.setup();
+    const closedTimeoutSnapshot: PipelineOperationsSnapshot = {
+      ...pipelinesCompletedWithIssuesSnapshot,
+      sourceFamilies: {
+        ...pipelinesCompletedWithIssuesSnapshot.sourceFamilies!,
+        counts: {
+          ...pipelinesCompletedWithIssuesSnapshot.sourceFamilies!.counts,
+          failed: 1,
+          exhausted: 0,
+        },
+      },
+      stages: pipelinesCompletedWithIssuesSnapshot.stages.map((entry) =>
+        entry.stage === "source_family" && entry.scope === "current_execution"
+          ? {
+              ...entry,
+              currentExecution: {
+                ...entry.currentExecution,
+                eligible: 2,
+                waiting: 0,
+                processing: 0,
+                succeeded: 1,
+                failed: 1,
+              },
+            }
+          : entry,
+      ),
+    };
+    await renderPipelineOperations(closedTimeoutSnapshot);
+
+    const crawl = screen.getByRole("region", { name: "Crawl sources stage" });
+    expect(crawl).toHaveAttribute("data-stage-status", "blocked");
+    expect(within(crawl).getByText("Attention required")).toBeInTheDocument();
+    expect(within(crawl).queryByText("In progress")).not.toBeInTheDocument();
+    expect(crawl).not.toHaveTextContent("50% terminal");
+
+    await user.click(within(crawl).getByRole("button", { name: /Crawl sources/i }));
+    expect(within(crawl).getByRole("progressbar", { name: "Stage progress" })).toHaveAttribute(
+      "aria-valuenow",
+      "100",
+    );
+    expect(crawl).toHaveTextContent("100% terminal");
+    expect(crawl).toHaveTextContent("Failed1");
+    expect(crawl).not.toHaveTextContent("Exhausted");
   });
 
   it("prioritizes four status facts and moves snapshot provenance to the inspector", async () => {

--- a/apps/web/src/views/pipelines/PipelinesView.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.tsx
@@ -74,7 +74,6 @@ const COUNT_FIELDS = [
   ["skipped", "Skipped"],
   ["blocked", "Blocked"],
   ["failed", "Failed"],
-  ["exhausted", "Exhausted"],
   ["canceled", "Canceled"],
   ["needsVerification", "Needs verification"],
   ["stale", "Stale"],

--- a/docs/api/complete-contract.md
+++ b/docs/api/complete-contract.md
@@ -269,8 +269,11 @@ available at `POST /v1/jobs/bulk-delete-permanent` and
 projection rows, and delete/hide tombstones. It does not write a new suppression
 record, so rediscovery can add the same posting again later.
 `POST /v1/jobs/bulk-retry-failed` accepts the same selected-job or
-all-matching bulk mutation body and resets each active failed or exhausted job's
-failed stage to `pending`; non-failed selected jobs are ignored.
+all-matching bulk mutation body and resets each active failed job's failed stage
+to `pending`; non-failed selected jobs are ignored. A persisted legacy
+`exhausted` row is exposed as `state: "failed"` with
+`failureReason: "attempt_budget_exhausted"`, remains retryable, and has its
+attempt count reset atomically by this action.
 
 ## Feedback learning and policy history
 
@@ -428,10 +431,18 @@ attempt without a separate legacy queue event retains its exact attempt and
 start/completion facts with an unknown queue timestamp. A terminal failed
 fanout preserves its exact partial dispatch set as `incomplete`.
 
+Decoder v3 additionally reconciles native activity lifecycle from the exact
+Temporal history. When a workflow is terminal but an activity process stopped
+before its final durable event was recorded, the decoder appends the proven
+failed or completed terminal event and refreshes the projection. It never
+promotes a queued or running event to terminal from workflow status alone.
+
 The canonical stage-count object contains non-negative integers for
 `eligible`, `waiting`, `processing`, `succeeded`, `skipped`, `blocked`,
-`failed`, `exhausted`, `canceled`, `needsVerification`, `stale`, and
-`unknown`. `existingBacklog` is either `{ kind: "domain_jobs", counts }` or
+`failed`, `canceled`, `needsVerification`, `stale`, and `unknown`. The
+`exhausted` numeric member remains in the wire shape for compatibility but is
+always zero; persisted exhausted-attempt rows contribute to `failed`.
+`existingBacklog` is either `{ kind: "domain_jobs", counts }` or
 `{ kind: "not_separate", reason }`; it is never an unlabeled zero.
 
 `stages[]` uses the fixed operational order `source_planning`, `source_family`,
@@ -447,8 +458,8 @@ has one of three scopes:
   cohorts. Orchestration and PDF work are not synthesized as global queues.
 
 Stage counts distinguish `eligible`, `waiting`, `processing`, `succeeded`,
-`skipped`, `blocked`, `failed`, `exhausted`, `canceled`,
-`needsVerification`, `stale`, and `unknown`. Job-stage counts come from
+`skipped`, `blocked`, `failed`, `canceled`, `needsVerification`, `stale`, and
+`unknown`. Job-stage counts come from
 `job_stage_states`; orchestration and PDF counts come from attempt-aware
 `pipeline_step_projections` keyed by the exact execution identity. The
 execution phase is one of `discovering`, `draining`, `completed`,
@@ -1229,7 +1240,9 @@ Current-version preparation maintenance actions are separate endpoints:
   local-only reset and does not require a worker.
 - `POST /v1/jobs/bulk-retry-failed` accepts selected jobs or all matching jobs.
   With the default `runAfter: false` it only resets each retryable failed stage
-  to `pending`. With `runAfter: true`, the API groups reset preparation stages
+  to `pending`. Attempt-budget failures are included even when their legacy
+  stored marker is non-retryable; the same transaction resets the attempt count
+  to zero. With `runAfter: true`, the API groups reset preparation stages
   (`enrich`, `score`, `tailor`, `cover`) and dispatches bounded batch
   `run_stage` workflows with the selected job URLs and requested worker count.
   The route records pipeline workflow metadata plus per-job `StageQueued`

--- a/docs/architecture/domain-model/tactical.md
+++ b/docs/architecture/domain-model/tactical.md
@@ -440,6 +440,12 @@ for human resolution rather than risking a duplicate employer submission (see
 the 2026-07-03 "At-Most-Once Apply" decision in `docs/decisions.md`). The domain
 model carries eleven stage-state variants in total.
 
+`Exhausted` is retained only as a persistence and event compatibility variant.
+Read models project it as `Failed` with
+`failureReason = attempt_budget_exhausted`, and an explicit retry resets the
+attempt count before returning the stage to `Pending`. It is not a distinct
+user-facing lifecycle state.
+
 - `RetryPolicy { maxAttempts: int, backoffMs?: int }`
 
 **Domain Events** (all events carry `tenantId`):

--- a/docs/architecture/pipeline/operations.md
+++ b/docs/architecture/pipeline/operations.md
@@ -274,6 +274,10 @@ normal operations-projection watermark/rebuild path.
 
 A current-execution membership with `work_plan_state='pending'` and no enrich
 stage row is an expected pre-dispatch state and is projected as **waiting**.
+Likewise, while the Discover workflow is starting or in progress, a planned
+source family whose bounded batch has not been scheduled yet is **waiting**.
+Once that workflow is terminal, a planned family with no durable lifecycle is
+**unknown** because it is then a genuine projection gap.
 Missing stage state after work-plan resolution remains **unknown** and therefore
 actionable; the read model does not hide a genuine projection gap.
 The producer-lifetime live enrichment activity is runtime telemetry, not a

--- a/docs/architecture/pipeline/operations.md
+++ b/docs/architecture/pipeline/operations.md
@@ -315,7 +315,11 @@ restore execution membership and work plans. Existing partial rows are merged
 idempotently, so a process kill during repair resumes without duplicate events
 or jobs. Native activities retain ownership of their normal events; mixed
 legacy/native histories merge the two key sets without replaying native work.
-Ambiguous provenance is refused rather than guessed.
+Decoder v3 also reads the exact native activity attempt that Temporal proves
+terminal. If the activity process stopped before recording its final durable
+event, reconciliation appends that missing terminal event and refreshes the
+projection. A terminal workflow therefore cannot leave one of its native steps
+queued or running. Ambiguous provenance is refused rather than guessed.
 
 Reconstructed decoder v2 does not treat `workflow_run_projections` as causal
 evidence because repeated generic workflow-start events can legitimately fold a

--- a/docs/architecture/tailoring.md
+++ b/docs/architecture/tailoring.md
@@ -726,8 +726,9 @@ once per durable Tailor execution, not once per candidate-repair call; inner
 attempts remain in an append-only generation audit keyed by workflow execution,
 durable attempt, and recorded time, so a later retry or a rerun of the same
 durable attempt cannot overwrite earlier prompts, candidates, validation, or
-judge evidence. A fifth failed durable execution is
-stored as non-retryable `exhausted` until an explicit attempt reset.
+judge evidence. A fifth failed durable execution retains the compatibility
+`exhausted` marker until an explicit attempt reset; product read models expose
+it as a retryable failure with `attempt_budget_exhausted` as the reason.
 
 Tailoring does not silently discard a missing, cross-job, or stale-generation
 requirement-fit report. That condition blocks Tailor on Score before candidate

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -186,6 +186,10 @@ For pipeline operations, seed a closed Temporal workflow whose final native
 activity timed out after recording only queued/running durable events. Startup
 reconciliation must append the exact terminal failure, make the stage 100%
 terminal, and ensure Pipelines never renders it as active or **In progress**.
+Also seed an active two-family source plan with one family running and only one
+durable family row. Pipelines must report one processing and one waiting family,
+with zero unknown. After terminalizing that workflow without recording the
+second family lifecycle, the missing family must become unknown.
 For a current score below the live materials threshold, preparation must persist
 Tailor, Cover, and Apply as non-retryable `skipped` rows with `MIN_SCORE` and the
 exact score/threshold pair. No row may remain `pending` after the workflow has

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -169,9 +169,11 @@ generation must be recorded and fenced, and the next activity must run on fresh
 bounded executor capacity without restarting the worker.
 Repeated Tailor validation/model-repair failures must also keep the inner LLM
 attempt count separate from the durable stage execution count. Each activity
-execution advances the durable count once; the fifth durable failure becomes
-non-retryable `exhausted`, and a later pickup cannot restart it without an
-explicit attempt reset. Run at least two durable failures against the same
+execution advances the durable count once; the fifth durable failure retains
+the non-retryable `exhausted` persistence marker, but product read models must
+show a retryable failed state with reason `attempt_budget_exhausted`. A later
+pickup cannot restart it without an explicit attempt reset. Verify that Retry
+atomically resets the attempt count to zero. Run at least two durable failures against the same
 materials generation and assert that both complete inner-attempt reports remain
 in the append-only audit history.
 When Tailor fails or reaches that exhausted boundary, assert that unstarted
@@ -180,6 +182,10 @@ Cover and Apply rows become non-retryable `blocked` dependencies with the exact
 next action. Repeat reconciliation to prove idempotence, interleave a dependent
 claim immediately before the guarded update to prove ownership preservation,
 and then complete Tailor to prove only the Tailor-owned blocks reset.
+For pipeline operations, seed a closed Temporal workflow whose final native
+activity timed out after recording only queued/running durable events. Startup
+reconciliation must append the exact terminal failure, make the stage 100%
+terminal, and ensure Pipelines never renders it as active or **In progress**.
 For a current score below the live materials threshold, preparation must persist
 Tailor, Cover, and Apply as non-retryable `skipped` rows with `MIN_SCORE` and the
 exact score/threshold pair. No row may remain `pending` after the workflow has

--- a/docs/user/normal-flows.md
+++ b/docs/user/normal-flows.md
@@ -176,8 +176,11 @@ Keep Pipelines open while the run works. Read its scopes separately:
 The source-family plan reports intake separately from the two reconciliation
 steps: the enrichment pass and preparation fanout. The live stage cards make
 waiting, processing, terminal, and attention totals visible first; **All stage
-outcomes** expands the exact succeeded, skipped, blocked, failed, exhausted,
-canceled, needs-verification, stale, and unknown counts. **Backlog and
+outcomes** expands the exact succeeded, skipped, blocked, failed, canceled,
+needs-verification, stale, and unknown counts. An attempt budget that has run
+out is a failed outcome with **attempt budget exhausted** as its reason, not a
+separate lifecycle state. Retrying that failure resets its attempt budget.
+**Backlog and
 diagnostics** keeps the execution sweep and unrelated global backlog separate
 from that current-execution flow. Capacity details include configured and active
 slots, internal parallelism when applicable, and approximate task-queue pollers,
@@ -232,7 +235,10 @@ states that the runtime inventory is unavailable; it never turns missing
 inventory into "no work." If the exact history cannot be read or mapped safely
 on one pass, the repair remains in automatic retry instead of becoming a
 permanent tracking mode. Reconnecting to its authoritative history restores that
-run or records its real terminal outcome. If immutable legacy history ended
+run or records its real terminal outcome. The same repair closes native activity
+rows when exact Temporal history proves that a closed workflow timed out or
+failed after its worker stopped reporting, so a closed run cannot remain shown
+as processing. If immutable legacy history ended
 before recording every target, the run is labeled **Historical run incomplete**;
 JobCtrl preserves all exact recovered evidence and does not fabricate or
 continuously retry the unknown remainder. **Set up a new Discover run** is

--- a/docs/user/normal-flows.md
+++ b/docs/user/normal-flows.md
@@ -180,6 +180,10 @@ outcomes** expands the exact succeeded, skipped, blocked, failed, canceled,
 needs-verification, stale, and unknown counts. An attempt budget that has run
 out is a failed outcome with **attempt budget exhausted** as its reason, not a
 separate lifecycle state. Retrying that failure resets its attempt budget.
+During an active source crawl, planned source families that have not entered
+their bounded execution batch appear as **waiting**, not unknown. Unknown is
+reserved for a planned family whose lifecycle is still missing after the
+Discover workflow has ended.
 **Backlog and
 diagnostics** keeps the execution sweep and unrelated global backlog separate
 from that current-execution flow. Capacity details include configured and active

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -28,6 +28,20 @@ export const STAGE_STATES = [
   "stale",
 ] as const;
 export type StageState = (typeof STAGE_STATES)[number];
+export const USER_FACING_STAGE_STATES = [
+  "pending",
+  "queued",
+  "running",
+  "succeeded",
+  "failed",
+  "blocked",
+  "skipped",
+  "needs_verification",
+  "canceled",
+  "stale",
+] as const satisfies readonly StageState[];
+export const STAGE_FAILURE_REASONS = ["attempt_budget_exhausted"] as const;
+export type StageFailureReason = (typeof STAGE_FAILURE_REASONS)[number];
 export const ACTIVE_STATES = [
   "unknown",
   "active",
@@ -2506,6 +2520,7 @@ export interface StageSummary {
   durationMs: number | null;
   errorCode: string | null;
   errorMessage: string | null;
+  failureReason?: StageFailureReason | null;
   retryable: boolean;
   blockedBy: string[];
   nextAction: string | null;
@@ -2905,6 +2920,7 @@ export interface JobSummary {
   currentState: StageState;
   errorCode: string | null;
   errorMessage: string | null;
+  failureReason?: StageFailureReason | null;
   nextAction: string | null;
   artifactCount: number;
   applyStatus: string | null;

--- a/workers/automation/src/jobctrl/discovery/execution_reconciliation.py
+++ b/workers/automation/src/jobctrl/discovery/execution_reconciliation.py
@@ -2,9 +2,9 @@
 
 This module is deliberately a write-side repair controller.  It reads one exact
 Temporal workflow/run history and append-only discovery evidence; it never uses
-global worker telemetry to attribute work to an execution.  Activities that
-already carry ``discovery_execution`` are ignored because their normal activity
-lifecycle owns those rows and events.
+global worker telemetry to attribute work to an execution. Native activities
+normally own their durable lifecycle, while reconciliation closes a lifecycle
+that Temporal proves terminal after the activity process stopped reporting.
 """
 
 from __future__ import annotations
@@ -52,7 +52,7 @@ _DISCOVERY_ACTIVITY_TYPES = frozenset(
     }
 )
 _STEP_ORDER = ("score", "tailor", "cover", "pdf")
-_DECODER_VERSION = 2
+_DECODER_VERSION = 3
 _LEGACY_WORK_PLAN_REASON_CODE = "legacy_history_recovery"
 _HISTORY_READ_ERROR_CODE = "temporal-history-read-failed"
 
@@ -119,6 +119,16 @@ def decode_legacy_discovery_history_v1(
     leaving ``queued_at`` absent rather than inventing a retry queue time.
     """
 
+    return _decode_discovery_activity_attempts(records, native=False)
+
+
+def _decode_discovery_activity_attempts(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    native: bool,
+) -> tuple[list[LegacyActivityAttempt], int]:
+    """Decode exact activity attempts for one lineage authority."""
+
     scheduled: dict[int, Mapping[str, Any]] = {}
     started: dict[int, list[tuple[int, Mapping[str, Any]]]] = defaultdict(list)
     terminal: dict[int, list[tuple[int, Mapping[str, Any]]]] = defaultdict(list)
@@ -138,13 +148,14 @@ def decode_legacy_discovery_history_v1(
         if activity_type not in _DISCOVERY_ACTIVITY_TYPES:
             continue
         payload = _mapping(scheduled_record.get("payload"))
-        if _first(payload, "discovery_execution", "discoveryExecution") is not None:
+        has_native_lineage = _first(payload, "discovery_execution", "discoveryExecution") is not None
+        if not native and has_native_lineage:
             skipped_native += 1
             continue
+        if native != has_native_lineage:
+            continue
         started_entry = started.get(scheduled_event_id, [])[-1:]
-        started_position, started_record = (
-            started_entry[0] if started_entry else (-1, None)
-        )
+        started_position, started_record = started_entry[0] if started_entry else (-1, None)
         terminal_record = _terminal_record_for_started(
             started_position,
             started_record,
@@ -160,11 +171,7 @@ def decode_legacy_discovery_history_v1(
                 activity_type=activity_type,
                 payload=payload,
                 result=_mapping(terminal_record.get("result")) if terminal_record else {},
-                queued_at=(
-                    str(scheduled_record.get("event_time") or "")
-                    if attempt == 1
-                    else None
-                ),
+                queued_at=(str(scheduled_record.get("event_time") or "") if attempt == 1 else None),
                 started_at=(str(started_record.get("event_time") or "") if started_record else None),
                 finished_at=(str(terminal_record.get("event_time") or "") if terminal_record else None),
                 attempt=attempt,
@@ -196,9 +203,7 @@ def _terminal_record_for_started(
     started_event_id = _safe_int(started_record.get("history_event_id"))
     candidates: list[Mapping[str, Any]] = []
     for terminal_position, terminal_record in terminals:
-        terminal_started_event_id = _safe_int(
-            terminal_record.get("started_event_id")
-        )
+        terminal_started_event_id = _safe_int(terminal_record.get("started_event_id"))
         if terminal_started_event_id:
             if started_event_id and terminal_started_event_id == started_event_id:
                 candidates.append(terminal_record)
@@ -288,19 +293,35 @@ def _native_step_keys_v1(
 ) -> set[tuple[str, str]]:
     """Derive the exact step identities claimed by native activity inputs."""
 
+    return {
+        (step.step_kind, step.item_key)
+        for step in _native_steps_v3(
+            records,
+            tenant_id=tenant_id,
+            workflow_id=workflow_id,
+            temporal_run_id=temporal_run_id,
+        )
+    }
+
+
+def _native_steps_v3(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    tenant_id: str,
+    workflow_id: str,
+    temporal_run_id: str,
+) -> list[LegacyStep]:
+    """Recover native lifecycle from Temporal without inventing ownership."""
+
     enrichment_pass = 0
     fanout_pass = 0
-    keys: set[tuple[str, str]] = set()
-    for record in records:
-        if record.get("kind") != "scheduled":
-            continue
-        activity_type = str(record.get("activity_type") or "")
-        if activity_type not in _DISCOVERY_ACTIVITY_TYPES:
-            continue
-        payload = _mapping(record.get("payload"))
+    steps: list[LegacyStep] = []
+    attempts, _ = _decode_discovery_activity_attempts(records, native=True)
+    for activity in attempts:
+        activity_type = activity.activity_type
+        payload = activity.payload
+        output = activity.result
         execution = _mapping(_first(payload, "discovery_execution", "discoveryExecution"))
-        if not execution:
-            continue
         if (
             str(_first(execution, "tenant_id", "tenantId") or "") != tenant_id
             or str(_first(execution, "workflow_id", "workflowId") or "") != workflow_id
@@ -308,12 +329,18 @@ def _native_step_keys_v1(
         ):
             raise LegacyDiscoveryRecoveryError("native_execution_reference_mismatch")
         if activity_type == "plan_discovery_sources":
-            keys.add(("source_planning", "plan"))
+            step_kind: PipelineStepKind = "source_planning"
+            item_key = "plan"
+            detail_code: PipelineStepDetailCode = "source_plan"
+            item_count = len(_string_list(_first(output, "families")))
         elif activity_type == "discovery_source_family":
             family = str(_first(payload, "family") or "").strip().lower()
             if not family:
                 raise LegacyDiscoveryRecoveryError("source_family_missing")
-            keys.add(("source_family", f"family:{family}"))
+            step_kind = "source_family"
+            item_key = f"family:{family}"
+            detail_code = "source_family"
+            item_count = 1
         elif activity_type == "discovery_enrichment":
             # The producer-lifetime consumer is runtime telemetry only. It ends
             # through intentional cancellation and deliberately emits no
@@ -327,6 +354,7 @@ def _native_step_keys_v1(
                 )
             ):
                 continue
+            step_kind = "enrichment_pass"
             item_key = str(_first(payload, "pipeline_step_item_key", "pipelineStepItemKey") or "")
             if not item_key:
                 if _safe_int(_first(payload, "progress_total", "progressTotal")) == 0:
@@ -334,16 +362,34 @@ def _native_step_keys_v1(
                     item_key = f"streaming:pass-{enrichment_pass}"
                 else:
                     item_key = "terminal"
-            keys.add(("enrichment_pass", item_key))
+            detail_code_value = str(
+                _first(
+                    payload,
+                    "pipeline_step_detail_code",
+                    "pipelineStepDetailCode",
+                )
+                or ""
+            )
+            detail_code = (
+                detail_code_value
+                if detail_code_value
+                else "streaming_pass"
+                if item_key.startswith("streaming:")
+                else "terminal_reconciliation"
+            )
+            item_count = _safe_int(_first(output, "passes"))
         else:
-            step_kind = str(_first(payload, "pipeline_step_kind", "pipelineStepKind") or "")
+            step_kind_value = str(_first(payload, "pipeline_step_kind", "pipelineStepKind") or "")
+            step_kind = (
+                step_kind_value
+                if step_kind_value
+                else "existing_backlog_sweep"
+                if str(_first(payload, "cohort_kind", "cohortKind") or "") == "existing_backlog"
+                else "preparation_fanout"
+            )
             item_key = str(_first(payload, "pipeline_step_item_key", "pipelineStepItemKey") or "")
             if not step_kind:
-                step_kind = (
-                    "existing_backlog_sweep"
-                    if str(_first(payload, "cohort_kind", "cohortKind") or "") == "existing_backlog"
-                    else "preparation_fanout"
-                )
+                raise LegacyDiscoveryRecoveryError("native_step_kind_missing")
             if not item_key:
                 if step_kind == "existing_backlog_sweep":
                     item_key = "existing_backlog"
@@ -352,8 +398,41 @@ def _native_step_keys_v1(
                     item_key = f"streaming:pass-{fanout_pass}"
                 else:
                     item_key = "terminal"
-            keys.add((step_kind, item_key))
-    return keys
+            detail_code_value = str(
+                _first(
+                    payload,
+                    "pipeline_step_detail_code",
+                    "pipelineStepDetailCode",
+                )
+                or ""
+            )
+            detail_code = (
+                detail_code_value
+                if detail_code_value
+                else "existing_backlog"
+                if step_kind == "existing_backlog_sweep"
+                else "streaming_pass"
+                if item_key.startswith("streaming:")
+                else "terminal_reconciliation"
+            )
+            item_count = _safe_int(_first(output, "targets"))
+        steps.append(
+            LegacyStep(
+                scheduled_event_id=activity.scheduled_event_id,
+                step_kind=step_kind,
+                item_key=item_key,
+                detail_code=detail_code,
+                item_count=item_count,
+                queued_at=activity.queued_at,
+                started_at=activity.started_at,
+                finished_at=activity.finished_at,
+                attempt=activity.attempt,
+                state=activity.state,
+                error_code=activity.error_code,
+                retryable=activity.retryable,
+            )
+        )
+    return steps
 
 
 async def reconcile_legacy_discovery_execution(
@@ -383,14 +462,11 @@ async def reconcile_legacy_discovery_execution(
         """,
         (tenant_id, workflow_id, temporal_run_id),
     ).fetchone()
-    current_manifest_was_verified = (
-        current_manifest is not None
-        and _recovery_manifest_matches_persisted_keys(
-            connection,
-            tenant_id=tenant_id,
-            workflow_id=workflow_id,
-            temporal_run_id=temporal_run_id,
-        )
+    current_manifest_was_verified = current_manifest is not None and _recovery_manifest_matches_persisted_keys(
+        connection,
+        tenant_id=tenant_id,
+        workflow_id=workflow_id,
+        temporal_run_id=temporal_run_id,
     )
     _transition_existing_recovery_manifest(
         connection,
@@ -469,15 +545,19 @@ async def reconcile_legacy_discovery_execution(
             for attempt in attempts
         )
         legacy_recovery_pending = any(
-            attempt.state in {"queued", "running"}
-            or (attempt.state == "failed" and attempt.retryable)
+            attempt.state in {"queued", "running"} or (attempt.state == "failed" and attempt.retryable)
             for attempt in attempts
         )
-        native_step_keys = _native_step_keys_v1(
+        native_steps = _native_steps_v3(
             normalized,
             tenant_id=tenant_id,
             workflow_id=workflow_id,
             temporal_run_id=temporal_run_id,
+        )
+        native_step_keys = {(step.step_kind, step.item_key) for step in native_steps}
+        workflow_terminal = any(record.get("kind") == "workflow_terminal" for record in normalized)
+        native_terminal_lifecycle_missing = workflow_terminal and any(
+            step.state in {"queued", "running"} or (step.state == "failed" and step.retryable) for step in native_steps
         )
         source_memberships = _exact_source_memberships(
             connection,
@@ -587,6 +667,13 @@ async def reconcile_legacy_discovery_execution(
 
         for step in steps:
             recovered_events += _append_missing_step_events(connection, execution, step)
+        for step in native_steps:
+            recovered_events += _append_missing_step_events(
+                connection,
+                execution,
+                step,
+                recovery_source="temporal",
+            )
         connection.commit()
         ProjectionBuilder(
             conn_factory=get_connection if conn is None else (lambda: connection),
@@ -598,7 +685,7 @@ async def reconcile_legacy_discovery_execution(
             raise LegacyDiscoveryRecoveryError("recovery_manifest_set_mismatch")
         final_state: Literal["ready", "recovering", "incomplete"] = (
             "incomplete"
-            if terminal_failed_fanout
+            if terminal_failed_fanout or native_terminal_lifecycle_missing
             else "recovering"
             if legacy_recovery_pending
             else "ready"
@@ -617,6 +704,8 @@ async def reconcile_legacy_discovery_execution(
             error_code=(
                 "legacy-fanout-terminal-failed"
                 if terminal_failed_fanout
+                else "native-terminal-lifecycle-missing"
+                if native_terminal_lifecycle_missing
                 else None
             ),
         )
@@ -688,19 +777,31 @@ async def _normalize_temporal_history(handle: Any, converter: Any) -> list[dict[
                     "kind": "completed" if completed else "failed",
                     "history_event_id": int(event.event_id),
                     "scheduled_event_id": int(attrs.scheduled_event_id),
-                    "started_event_id": _safe_int(
-                        getattr(attrs, "started_event_id", 0)
-                    ),
+                    "started_event_id": _safe_int(getattr(attrs, "started_event_id", 0)),
                     "event_time": event_time,
                     "result": (await _decode_payloads(converter, attrs.result) if completed else {}),
-                    "error_code": (
-                        "activity_canceled" if canceled else _failure_code(failure)
-                    ),
+                    "error_code": ("activity_canceled" if canceled else _failure_code(failure)),
                     "retryable": _failure_retryable(
                         failure,
                         _safe_int(getattr(attrs, "retry_state", 0)),
                         canceled=canceled,
                     ),
+                }
+            )
+        elif kind in {
+            "workflow_execution_completed_event_attributes",
+            "workflow_execution_failed_event_attributes",
+            "workflow_execution_timed_out_event_attributes",
+            "workflow_execution_canceled_event_attributes",
+            "workflow_execution_terminated_event_attributes",
+            "workflow_execution_continued_as_new_event_attributes",
+        }:
+            records.append(
+                {
+                    "kind": "workflow_terminal",
+                    "history_event_id": int(event.event_id),
+                    "event_time": event_time,
+                    "state": kind.removeprefix("workflow_execution_").removesuffix("_event_attributes"),
                 }
             )
         else:
@@ -912,6 +1013,8 @@ def _append_missing_step_events(
     conn: Any,
     execution: DiscoveryExecutionRef,
     step: LegacyStep,
+    *,
+    recovery_source: Literal["legacy", "temporal"] = "legacy",
 ) -> int:
     tenant = TenantId(execution.tenant_id)
     detail = PipelineStepSafeDetail(code=step.detail_code, item_count=step.item_count)
@@ -996,7 +1099,10 @@ def _append_missing_step_events(
             None,
             "workflow",
             event.event_type,
-            payload={**dict(event.payload), "recoveredFromLegacyHistory": True},
+            payload={
+                **dict(event.payload),
+                ("recoveredFromLegacyHistory" if recovery_source == "legacy" else "recoveredFromTemporalHistory"): True,
+            },
             occurred_at=event.occurred_at,
         )
         written += 1

--- a/workers/automation/tests/test_discovery_execution_reconciliation.py
+++ b/workers/automation/tests/test_discovery_execution_reconciliation.py
@@ -761,8 +761,7 @@ async def test_decoder_v2_recovers_exact_legacy_fanouts_and_resumes_partial_repl
     assert all(row["work_plan_state"] == "planned" for row in memberships)
     assert all(json.loads(row["required_steps_json"]) == ["score", "tailor", "cover", "pdf"] for row in memberships)
     assert all(
-        row["preparation_workflow_id"] == f"prep-job-{job_index_by_id[str(row['job_id'])]:03d}"
-        for row in memberships
+        row["preparation_workflow_id"] == f"prep-job-{job_index_by_id[str(row['job_id'])]:03d}" for row in memberships
     )
     assert all(row["work_plan_reason"] == _LEGACY_WORK_PLAN_REASON_CODE for row in memberships)
 
@@ -799,7 +798,7 @@ async def test_decoder_v2_recovers_exact_legacy_fanouts_and_resumes_partial_repl
     ready_manifest = dict(conn.execute("SELECT * FROM discovery_execution_recoveries").fetchone())
     assert ready_manifest["state"] == "ready"
     assert ready_manifest["mode"] == "reconstructed"
-    assert ready_manifest["decoder_version"] == 2
+    assert ready_manifest["decoder_version"] == 3
     assert ready_manifest["history_event_id"] == 1_000
     assert ready_manifest["expected_membership_count"] == 72
     assert ready_manifest["persisted_membership_count"] == 72
@@ -1016,6 +1015,7 @@ def test_native_history_excludes_runtime_only_live_enrichment_key() -> None:
     records = [
         {
             "kind": "scheduled",
+            "event_id": 1,
             "activity_type": "discovery_enrichment",
             "payload": {
                 "discovery_execution": execution,
@@ -1025,6 +1025,7 @@ def test_native_history_excludes_runtime_only_live_enrichment_key() -> None:
         },
         {
             "kind": "scheduled",
+            "event_id": 2,
             "activity_type": "discovery_enrichment",
             "payload": {
                 "discovery_execution": execution,
@@ -1091,7 +1092,7 @@ def test_recovery_manifest_upserts_monotonic_history_watermark(tmp_path) -> None
     row = conn.execute("SELECT * FROM discovery_execution_recoveries").fetchone()
     assert row["state"] == "ready"
     assert row["mode"] == "reconstructed"
-    assert row["decoder_version"] == 2
+    assert row["decoder_version"] == 3
     assert row["history_event_id"] == 18
     assert row["key_digest"] == digest
     assert row["last_error_code"] is None
@@ -1796,9 +1797,7 @@ async def test_reconciliation_repairs_stale_ready_manifest(tmp_path, monkeypatch
         persisted_memberships=1,
         expected_steps=0,
         persisted_steps=0,
-        key_digest=_recovery_key_digest(
-            {str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:old"))}, set()
-        ),
+        key_digest=_recovery_key_digest({str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:old"))}, set()),
     )
 
     async def normalized_history(_handle, _converter):
@@ -1880,7 +1879,7 @@ async def test_reconciliation_revalidates_prior_decoder_manifest(tmp_path, monke
 
     row = conn.execute("SELECT * FROM discovery_execution_recoveries").fetchone()
     assert row["state"] == "ready"
-    assert row["decoder_version"] == 2
+    assert row["decoder_version"] == 3
 
 
 @pytest.mark.asyncio
@@ -1957,6 +1956,179 @@ async def test_native_run_is_ready_only_after_declared_step_is_projected(tmp_pat
     assert row["mode"] == "native"
     assert row["history_event_id"] == 2
     assert row["expected_step_count"] == row["persisted_step_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_decoder_v3_repairs_native_timeout_left_running_by_closed_workflow(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    conn = init_db(tmp_path / "native-timeout.db")
+    execution = DiscoveryExecutionRef(
+        tenant_id="local",
+        workflow_id="discover-local",
+        temporal_run_id="run-native-timeout",
+    )
+    tenant_id = TenantId(execution.tenant_id)
+    detail = PipelineStepSafeDetail(code="source_family", item_count=1)
+    for event in (
+        create_pipeline_step_queued(
+            tenant_id,
+            PipelineStepQueuedPayload(
+                execution=execution,
+                step_kind="source_family",
+                item_key="family:jobspy",
+                attempt=3,
+                queued_at="2026-08-12T19:12:00+00:00",
+                detail=detail,
+            ),
+        ),
+        create_pipeline_step_started(
+            tenant_id,
+            PipelineStepStartedPayload(
+                execution=execution,
+                step_kind="source_family",
+                item_key="family:jobspy",
+                attempt=3,
+                started_at="2026-08-12T19:12:01+00:00",
+                detail=detail,
+            ),
+        ),
+    ):
+        record_job_event(
+            conn,
+            None,
+            "workflow",
+            event.event_type,
+            payload=dict(event.payload),
+            occurred_at=event.occurred_at,
+        )
+    conn.commit()
+    ProjectionBuilder(
+        conn_factory=lambda: conn,
+        tenant_id=tenant_id,
+    ).refresh()
+    assert (
+        conn.execute("SELECT state FROM pipeline_step_projections WHERE step_kind = 'source_family'").fetchone()[
+            "state"
+        ]
+        == "running"
+    )
+
+    _ensure_recovery_manifest_table(conn)
+    step_keys = {("source_family", "family:jobspy")}
+    _write_recovery_manifest(
+        conn,
+        execution,
+        state="ready",
+        mode="native",
+        history_event_id=4,
+        expected_memberships=0,
+        persisted_memberships=0,
+        expected_steps=1,
+        persisted_steps=1,
+        key_digest=_recovery_key_digest(set(), step_keys),
+    )
+    # This is the settled checkpoint shipped before native terminal lifecycle
+    # reconciliation was introduced.
+    conn.execute("UPDATE discovery_execution_recoveries SET decoder_version = 2")
+    conn.commit()
+
+    records = [
+        {
+            "kind": "scheduled",
+            "history_event_id": 1,
+            "event_id": 1,
+            "event_time": "2026-08-12T19:11:59+00:00",
+            "activity_type": "discovery_source_family",
+            "payload": {
+                "family": "jobspy",
+                "discovery_execution": {
+                    "tenant_id": execution.tenant_id,
+                    "workflow_id": execution.workflow_id,
+                    "temporal_run_id": execution.temporal_run_id,
+                },
+            },
+        },
+        {
+            "kind": "started",
+            "history_event_id": 2,
+            "scheduled_event_id": 1,
+            "event_time": "2026-08-12T19:12:01+00:00",
+            "attempt": 3,
+        },
+        {
+            "kind": "failed",
+            "history_event_id": 3,
+            "scheduled_event_id": 1,
+            "started_event_id": 2,
+            "event_time": "2026-08-12T19:42:01+00:00",
+            "error_code": "activity_timeout",
+            "retryable": False,
+        },
+        {
+            "kind": "workflow_terminal",
+            "history_event_id": 4,
+            "event_time": "2026-08-12T19:42:02+00:00",
+            "state": "succeeded",
+        },
+    ]
+
+    async def normalized_history(_handle, _converter):
+        return records
+
+    monkeypatch.setattr(execution_reconciliation, "_normalize_temporal_history", normalized_history)
+
+    class FakeClient:
+        data_converter = object()
+
+        @staticmethod
+        def get_workflow_handle(workflow_id, *, run_id):
+            assert workflow_id == execution.workflow_id
+            assert run_id == execution.temporal_run_id
+            return object()
+
+    result = await execution_reconciliation.reconcile_legacy_discovery_execution(
+        FakeClient(),
+        workflow_id=execution.workflow_id,
+        temporal_run_id=execution.temporal_run_id,
+        conn=conn,
+    )
+
+    assert result.activities_recovered == 1
+    step = conn.execute(
+        """
+        SELECT state, attempt, error_code, retryable
+        FROM pipeline_step_projections
+        WHERE step_kind = 'source_family' AND item_key = 'family:jobspy'
+        """
+    ).fetchone()
+    assert dict(step) == {
+        "state": "failed",
+        "attempt": 3,
+        "error_code": "activity-timeout",
+        "retryable": 0,
+    }
+    failed_payload = json.loads(
+        conn.execute("SELECT payload_json FROM job_events WHERE event_type = 'PipelineStepFailed'").fetchone()[
+            "payload_json"
+        ]
+    )
+    assert failed_payload["recoveredFromTemporalHistory"] is True
+    assert "recoveredFromLegacyHistory" not in failed_payload
+    manifest = dict(conn.execute("SELECT * FROM discovery_execution_recoveries").fetchone())
+    assert manifest["state"] == "ready"
+    assert manifest["decoder_version"] == 3
+
+    event_count = conn.execute("SELECT COUNT(*) FROM job_events").fetchone()[0]
+    replay = await execution_reconciliation.reconcile_legacy_discovery_execution(
+        FakeClient(),
+        workflow_id=execution.workflow_id,
+        temporal_run_id=execution.temporal_run_id,
+        conn=conn,
+    )
+    assert replay.activities_recovered == 0
+    assert conn.execute("SELECT COUNT(*) FROM job_events").fetchone()[0] == event_count
 
 
 @pytest.mark.asyncio

--- a/workers/automation/tests/test_worker_heartbeat_loop.py
+++ b/workers/automation/tests/test_worker_heartbeat_loop.py
@@ -135,8 +135,7 @@ def test_recovery_candidates_keep_open_runs_and_only_latest_incomplete_terminal(
             )
         else:
             conn.execute(
-                f"INSERT INTO {table} VALUES "
-                "('local', 'discover-open', 'run-open', 'source_planning', 'plan')"
+                f"INSERT INTO {table} VALUES ('local', 'discover-open', 'run-open', 'source_planning', 'plan')"
             )
 
     assert cli._legacy_discovery_recovery_candidates(conn, tenant_id="local") == [
@@ -159,7 +158,7 @@ def test_recovery_candidates_skip_ready_latest_terminal_checkpoint() -> None:
     conn.execute(
         """
         INSERT INTO discovery_execution_recoveries VALUES (
-            'local', 'discover-done', 'run-done', 'ready', 'native', 2, 12,
+            'local', 'discover-done', 'run-done', 'ready', 'native', 3, 12,
             0, 0, 0, 0, ?, NULL, '2026-07-16T09:01:00Z'
         )
         """,
@@ -179,9 +178,7 @@ def test_recovery_candidates_skip_terminal_incomplete_checkpoint() -> None:
                   '2026-07-16T09:00:00Z', 'run-incomplete')
         """
     )
-    digest = execution_reconciliation._recovery_key_digest(
-        {"22222222-2222-4222-8222-222222222222"}, set()
-    )
+    digest = execution_reconciliation._recovery_key_digest({"22222222-2222-4222-8222-222222222222"}, set())
     conn.execute(
         "INSERT INTO discovery_execution_jobs VALUES "
         "('local', 'discover-incomplete', 'run-incomplete', "
@@ -219,9 +216,7 @@ def test_recovery_candidates_repair_stale_ready_checkpoint() -> None:
         )
         """
     )
-    stale_digest = execution_reconciliation._recovery_key_digest(
-        {"44444444-4444-4444-8444-444444444444"}, set()
-    )
+    stale_digest = execution_reconciliation._recovery_key_digest({"44444444-4444-4444-8444-444444444444"}, set())
     conn.execute(
         """
         INSERT INTO discovery_execution_recoveries VALUES (


### PR DESCRIPTION
## Summary

- expose attempt-budget exhaustion as a retryable failed stage while preserving the raw exhausted value for storage compatibility
- reconstruct missing native activity terminal events from exact Temporal history so a closed workflow cannot remain shown as active or 50% complete
- reset the attempt budget atomically when the user retries an exhausted stage
- classify a planned source family that has not been scheduled yet as waiting while its Discover workflow is active, reserving unknown for a genuine terminal projection gap
- align Jobs filters, pipeline outcome counts, diagnostics, contracts, tests, and product documentation with the public lifecycle model

## Why

A terminal Temporal activity could remain projected as running after its worker stopped reporting, leaving a completed Discover run visibly active forever. Attempt exhaustion was also presented as a lifecycle state even though it is the reason a stage failed and the stage can be retried. Active bounded source-family execution also mislabeled planned-but-not-yet-scheduled work as unknown instead of waiting.

## Validation

- Python suite: 3613 passed, 2 skipped
- API suite: 779 passed
- Web suite: 2024 passed
- source-family operations regression: 50 passed
- contracts, API, and web TypeScript checks passed
- Ruff check and format checks passed
- production web build passed
- documentation build and internal-link validation passed
- Chromium product QA confirmed a closed final-timeout run renders 100% terminal with Failed 1, no active/50%/Exhausted state, and no console or layout errors
- live API and browser QA confirmed an active two-family run renders Waiting 1, Processing 1, Unknown 0 with no console, network, or layout errors; a terminal missing-lifecycle fixture remains Unknown 1
- disposable API QA confirmed Retry resets the stage to pending, sets attempts to 0, clears the error, and records reset_attempts=true
- independent review and QA gates passed with no findings

## Checklist

- [x] External contributor commits include a DCO Signed-off-by trailer.
- [x] I ran the relevant local checks and listed them above.
- [x] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.
