### PR TITLE
fix(pipeline): estimate bounded source completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@ evidence, qualifications, and the complete capability matrix.
   Pipelines reports how many units resumed. JobStreaming 0.0.3 also supplies
   cursor-free provider page progress so the active crawl can show completed
   pages, raw listings, emitted jobs, and known continuation without guessing
-  an unavailable provider total or ETA.
+  an unavailable provider total. JobCtrl can separately estimate source-family
+  completion from recent whole-family durations when live queue and capacity
+  observations bound the shared worker contention.
 - Optionally reconcile a local Temporal Schedule for discovery; it is disabled
   by default and uses the configured cron only after you enable it.
 - Enrich postings with full descriptions, canonical posting URLs, and apply

--- a/apps/api/src/pipeline-operations.ts
+++ b/apps/api/src/pipeline-operations.ts
@@ -268,13 +268,17 @@ export function buildPipelineOperationsSnapshot(
   );
   const globalCounts = globalStageCounts(db, tenantId, selected);
   const globalRetryability = loadGlobalRetryability(db, tenantId, selected);
+  const globalQueuedOrRunningDemand = hasGlobalQueuedOrRunningStageDemand(
+    db,
+    tenantId,
+    selected,
+  );
   const sourceFamilies = sourceFamilyProgress(
     db,
     tenantId,
     selected,
-    sweepCounts,
-    globalCounts,
     globalRetryability,
+    globalQueuedOrRunningDemand,
     generatedAt,
     telemetry,
     budgetAvailable,
@@ -315,6 +319,7 @@ export function buildPipelineOperationsSnapshot(
     now,
     runtimeAttribution,
     projectionCoverage,
+    sourceFamilyEta: sourceFamilies?.eta ?? null,
   });
 
   return {
@@ -1202,6 +1207,29 @@ function globalStageCounts(
   return counts;
 }
 
+function hasGlobalQueuedOrRunningStageDemand(
+  db: SqliteDatabase,
+  tenantId: string,
+  selected: SelectedExecution,
+): boolean {
+  const excluded = selected.current.members.concat(selected.sweep.members).map((member) => member.job_id);
+  const where = [
+    "tenant_id = ?",
+    "stage IN ('enrich', 'score', 'tailor', 'cover')",
+    "state IN ('queued', 'running')",
+  ];
+  const params: SqliteValue[] = [tenantId];
+  if (excluded.length > 0) {
+    where.push(`job_id NOT IN (${excluded.map(() => "?").join(", ")})`);
+    params.push(...excluded);
+  }
+  return allRows<{ present: number }>(
+    db,
+    `SELECT 1 AS present FROM job_stage_states WHERE ${where.join(" AND ")} LIMIT 1`,
+    params,
+  ).length > 0;
+}
+
 function loadGlobalRetryability(
   db: SqliteDatabase,
   tenantId: string,
@@ -1316,6 +1344,7 @@ function buildStages(input: {
   now: Date;
   runtimeAttribution: SelectedRuntimeAttribution;
   projectionCoverage: PipelineProjectionCoverage;
+  sourceFamilyEta: PipelineEta | null;
 }): PipelineOperationalStage[] {
   const result: PipelineOperationalStage[] = [];
   const selectedScope = input.projectionCoverage.status === "ready" ? "known" : "unknown";
@@ -1323,35 +1352,38 @@ function buildStages(input: {
     const current = input.currentCounts.get(stage) ?? emptyCounts();
     const sweep = input.sweepCounts.get(stage) ?? emptyCounts();
     const global = input.globalCounts.get(stage) ?? emptyCounts();
-    const stageEta = estimateForStage(
-      input.db,
-      input.tenantId,
-      stage,
-      current,
-      input.selected,
-      input.telemetry,
-      input.budgetAvailable,
-      input.generatedAt,
-      input.now,
-      retryableRemainingForStage(input.selected, input.selected.current, stage, true),
-      true,
-      {
-        runtimeActiveWork: selectedRuntimeStageActiveWork(
-          input.runtimeAttribution,
-          "current_execution",
-          stage,
-        ),
-        scope: selectedScope,
-      },
-      currentStageContention(
-        input.selected,
-        stage,
-        input.sweepCounts,
-        input.globalCounts,
-        input.globalRetryability,
-        input.telemetry,
-      ),
-    );
+    const stageEta =
+      stage === "source_family" && input.sourceFamilyEta !== null
+        ? input.sourceFamilyEta
+        : estimateForStage(
+            input.db,
+            input.tenantId,
+            stage,
+            current,
+            input.selected,
+            input.telemetry,
+            input.budgetAvailable,
+            input.generatedAt,
+            input.now,
+            retryableRemainingForStage(input.selected, input.selected.current, stage, true),
+            true,
+            {
+              runtimeActiveWork: selectedRuntimeStageActiveWork(
+                input.runtimeAttribution,
+                "current_execution",
+                stage,
+              ),
+              scope: selectedScope,
+            },
+            currentStageContention(
+              input.selected,
+              stage,
+              input.sweepCounts,
+              input.globalCounts,
+              input.globalRetryability,
+              input.telemetry,
+            ),
+          );
     result.push({
       stage,
       label: STAGE_LABELS[stage],
@@ -1479,9 +1511,8 @@ function sourceFamilyProgress(
   db: SqliteDatabase,
   tenantId: string,
   selected: SelectedExecution,
-  sweepCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>,
-  globalCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>,
   globalRetryability: GlobalRetryability,
+  globalQueuedOrRunningDemand: boolean,
   generatedAt: string,
   telemetry: WorkerRuntimeTelemetrySnapshot,
   budgetAvailable: boolean,
@@ -1499,35 +1530,113 @@ function sourceFamilyProgress(
   )
     ? latestDiscoveryProviderProgress(db, tenantId, selected)
     : null;
+  const eta = estimateSourceFamilyEta({
+    db,
+    tenantId,
+    selected,
+    globalRetryability,
+    globalQueuedOrRunningDemand,
+    sourceRows,
+    counts,
+    providerProgress,
+    generatedAt,
+    telemetry,
+    budgetAvailable,
+    now,
+    runtimeAttribution,
+    projectionCoverage,
+  });
   return {
     planned,
     counts,
-    eta: estimatePipelineEta({
-      ...basicEtaInput(
-        selected,
-        telemetry,
-        budgetAvailable,
-        generatedAt,
-        selectedRuntimeStageActiveWork(runtimeAttribution, "current_execution", "source_family"),
-      ),
-      scope: projectionCoverage.status === "ready" ? "known" : "unknown",
-      membershipOpen: false,
-      stages: [
-        {
-          stage: "source_family",
-          remainingCurrentStage: etaRemainingCount(
-            counts,
-            retryablePipelineSteps(sourceRows, isTerminalWorkflowStatus(selected.row.status)),
-          ),
-          primaryEvidence: "pipeline_step_projection",
-          samples: pipelineStepHistorySamples(db, tenantId, "source_family", now),
-        },
-      ],
-      remainingPaths: [],
-      contention: sourceContention(selected, sweepCounts, globalCounts, globalRetryability, telemetry),
-    }) as PipelineEta,
+    eta,
     asOf: generatedAt,
     ...(providerProgress ? { providerProgress } : {}),
+  };
+}
+
+function estimateSourceFamilyEta(input: {
+  db: SqliteDatabase;
+  tenantId: string;
+  selected: SelectedExecution;
+  globalRetryability: GlobalRetryability;
+  globalQueuedOrRunningDemand: boolean;
+  sourceRows: PipelineStepRow[];
+  counts: PipelineStageCounts;
+  providerProgress: DiscoveryProviderProgress | null;
+  generatedAt: string;
+  telemetry: WorkerRuntimeTelemetrySnapshot;
+  budgetAvailable: boolean;
+  now: Date;
+  runtimeAttribution: SelectedRuntimeAttribution;
+  projectionCoverage: PipelineProjectionCoverage;
+}): PipelineEta {
+  const durableSourceConcurrency = Math.max(1, input.counts.processing);
+  const observedSourceConcurrency = Math.max(
+    1,
+    selectedRuntimeStageActiveCount(
+      input.runtimeAttribution,
+      "current_execution",
+      "source_family",
+    ),
+  );
+  const processingFamilies = Math.min(
+    durableSourceConcurrency,
+    observedSourceConcurrency,
+  );
+  const configuredSlots =
+    input.telemetry.status === "available"
+      ? Math.min(processingFamilies, Math.max(1, input.telemetry.configuredSlots))
+      : processingFamilies;
+  const estimated = estimatePipelineEta({
+    ...basicEtaInput(
+      input.selected,
+      input.telemetry,
+      input.budgetAvailable,
+      input.generatedAt,
+      selectedRuntimeStageActiveWork(
+        input.runtimeAttribution,
+        "current_execution",
+        "source_family",
+      ),
+    ),
+    scope: input.projectionCoverage.status === "ready" ? "known" : "unknown",
+    membershipOpen: false,
+    configuredSlots,
+    stages: [
+      {
+        stage: "source_family",
+        remainingCurrentStage: etaRemainingCount(
+          input.counts,
+          retryablePipelineSteps(
+            input.sourceRows,
+            isTerminalWorkflowStatus(input.selected.row.status),
+          ),
+        ),
+        primaryEvidence: "pipeline_step_projection",
+        samples: pipelineStepHistorySamples(
+          input.db,
+          input.tenantId,
+          "source_family",
+          input.now,
+        ),
+      },
+    ],
+    remainingPaths: [],
+    contention: sourceFamilyHistoricalContention(
+      input.selected,
+      input.globalRetryability,
+      input.globalQueuedOrRunningDemand,
+      input.telemetry,
+    ),
+  }) as PipelineEta;
+  if (estimated.status !== "available") return estimated;
+  return {
+    ...estimated,
+    basis: "source_rate",
+    caveat: input.providerProgress?.totalUnits === null
+      ? "Provider total is unavailable; range uses recent whole-family duration and bounded live capacity."
+      : "Range uses recent whole-family duration and bounded live capacity.",
   };
 }
 
@@ -2172,6 +2281,64 @@ function sourceContention(
   return competingDomainWork ? { kind: "unknown" as const } : runtime;
 }
 
+function sourceFamilyHistoricalContention(
+  selected: SelectedExecution,
+  globalRetryability: GlobalRetryability,
+  globalQueuedOrRunningDemand: boolean,
+  telemetry: WorkerRuntimeTelemetrySnapshot,
+) {
+  const runtime = sharedRuntimeContention(telemetry);
+  if (runtime.kind !== "bounded") return runtime;
+  if (
+    globalRetryability.hasUnboundedRetryableDemand ||
+    globalQueuedOrRunningDemand
+  ) {
+    return { kind: "unknown" as const };
+  }
+  // One preparation workflow can contribute several sequential stage rows,
+  // but it can occupy only one shared slot at a time. Reserve one slot for
+  // each remaining sweep member that is not already running. If fresh spare
+  // capacity absorbs that whole set, the observed source lane stays bounded.
+  const unoccupiedSweepDemand = selected.sweep.members.filter(
+    (member) =>
+      sweepMemberHasRemainingWork(selected, member) &&
+      !sweepMemberHasRunningWork(selected, member),
+  ).length;
+  return unoccupiedSweepDemand > telemetry.availableSlots
+    ? { kind: "unknown" as const }
+    : runtime;
+}
+
+function sweepMemberHasRemainingWork(
+  selected: SelectedExecution,
+  member: MembershipRow,
+): boolean {
+  if (member.work_plan_state === "not_eligible") return false;
+  const terminalOwner = memberPreparationWorkflowFailed(
+    member,
+    selected.sweep.preparationWorkflowStatuses,
+  );
+  const states = selected.sweep.stageStates.get(member.job_id);
+  if (!isTerminalStageState(states?.get("enrich"), terminalOwner)) return true;
+  if (member.work_plan_state !== "planned") return true;
+  return requiredSteps(member).some((stage) =>
+    stage === "pdf"
+      ? !isTerminalStepState(pdfStepForMember(member, selected.steps), terminalOwner)
+      : !isTerminalStageState(states?.get(stage), terminalOwner),
+  );
+}
+
+function sweepMemberHasRunningWork(
+  selected: SelectedExecution,
+  member: MembershipRow,
+): boolean {
+  const states = selected.sweep.stageStates.get(member.job_id);
+  if ([...(states?.values() ?? [])].some((state) => state.state === "running")) {
+    return true;
+  }
+  return pdfStepForMember(member, selected.steps)?.state === "running";
+}
+
 function etaRemainingCount(counts: PipelineStageCounts, retryableFailures: number): number {
   return remainingCount(counts) + retryableFailures;
 }
@@ -2295,10 +2462,18 @@ function selectedRuntimeStageActiveWork(
   scope: SelectedRuntimeScope,
   stage: (typeof OPERATIONAL_STAGES)[number],
 ): boolean {
+  return selectedRuntimeStageActiveCount(attribution, scope, stage) > 0;
+}
+
+function selectedRuntimeStageActiveCount(
+  attribution: SelectedRuntimeAttribution,
+  scope: SelectedRuntimeScope,
+  stage: (typeof OPERATIONAL_STAGES)[number],
+): number {
   const counts = scope === "execution_sweep"
     ? attribution.sweepStageCounts
     : attribution.currentStageCounts;
-  return (counts.get(stage) ?? 0) > 0;
+  return counts.get(stage) ?? 0;
 }
 
 function usesStepProjection(stage: string): boolean {

--- a/apps/api/test/pipeline-operations.test.ts
+++ b/apps/api/test/pipeline-operations.test.ts
@@ -1150,7 +1150,7 @@ describe("pipeline operations read model", () => {
     });
   });
 
-  it("does not price source or a current stage as isolated from a retryable sweep stage", () => {
+  it("withholds source and current-stage ETAs when sweep demand exceeds spare capacity", () => {
     const fixture = createFixture();
     insertExecution(fixture, { status: "succeeded" });
     insertMember(fixture, { key: "cross-stage-current", requiredSteps: ["score"] });
@@ -1171,9 +1171,14 @@ describe("pipeline operations read model", () => {
       );
     }
     insertHeartbeat(fixture, {
-      activeSlots: 1,
-      counts: { score_job: 1 },
-      details: [activityDetail("score_job", "op_000000000000000000000018", unmatchedWorkflowRef("cross-stage"))],
+      activeSlots: 4,
+      counts: { score_job: 4 },
+      details: [
+        activityDetail("score_job", "op_000000000000000000000018", unmatchedWorkflowRef("cross-stage-1")),
+        activityDetail("score_job", "op_000000000000000000000019", unmatchedWorkflowRef("cross-stage-2")),
+        activityDetail("score_job", "op_000000000000000000000020", unmatchedWorkflowRef("cross-stage-3")),
+        activityDetail("score_job", "op_000000000000000000000021", unmatchedWorkflowRef("cross-stage-4")),
+      ],
     });
 
     const result = snapshot(fixture);
@@ -1278,19 +1283,123 @@ describe("pipeline operations read model", () => {
     });
   });
 
-  it("does not price source work as isolated when global preparation work shares the activity pool", () => {
+  it("prices source history when one sweep workflow fits spare capacity and global rows stay dormant", () => {
     const fixture = createFixture();
     insertExecution(fixture, { status: "in_progress" });
-    insertStep(fixture, { stepKind: "source_planning", itemKey: "global-plan", state: "succeeded", detailCount: 1 });
-    insertStep(fixture, { stepKind: "source_family", itemKey: "global-source", state: "running" });
+    insertStep(fixture, { stepKind: "source_planning", itemKey: "global-plan", state: "succeeded", detailCount: 2 });
+    insertStep(fixture, { stepKind: "source_family", itemKey: "family:jobspy", state: "running" });
+    insertMember(fixture, {
+      key: "spare-sweep",
+      cohort: "existing_backlog",
+      requiredSteps: ["score", "tailor", "cover"],
+    });
+    insertStageState(fixture, "spare-sweep", "enrich", "succeeded");
+    insertStageState(fixture, "spare-sweep", "score", "pending");
+    insertStageState(fixture, "spare-sweep", "tailor", "pending");
+    insertStageState(fixture, "spare-sweep", "cover", "pending");
     insertStageState(fixture, "global-outside", "score", "pending");
+    for (let index = 0; index < 5; index += 1) {
+      insertHistoricalStep(fixture, {
+        stepKind: "source_family",
+        itemKey: `global-source-history-${index}`,
+        durationMs: 600_000,
+        index,
+      });
+    }
+    fixture.db.prepare(
+      `INSERT INTO job_events (
+         tenant_id, job_id, identity_version, stage, event_type, level,
+         message, occurred_at, payload_json
+       ) VALUES ('local', NULL, 1, 'discover', 'StageProgress', 'info', ?, ?, ?)`,
+    ).run(
+      "current provider progress",
+      "2026-07-14T11:59:00.000Z",
+      JSON.stringify({
+        workflowId: DISCOVER_WORKFLOW_ID,
+        discoverRunId: DISCOVER_RUN_ID,
+        progress: {
+          sourceProgress: {
+            providerProgress: {
+              site: "linkedin",
+              phase: "search",
+              unit: "page",
+              completedUnits: 39,
+              totalUnits: null,
+              rawItemsSeen: 390,
+              jobsEmitted: 371,
+              hasMore: null,
+            },
+          },
+        },
+      }),
+    );
+    insertHeartbeat(fixture, {
+      activeSlots: 2,
+      counts: { discovery_source_family: 1, discovery_enrichment: 1 },
+      details: [
+        activityDetail("discovery_source_family", "op_000000000000000000000015", DISCOVER_WORKFLOW_ID),
+        activityDetail("discovery_enrichment", "op_000000000000000000000016", DISCOVER_WORKFLOW_ID),
+      ],
+    });
+
+    const result = snapshot(fixture);
+    expect(result.sourceFamilies).toMatchObject({
+      counts: { eligible: 2, waiting: 1, processing: 1, unknown: 0 },
+      providerProgress: { completedUnits: 39, totalUnits: null },
+      eta: {
+        status: "available",
+        lowSeconds: 1_200,
+        highSeconds: 1_260,
+        confidence: "low",
+        basis: "source_rate",
+        sampleSize: 5,
+      },
+    });
+    expect(stage(result, "source_family", "current_execution").eta).toEqual(
+      result.sourceFamilies?.eta,
+    );
+    expect(result.sourceFamilies?.eta).toMatchObject({
+      caveat: "Provider total is unavailable; range uses recent whole-family duration and bounded live capacity.",
+    });
+  });
+
+  it("withholds source history when global job-stage work is queued before telemetry observes it", () => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "in_progress" });
+    insertStep(fixture, {
+      stepKind: "source_planning",
+      itemKey: "queued-global-plan",
+      state: "succeeded",
+      detailCount: 1,
+    });
+    insertStep(fixture, {
+      stepKind: "source_family",
+      itemKey: "queued-global-source",
+      state: "running",
+    });
+    insertStageState(fixture, "queued-global-outside", "score", "queued");
+    for (let index = 0; index < 5; index += 1) {
+      insertHistoricalStep(fixture, {
+        stepKind: "source_family",
+        itemKey: `queued-global-source-history-${index}`,
+        durationMs: 600_000,
+        index,
+      });
+    }
     insertHeartbeat(fixture, {
       activeSlots: 1,
       counts: { discovery_source_family: 1 },
-      details: [activityDetail("discovery_source_family", "op_000000000000000000000015", DISCOVER_WORKFLOW_ID)],
+      details: [
+        activityDetail(
+          "discovery_source_family",
+          "op_000000000000000000000021",
+          DISCOVER_WORKFLOW_ID,
+        ),
+      ],
     });
 
-    expect(snapshot(fixture).sourceFamilies?.eta).toMatchObject({
+    const result = snapshot(fixture);
+    expect(result.sourceFamilies?.eta).toMatchObject({
       status: "unavailable",
       reason: "contention_unbounded",
     });
@@ -1571,6 +1680,28 @@ function insertStep(
   );
 }
 
+function insertHistoricalStep(
+  fixture: Fixture,
+  input: { stepKind: string; itemKey: string; durationMs: number; index: number },
+): void {
+  fixture.db.prepare(
+    `INSERT INTO pipeline_step_projections (
+       tenant_id, discover_workflow_id, discover_run_id, step_kind, item_key, state, attempt,
+       queued_at, started_at, finished_at, duration_ms, retryable, detail_count, last_event_id, last_updated_at
+     ) VALUES ('local', ?, ?, ?, ?, 'succeeded', 1, ?, ?, ?, ?, 0, NULL, 0, ?)`,
+  ).run(
+    `history-workflow-${input.index}`,
+    `history-run-${input.index}`,
+    input.stepKind,
+    input.itemKey,
+    "2026-07-14T10:00:00.000Z",
+    "2026-07-14T10:00:00.000Z",
+    new Date(NOW.getTime() - input.index * 60_000).toISOString(),
+    input.durationMs,
+    NOW.toISOString(),
+  );
+}
+
 function insertHeartbeat(
   fixture: Fixture,
   input: {
@@ -1614,6 +1745,7 @@ function activityDetail(
     score_job: "job-scoring",
     tailor_job: "job-tailoring",
     discovery_source_family: "discovery-source-family",
+    discovery_enrichment: "discovery-enrichment",
     discovery_preparation_fanout: "discovery-preparation-fanout",
     plan_discovery_sources: "discovery-plan",
     derive_preparation_targets: "preparation-targets",

--- a/apps/web/src/views/pipelines/PipelinesView.fixtures.ts
+++ b/apps/web/src/views/pipelines/PipelinesView.fixtures.ts
@@ -37,6 +37,18 @@ const etaAvailable: PipelineEta = {
   caveat: "Estimate excludes unrelated backlog outside this discovery run.",
 };
 
+const sourceEtaAvailable: PipelineEta = {
+  status: "available",
+  lowSeconds: 1_200,
+  highSeconds: 1_260,
+  confidence: "low",
+  basis: "source_rate",
+  sampleSize: 5,
+  asOf: AS_OF,
+  caveat:
+    "Provider total is unavailable; range uses recent whole-family duration and bounded live capacity.",
+};
+
 const etaCalibrating: PipelineEta = {
   status: "calibrating",
   completedSamples: 2,
@@ -111,7 +123,13 @@ function stage(
 
 const discoveringStages: PipelineOperationalStage[] = [
   stage("source_planning", "Plan sources", "current_execution", counts({ eligible: 1, succeeded: 1 })),
-  stage("source_family", "Crawl sources", "current_execution", counts({ eligible: 3, processing: 2, succeeded: 1 })),
+  stage(
+    "source_family",
+    "Crawl sources",
+    "current_execution",
+    counts({ eligible: 3, processing: 2, succeeded: 1 }),
+    sourceEtaAvailable,
+  ),
   stage("reconciliation", "Enrichment reconciliation", "current_execution", counts({ eligible: 2, waiting: 2 })),
   stage("enrich", "Enrich", "execution_sweep", counts({ eligible: 9, waiting: 5, processing: 2, succeeded: 2 })),
   stage("score", "Score", "execution_sweep", counts({ eligible: 7, waiting: 4, processing: 1, succeeded: 2 })),
@@ -156,7 +174,7 @@ function snapshot(overrides: Partial<PipelineOperationsSnapshot> = {}): Pipeline
     sourceFamilies: {
       planned: 3,
       counts: counts({ eligible: 3, processing: 2, succeeded: 1 }),
-      eta: etaAvailable,
+      eta: sourceEtaAvailable,
       asOf: AS_OF,
       providerProgress: {
         site: "indeed",

--- a/apps/web/src/views/pipelines/PipelinesView.test.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.test.tsx
@@ -119,6 +119,7 @@ describe("PipelinesView", () => {
     expect(crawlTrigger).toHaveTextContent(
       "Source family · 2 active · 1 terminal · 0 attention",
     );
+    expect(crawlTrigger).toHaveTextContent("20 min–21 min");
     await user.click(crawlTrigger);
     expect(crawlTrigger).toHaveAttribute("aria-expanded", "true");
     expect(
@@ -148,6 +149,7 @@ describe("PipelinesView", () => {
     expect(crawl).toHaveTextContent(
       "Indeed · 3 pages completed; provider total unavailable · 42 raw listings seen · 9 jobs emitted · more pages available",
     );
+    expect(within(crawl).getAllByText("20 min–21 min").length).toBeGreaterThan(0);
 
     expect(
       screen.queryByRole("region", { name: "Execution sweep ledger table" }),

--- a/docs/api/complete-contract.md
+++ b/docs/api/complete-contract.md
@@ -517,8 +517,15 @@ requires closed execution membership; per-stage and source-family rows can
 estimate their already-known scoped backlog while membership remains open. The
 estimator uses canonical job-stage and pipeline-step durations, falling back to
 operational attempt metrics only when the primary source is empty; it never
-blends the two. Any unbounded shared-queue contention suppresses a numeric
-estimate.
+blends the two. A source-family estimate may use recent completed-family
+durations even when provider `totalUnits` is null; it does not synthesize a
+remaining-page count. It uses observed source concurrency and requires fresh,
+complete runtime inventory plus a bounded Temporal queue. Selected-run sweep
+work reserves one slot per remaining preparation workflow, not one per
+sequential stage, and suppresses the numeric source estimate only when that
+demand exceeds spare capacity. Unbounded retry demand or shared-queue
+contention still suppresses it; dormant global rows do not until queued or
+observed as active work.
 
 The Operations query polls every 15 seconds while phase is `discovering` or
 `draining`, every 60 seconds otherwise, and never in the background. SSE

--- a/docs/api/operations-and-events.md
+++ b/docs/api/operations-and-events.md
@@ -176,9 +176,14 @@ version is `pipeline-eta-v1`. Every numeric ETA requires fresh capacity, at
 least five successful duration samples for each relevant remaining stage, and
 bounded shared-queue contention. The overall ETA additionally waits for
 execution membership to close; per-stage and source-family ETAs can estimate
-their already-known scoped backlog while membership remains open. The estimator
-uses recent canonical stage/projection durations, reports a low/high range,
-confidence, basis, sample size, timestamp, and caveat, and rounds outward.
+their already-known scoped backlog while membership remains open. A null
+provider total never becomes a synthetic remaining-page count; the
+source-family range can instead use recent whole-family projection durations
+and the observed source concurrency when runtime inventory and queue telemetry
+are bounded. Dormant global rows outside the selected execution do not count as
+live source contention until queued or active. The estimator uses recent
+canonical stage/projection durations, reports a low/high range, confidence,
+basis, sample size, timestamp, and caveat, and rounds outward.
 Otherwise the response returns a typed `calibrating`, `paused`, `stale`, or
 `unavailable` reason such as `membership_open` (overall ETA only),
 `worker_unavailable`, `budget_exceeded`, `telemetry_stale`, or

--- a/docs/architecture/pipeline/operations.md
+++ b/docs/architecture/pipeline/operations.md
@@ -125,8 +125,11 @@ raw items seen, emitted jobs, and tri-state continuation. The worker stamps the
 exact Discover workflow/run identity onto the progress event, and Operations
 accepts only a matching execution before rendering the latest traversal facts.
 Unknown provider totals stay null and do not become a synthetic percentage or
-ETA. Raw provider output, cursors, resume dictionaries, checkpoints, owner
-tokens, and error messages are not projected into this broad progress payload.
+provider-derived ETA. A separate source-family ETA may use recent completed
+whole-family durations when live worker inventory and the Temporal queue bound
+the source lane. Raw provider output, cursors, resume dictionaries,
+checkpoints, owner tokens, and error messages are not projected into this broad
+progress payload.
 
 ## Pipeline Operations Snapshot
 
@@ -179,8 +182,10 @@ materials, or PDF work is complete.
 Provider traversal progress is observational evidence inside the active broad-
 board family, not a third completion authority. It can explain that a provider
 has completed pages and whether continuation is known. It cannot bound shared-
-pool contention or establish remaining pages when `totalUnits` is null, so the
-ETA estimator remains conservative in those states.
+pool contention or establish remaining pages when `totalUnits` is null. The
+source-family estimator therefore never derives a remaining-page count from
+that payload; it can instead price the known planned-family backlog from recent
+whole-family duration samples when runtime evidence bounds the source lane.
 
 The API prefers an active or draining Discover execution and otherwise shows
 the latest terminal execution. The phase vocabulary is `discovering`,
@@ -390,9 +395,17 @@ approximate infrastructure observations, never as job counts.
 most 50 recent samples, and a minimum of five samples for every remaining
 stage. The overall numeric range is withheld while membership is open;
 per-stage and source-family ranges can price their already-known scoped backlog
-before closure. Every estimate still withholds a number when telemetry is stale,
-a worker is unavailable, work is budget-blocked, or shared contention is
-unbounded. Non-numeric `calibrating`, `paused`, `stale`, and `unavailable`
+before closure. A source-family range uses the currently observed source
+concurrency rather than claiming every configured slot. Dormant global rows
+outside the selected execution are not live contention until their canonical
+state is queued or running, or activity inventory or the Temporal queue observes
+them. Selected-run sweep work reserves
+one slot per remaining preparation workflow rather than one per sequential
+stage; the source estimate is withheld when that demand exceeds spare capacity.
+Unbounded retry demand, queued work, and truncated inventory remain unbounded.
+Every estimate still withholds a number when telemetry is stale, a worker is
+unavailable, work is budget-blocked, or shared contention is unbounded.
+Non-numeric `calibrating`, `paused`, `stale`, and `unavailable`
 states are part of the contract. The web surface presents a `paused` estimate
 as **No ETA** plus the bounded reason so it cannot be mistaken for the Temporal
 workflow's lifecycle state. In particular, `no_dispatch` means the estimator

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2145,6 +2145,15 @@ normalized, cursor-free `ProviderProgress` observations are projected under the
 exact Discover workflow/run identity, while provider totals remain nullable and
 separate from JobCtrl acceptance counts and whole-pipeline ETA evidence.
 
+Amended (2026-08-13): a null provider total still forbids a provider-progress
+percentage or remaining-page estimate. It does not forbid a separate
+source-family range derived from recent completed-family durations when the
+planned family count, source concurrency, runtime inventory, and Temporal queue
+are bounded. Dormant global rows outside the selected execution become source
+contention only when they are queued or observed as active work. Selected-run
+sweep demand reserves one slot per remaining preparation workflow and blocks
+the source range only when those workflows exceed currently spare capacity.
+
 ## 2026-07-29: Stable Job Identity And Human-Approved Feedback Learning
 
 Status: accepted

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -111,8 +111,14 @@ boundary carrying a private fake cursor. Verify that the worker callback,
 exact-run Operations response, and expanded **Crawl sources** row expose only
 the normalized provider/page counts and continuation state. The private cursor
 must be absent, an event from another Temporal run must not leak into the
-selected execution, and a missing provider total must render as unavailable
-rather than a synthetic percentage:
+selected execution, and a missing provider total must not become a synthetic
+percentage. With two planned families, one active family, five recent
+whole-family duration samples, complete runtime inventory, and an empty task
+queue, the same fixture must produce a bounded `source_rate` range. One
+selected-sweep preparation workflow with several sequential stages must reserve
+one slot and remain bounded when spare capacity exists; queued backlog,
+unbounded retry demand, sweep demand beyond spare slots, or truncated inventory
+still produces `contention_unbounded`:
 
 ```bash
 corepack pnpm --filter @jobctrl/api exec vitest run \

--- a/docs/user/discovery.md
+++ b/docs/user/discovery.md
@@ -217,9 +217,14 @@ when another board fails. Pipelines shows `N resumed` when recovery happened.
 JobStreaming page progress is projected separately from JobCtrl acceptance
 counts. The provider payload contains no cursor or resume dictionary, and the
 Pipelines operations view binds it to the exact Discover workflow/run before
-displaying it. These traversal facts explain current crawl activity; they do
-not override a whole-stage ETA that is unavailable because shared worker-pool
-contention or an authoritative provider total is still unknown.
+displaying it. These traversal facts explain current crawl activity and never
+become a synthetic provider percentage when the total is unknown. Pipelines may
+still estimate the bounded source-family backlog from recent completed-family
+durations when worker inventory and the Temporal queue are fresh and complete.
+Dormant global job rows do not block that source-only estimate until they are
+actually queued or observed as active work. Selected-run sweep demand withholds
+it only when the unique remaining preparation workflows exceed spare runtime
+capacity; unbounded retry demand or queue contention always withholds it.
 
 **Stop discovery** is different from interruption: cooperative cancellation
 interrupts provider waits and marks active and pending units canceled. Canceled

--- a/docs/user/normal-flows.md
+++ b/docs/user/normal-flows.md
@@ -194,6 +194,10 @@ inventory. Treat ETA as an observed range: calibrating, no recent dispatch,
 stale, unavailable, and no-work states are deliberately explicit rather than
 replaced by a guessed finish time. An
 unavailable ETA does not mean that the workflow itself is paused.
+An unknown provider page total prevents a crawl percentage, not necessarily a
+source-family ETA: after at least five recent family completions, Pipelines can
+use whole-family duration history when live capacity and queue observations
+bound the current source lane.
 When a closed run leaves work behind, **Set up a new Discover run** becomes
 available only after the live operations snapshot proves that shared runtime
 capacity is idle. The Discover run control follows the same guard, so selecting


### PR DESCRIPTION
## Summary

- estimate source-family completion from recent successful whole-family durations when provider totals are unavailable
- bound the estimate by exact live source concurrency, spare worker capacity, selected-run preparation workflows, global queued/running work, retry demand, queue health, and inventory completeness
- keep provider totals nullable and expose the estimate as low-confidence `source_rate` evidence without inventing a page percentage
- update the owning API, architecture, user, decision, and reliability documentation

## Why

JobStreaming 0.0.3 exposes cursor-free provider progress, but LinkedIn does not expose a reliable total. JobCtrl previously treated sequential downstream stage rows as simultaneous contention, so Pipelines withheld a defensible source-family ETA even when the shared pool had bounded spare capacity.

## Validation

- API pipeline operations: 51/51 passed
- full API suite: 779 passed
- Pipelines web suite: 39/39 passed
- API and web TypeScript checks passed
- docs build passed with 9,651 references resolved
- independent review and product QA: PASS, 0 Blocker/High/Medium/Low findings
- live read-only verification rendered 2.2 hr-7.9 hr from 9 samples while preserving the null provider total; no layout, console, or request errors
- regression matrix proves pending global work stays dormant, queued/running global work suppresses the estimate, and queue/inventory/retry/capacity uncertainty remains unbounded

## Checklist

- [x] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`).
- [x] I ran the relevant local checks and listed them above.
- [x] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.
