### PR TITLE
fix(pipeline): keep native recovery proof current

### DIFF
--- a/apps/api/src/discovery-execution-recovery.ts
+++ b/apps/api/src/discovery-execution-recovery.ts
@@ -1,0 +1,100 @@
+import { createHash } from "node:crypto";
+
+import { allRows, tableExists, type SqliteDatabase } from "./db.js";
+
+export const CURRENT_DISCOVERY_EXECUTION_DECODER_VERSION = 3;
+
+interface ReadyNativeRecoveryRow {
+  [key: string]: unknown;
+  discover_workflow_id: string;
+  discover_run_id: string;
+}
+
+interface RecoveryMembershipRow {
+  job_id: string;
+}
+
+interface RecoveryStepRow {
+  step_kind: string;
+  item_key: string;
+}
+
+export function recoveryKeyDigest(
+  membershipKeys: readonly string[],
+  stepKeys: ReadonlyArray<readonly [string, string]>,
+): string {
+  const memberships = [...new Set(membershipKeys)].map(utf8Hex).sort();
+  const steps = [...new Set(stepKeys.map((stepKey) => JSON.stringify(stepKey)))]
+    .map(utf8Hex)
+    .sort();
+  return createHash("sha256")
+    .update(JSON.stringify({ memberships, steps }))
+    .digest("hex");
+}
+
+export function advanceReadyNativeRecoveryManifests(
+  db: SqliteDatabase,
+  tenantId: string,
+  updatedAt = new Date().toISOString(),
+): number {
+  if (!tableExists(db, "discovery_execution_recoveries")) return 0;
+
+  const manifests = allRows<ReadyNativeRecoveryRow>(
+    db,
+    `SELECT discover_workflow_id, discover_run_id
+       FROM discovery_execution_recoveries
+      WHERE tenant_id = ? AND state = 'ready' AND mode = 'native'
+        AND decoder_version = ?`,
+    [tenantId, CURRENT_DISCOVERY_EXECUTION_DECODER_VERSION],
+  );
+  const memberships = db.prepare(
+    `SELECT job_id FROM discovery_execution_jobs
+      WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?`,
+  );
+  const steps = db.prepare(
+    `SELECT step_kind, item_key FROM pipeline_step_projections
+      WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?`,
+  );
+  const update = db.prepare(
+    `UPDATE discovery_execution_recoveries
+        SET expected_membership_count = ?, persisted_membership_count = ?,
+            expected_step_count = ?, persisted_step_count = ?,
+            key_digest = ?, last_error_code = NULL, updated_at = ?
+      WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?
+        AND state = 'ready' AND mode = 'native' AND decoder_version = ?`,
+  );
+
+  let changed = 0;
+  for (const manifest of manifests) {
+    const membershipKeys = (memberships.all(
+      tenantId,
+      manifest.discover_workflow_id,
+      manifest.discover_run_id,
+    ) as RecoveryMembershipRow[]).map((row) => row.job_id);
+    const stepKeys = (steps.all(
+      tenantId,
+      manifest.discover_workflow_id,
+      manifest.discover_run_id,
+    ) as RecoveryStepRow[]).map(
+      (row): [string, string] => [row.step_kind, row.item_key],
+    );
+    const result = update.run(
+      membershipKeys.length,
+      membershipKeys.length,
+      stepKeys.length,
+      stepKeys.length,
+      recoveryKeyDigest(membershipKeys, stepKeys),
+      updatedAt,
+      tenantId,
+      manifest.discover_workflow_id,
+      manifest.discover_run_id,
+      CURRENT_DISCOVERY_EXECUTION_DECODER_VERSION,
+    );
+    changed += result.changes;
+  }
+  return changed;
+}
+
+function utf8Hex(value: string): string {
+  return Buffer.from(value, "utf8").toString("hex");
+}

--- a/apps/api/src/pipeline-operations.ts
+++ b/apps/api/src/pipeline-operations.ts
@@ -15,6 +15,10 @@ import type {
 } from "./contracts.js";
 import { allRows, type SqliteDatabase, type SqliteValue } from "./db.js";
 import {
+  CURRENT_DISCOVERY_EXECUTION_DECODER_VERSION,
+  recoveryKeyDigest,
+} from "./discovery-execution-recovery.js";
+import {
   estimatePipelineEta,
   type PipelineEtaEstimatorInput,
   type PipelineEtaStageInput,
@@ -25,8 +29,6 @@ import { readLlmSpendHealth } from "./worker-health.js";
 const DEFAULT_TENANT = "local";
 const ETA_SAMPLE_LIMIT = 50;
 const ETA_SAMPLE_WINDOW_MS = 14 * 24 * 60 * 60 * 1_000;
-const CURRENT_DISCOVERY_EXECUTION_DECODER_VERSION = 3;
-
 const JOB_STAGES = ["enrich", "score", "tailor", "cover"] as const;
 const OPERATIONAL_STAGES = [
   "source_planning",
@@ -934,23 +936,6 @@ function recoveringProjectionCoverage(
     persistedStepCount,
     updatedAt: null,
   };
-}
-
-function recoveryKeyDigest(
-  membershipKeys: readonly string[],
-  stepKeys: ReadonlyArray<readonly [string, string]>,
-): string {
-  const memberships = membershipKeys.map(utf8Hex).sort();
-  const steps = stepKeys
-    .map((stepKey) => utf8Hex(JSON.stringify(stepKey)))
-    .sort();
-  return createHash("sha256")
-    .update(JSON.stringify({ memberships, steps }))
-    .digest("hex");
-}
-
-function utf8Hex(value: string): string {
-  return Buffer.from(value, "utf8").toString("hex");
 }
 
 function positiveIntegerOrNull(value: unknown): number | null {

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -29,6 +29,7 @@ import type {
   PostedCompensationFactResponse,
 } from "./contracts.js";
 import { allRows, getRow, openDatabase, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import { advanceReadyNativeRecoveryManifests } from "./discovery-execution-recovery.js";
 import { normalizeJobLocation } from "./location-normalization.js";
 import { getMarketCompensationEstimate } from "./market-compensation-estimates.js";
 import { getPostedCompensationFact } from "./posted-compensation-facts.js";
@@ -631,6 +632,7 @@ function rebuildPipelineStepProjections(db: SqliteDatabase, tenantId: string): v
         projection.lastUpdatedAt,
       );
     }
+    advanceReadyNativeRecoveryManifests(db, tenantId);
   });
   replace();
 }

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -16,6 +16,7 @@ import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
 import { buildApp } from "../src/server.js";
 import { initializeExactV7Database } from "./v7-schema.js";
 import { REFRESH_EVENT_BATCH_LIMIT, refreshProjections, setWatermark } from "../src/projections.js";
+import { recoveryKeyDigest } from "../src/discovery-execution-recovery.js";
 import { PROJECTION_WATERMARK_NAME } from "../src/contracts.js";
 
 const EVENT_JOB_URL = "https://example.com/jobs/event-driven";
@@ -4013,6 +4014,89 @@ describe("shared watermark discipline", () => {
       .prepare("SELECT last_event_id, updated_at FROM event_watermarks WHERE projection_name = ?")
       .get(PROJECTION_WATERMARK_NAME) as { last_event_id: number; updated_at: string } | undefined;
   }
+
+  it("advances a ready native recovery proof with the pipeline-step fold", () => {
+    const { dbPath, cleanup } = withTempDb();
+    try {
+      seedSchema(dbPath);
+      const db = new Database(dbPath);
+      const workflowId = "discover-native-proof";
+      const runId = "00000000-0000-4000-8000-000000000090";
+      db.prepare(
+        `INSERT INTO discovery_execution_jobs (
+           tenant_id, discover_workflow_id, discover_run_id, job_id,
+           cohort_kind, work_plan_state, linked_at
+         ) VALUES ('local', ?, ?, ?, 'observed_this_run', 'pending', ?)`,
+      ).run(workflowId, runId, EVENT_JOB_ID, "2026-08-13T12:00:00.000Z");
+      db.prepare(
+        `INSERT INTO discovery_execution_recoveries (
+           tenant_id, discover_workflow_id, discover_run_id, state, mode,
+           decoder_version, history_event_id, expected_membership_count,
+           persisted_membership_count, expected_step_count, persisted_step_count,
+           key_digest, last_error_code, updated_at
+         ) VALUES ('local', ?, ?, 'ready', 'native', 3, 12, 1, 1, 0, 0, ?, NULL, ?)`,
+      ).run(
+        workflowId,
+        runId,
+        recoveryKeyDigest([EVENT_JOB_ID], []),
+        "2026-08-13T12:00:00.000Z",
+      );
+      db.prepare(
+        `INSERT INTO job_events (
+           tenant_id, job_id, identity_version, stage, event_type, level,
+           message, occurred_at, payload_json
+         ) VALUES ('local', NULL, 1, 'discover', 'PipelineStepQueued', 'info',
+                   'source family queued', ?, ?)`,
+      ).run(
+        "2026-08-13T12:00:01.000Z",
+        JSON.stringify({
+          execution: {
+            tenantId: "local",
+            workflowId,
+            temporalRunId: runId,
+          },
+          stepKind: "source_family",
+          itemKey: "family:jobspy",
+          attempt: 1,
+          queuedAt: "2026-08-13T12:00:01.000Z",
+          detail: { code: "source_family", itemCount: 1 },
+        }),
+      );
+
+      refreshProjections(db);
+
+      const manifest = db.prepare(
+        `SELECT state, history_event_id, expected_membership_count,
+                persisted_membership_count, expected_step_count,
+                persisted_step_count, key_digest
+           FROM discovery_execution_recoveries
+          WHERE tenant_id = 'local' AND discover_workflow_id = ? AND discover_run_id = ?`,
+      ).get(workflowId, runId) as {
+        state: string;
+        history_event_id: number;
+        expected_membership_count: number;
+        persisted_membership_count: number;
+        expected_step_count: number;
+        persisted_step_count: number;
+        key_digest: string;
+      };
+      expect(manifest).toEqual({
+        state: "ready",
+        history_event_id: 12,
+        expected_membership_count: 1,
+        persisted_membership_count: 1,
+        expected_step_count: 1,
+        persisted_step_count: 1,
+        key_digest: recoveryKeyDigest(
+          [EVENT_JOB_ID],
+          [["source_family", "family:jobspy"]],
+        ),
+      });
+      db.close();
+    } finally {
+      cleanup();
+    }
+  });
 
   it("never rewinds the watermark and keeps updated_at on a stale write", () => {
     const { dbPath, cleanup } = withTempDb();

--- a/docs/api/complete-contract.md
+++ b/docs/api/complete-contract.md
@@ -423,6 +423,15 @@ inventory returns `recovering`, never an invented idle or `ready` checkpoint. A
 ready row is accepted only when its exact persisted counts and canonical key
 digest still match the selected execution.
 
+For `mode = "native"`, later execution-membership writes and pipeline-step
+projection folds carrying the same exact workflow/run identity advance the
+ready checkpoint's counts and digest atomically with those canonical keys. The
+`historyEventId` remains the last reconciled history boundary; it is not
+fabricated from a native database write. Reconstructed checkpoints can advance
+only through history reconciliation. Reading a newer history snapshot does not
+temporarily downgrade an already-verified ready checkpoint; `recovering` is
+published only when the durable proof actually needs rebuilding.
+
 Reconstructed decoder v2 treats append-only workflow-start events—not folded
 workflow projections—as preparation-lineage evidence. Each legacy fanout's
 causal workflow count must equal its declared target count before overlapping

--- a/docs/architecture/pipeline/operations.md
+++ b/docs/architecture/pipeline/operations.md
@@ -298,8 +298,10 @@ it does not restate telemetry freshness. Its states are:
 
 - `ready`: the worker decoded one exact Temporal workflow/run history, refreshed
   its projections, and verified equality of the expected and persisted
-  membership-key and pipeline-step-key sets at the recorded history-event
-  watermark;
+  membership-key and pipeline-step-key sets. For native runs, later canonical
+  writes carrying that same execution identity advance the verified key-set
+  proof atomically while the history-event watermark remains the last audited
+  history boundary;
 - `recovering`: startup or heartbeat reconciliation is rebuilding those exact
   sets;
 - `retrying`: the latest safe reconciliation attempt refused an ambiguous input
@@ -316,6 +318,16 @@ counts, a digest of both canonical key sets, and a bounded error code. A
 `ready` row is valid only while its counts and digest still match the current
 durable rows. Row counts alone, workflow terminal state, and runtime telemetry
 can never promote an execution to `ready`.
+
+Once a native checkpoint is ready, linking a new execution member and folding a
+new pipeline-step key update that checkpoint's counts and digest in the same
+SQLite transaction as the canonical write. Both the Python and TypeScript
+projection owners apply the identical digest algorithm. A failed proof update
+therefore rolls back the native key write instead of exposing a one-row-ahead
+`recovering` snapshot. Reconstructed checkpoints never use this path; their
+expected sets remain exclusively owned by history reconciliation. A heartbeat
+also keeps an already-verified checkpoint visible while it reads history and
+publishes `recovering` only after it has evidence that repair is needed.
 
 The worker runs reconciliation before accepting activities and again on every
 heartbeat. Legacy activity history is decoded into queued, running, completed,

--- a/workers/automation/src/jobctrl/discovery/execution_reconciliation.py
+++ b/workers/automation/src/jobctrl/discovery/execution_reconciliation.py
@@ -9,7 +9,6 @@ that Temporal proves terminal after the activity process stopped reporting.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import sqlite3
@@ -38,6 +37,10 @@ from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.discovery.sqlite_execution_repository import (
     SqliteDiscoveryExecutionRepository,
 )
+from jobctrl.infrastructure.discovery.recovery_manifest import (
+    CURRENT_DISCOVERY_EXECUTION_DECODER_VERSION,
+    recovery_key_digest,
+)
 from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
 from jobctrl.state import record_job_event
 
@@ -52,7 +55,7 @@ _DISCOVERY_ACTIVITY_TYPES = frozenset(
     }
 )
 _STEP_ORDER = ("score", "tailor", "cover", "pdf")
-_DECODER_VERSION = 3
+_DECODER_VERSION = CURRENT_DISCOVERY_EXECUTION_DECODER_VERSION
 _LEGACY_WORK_PLAN_REASON_CODE = "legacy_history_recovery"
 _HISTORY_READ_ERROR_CODE = "temporal-history-read-failed"
 
@@ -455,24 +458,6 @@ async def reconcile_legacy_discovery_execution(
         temporal_run_id=temporal_run_id,
     )
     repository = SqliteDiscoveryExecutionRepository(connection)
-    current_manifest = connection.execute(
-        """
-        SELECT * FROM discovery_execution_recoveries
-        WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?
-        """,
-        (tenant_id, workflow_id, temporal_run_id),
-    ).fetchone()
-    current_manifest_was_verified = current_manifest is not None and _recovery_manifest_matches_persisted_keys(
-        connection,
-        tenant_id=tenant_id,
-        workflow_id=workflow_id,
-        temporal_run_id=temporal_run_id,
-    )
-    _transition_existing_recovery_manifest(
-        connection,
-        execution,
-        state="recovering",
-    )
     try:
         handle = temporal_client.get_workflow_handle(workflow_id, run_id=temporal_run_id)
         normalized = await _normalize_temporal_history(handle, temporal_client.data_converter)
@@ -486,20 +471,22 @@ async def reconcile_legacy_discovery_execution(
         raise
     history_event_id = max((_safe_int(record.get("history_event_id")) for record in normalized), default=0)
     history_snapshot_at = max((str(record.get("event_time") or "") for record in normalized), default="")
-    existing_membership_keys = _persisted_membership_keys(connection, tenant_id, workflow_id, temporal_run_id)
-    existing_step_keys = _persisted_step_keys(connection, tenant_id, workflow_id, temporal_run_id)
-    if (
-        current_manifest is not None
-        and str(current_manifest["state"]) == "ready"
-        and current_manifest_was_verified
-        and int(current_manifest["decoder_version"]) == _DECODER_VERSION
-        and int(current_manifest["history_event_id"]) >= history_event_id
-        and _recovery_manifest_snapshot_matches_keys(
-            current_manifest,
-            existing_membership_keys,
-            existing_step_keys,
-        )
-    ):
+    # Native writers may advance a ready proof while Temporal history is being
+    # read. Re-read after the await so the fast path validates the current
+    # atomic proof instead of downgrading a newer, still-valid checkpoint.
+    verified_snapshot = _verified_recovery_manifest_snapshot(
+        connection,
+        tenant_id=tenant_id,
+        workflow_id=workflow_id,
+        temporal_run_id=temporal_run_id,
+    )
+    if verified_snapshot is not None:
+        current_manifest, existing_membership_keys, existing_step_keys = verified_snapshot
+    else:
+        current_manifest = None
+        existing_membership_keys = _persisted_membership_keys(connection, tenant_id, workflow_id, temporal_run_id)
+        existing_step_keys = _persisted_step_keys(connection, tenant_id, workflow_id, temporal_run_id)
+    if current_manifest is not None and int(current_manifest["history_event_id"]) >= history_event_id:
         _transition_existing_recovery_manifest(
             connection,
             execution,
@@ -1298,95 +1285,93 @@ def _recovery_manifest_matches_persisted_keys(
 ) -> bool:
     """Return whether a ready manifest still proves the current exact key sets."""
 
-    try:
-        manifest = conn.execute(
-            """
-            SELECT state, mode, decoder_version, history_event_id,
-                   expected_membership_count, persisted_membership_count,
-                   expected_step_count, persisted_step_count, key_digest,
-                   updated_at
-            FROM discovery_execution_recoveries
-            WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?
-            """,
-            (tenant_id, workflow_id, temporal_run_id),
-        ).fetchone()
-        if manifest is None:
-            return False
-        memberships = _persisted_membership_keys(conn, tenant_id, workflow_id, temporal_run_id)
-        steps = _persisted_step_keys(conn, tenant_id, workflow_id, temporal_run_id)
-        manifest_integers = {
-            field: int(manifest[field])
-            for field in (
-                "decoder_version",
-                "history_event_id",
-                "expected_membership_count",
-                "persisted_membership_count",
-                "expected_step_count",
-                "persisted_step_count",
-            )
-        }
-    except (KeyError, TypeError, ValueError, sqlite3.OperationalError):
-        return False
-
-    membership_count = len(memberships)
-    step_count = len(steps)
     return (
-        str(manifest["state"]) == "ready"
-        and str(manifest["mode"]) in {"native", "reconstructed"}
-        and manifest_integers["decoder_version"] == _DECODER_VERSION
-        and manifest_integers["history_event_id"] >= 0
-        and manifest_integers["expected_membership_count"] == membership_count
-        and manifest_integers["persisted_membership_count"] == membership_count
-        and manifest_integers["expected_step_count"] == step_count
-        and manifest_integers["persisted_step_count"] == step_count
-        and str(manifest["key_digest"]) == _recovery_key_digest(memberships, steps)
-        and bool(str(manifest["updated_at"] or "").strip())
+        _verified_recovery_manifest_snapshot(
+            conn,
+            tenant_id=tenant_id,
+            workflow_id=workflow_id,
+            temporal_run_id=temporal_run_id,
+        )
+        is not None
     )
 
 
-def _recovery_manifest_snapshot_matches_keys(
-    manifest: Any,
-    memberships: set[str],
-    steps: set[tuple[str, str]],
-) -> bool:
-    """Revalidate a pre-read ready snapshot after its state was downgraded."""
+def _verified_recovery_manifest_snapshot(
+    conn: Any,
+    *,
+    tenant_id: str,
+    workflow_id: str,
+    temporal_run_id: str,
+) -> tuple[Any, set[str], set[tuple[str, str]]] | None:
+    """Read one internally consistent ready proof without blocking writers.
 
-    try:
-        return (
-            int(manifest["expected_membership_count"]) == len(memberships)
-            and int(manifest["persisted_membership_count"]) == len(memberships)
-            and int(manifest["expected_step_count"]) == len(steps)
-            and int(manifest["persisted_step_count"]) == len(steps)
-            and str(manifest["key_digest"]) == _recovery_key_digest(memberships, steps)
-        )
-    except (KeyError, TypeError, ValueError):
-        return False
+    Native writers update their key and proof atomically, but may commit between
+    individual SELECT statements here. Reading the manifest both before and
+    after its key sets lets us retry that narrow interleaving. A writer that
+    commits after the second read cannot invalidate the captured snapshot: the
+    older manifest and key sets remain mutually consistent and the writer's
+    newer proof is also ready.
+    """
+
+    query = """
+        SELECT state, mode, decoder_version, history_event_id,
+               expected_membership_count, persisted_membership_count,
+               expected_step_count, persisted_step_count, key_digest,
+               updated_at
+        FROM discovery_execution_recoveries
+        WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?
+    """
+    params = (tenant_id, workflow_id, temporal_run_id)
+    for _attempt in range(8):
+        try:
+            before = conn.execute(query, params).fetchone()
+            if before is None:
+                return None
+            memberships = _persisted_membership_keys(conn, tenant_id, workflow_id, temporal_run_id)
+            steps = _persisted_step_keys(conn, tenant_id, workflow_id, temporal_run_id)
+            after = conn.execute(query, params).fetchone()
+            if after is None:
+                return None
+            if tuple(before) != tuple(after):
+                continue
+            manifest_integers = {
+                field: int(after[field])
+                for field in (
+                    "decoder_version",
+                    "history_event_id",
+                    "expected_membership_count",
+                    "persisted_membership_count",
+                    "expected_step_count",
+                    "persisted_step_count",
+                )
+            }
+        except (KeyError, TypeError, ValueError, sqlite3.OperationalError):
+            return None
+
+        membership_count = len(memberships)
+        step_count = len(steps)
+        if (
+            str(after["state"]) == "ready"
+            and str(after["mode"]) in {"native", "reconstructed"}
+            and manifest_integers["decoder_version"] == _DECODER_VERSION
+            and manifest_integers["history_event_id"] >= 0
+            and manifest_integers["expected_membership_count"] == membership_count
+            and manifest_integers["persisted_membership_count"] == membership_count
+            and manifest_integers["expected_step_count"] == step_count
+            and manifest_integers["persisted_step_count"] == step_count
+            and str(after["key_digest"]) == _recovery_key_digest(memberships, steps)
+            and bool(str(after["updated_at"] or "").strip())
+        ):
+            return after, memberships, steps
+        return None
+    return None
 
 
 def _recovery_key_digest(
     memberships: set[str],
     steps: set[tuple[str, str]],
 ) -> str:
-    def key_hex(value: str) -> str:
-        return value.encode("utf-8").hex()
-
-    canonical = json.dumps(
-        {
-            "memberships": sorted(key_hex(value) for value in memberships),
-            "steps": sorted(
-                key_hex(
-                    json.dumps(
-                        [step_kind, item_key],
-                        ensure_ascii=False,
-                        separators=(",", ":"),
-                    )
-                )
-                for step_kind, item_key in steps
-            ),
-        },
-        separators=(",", ":"),
-    )
-    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return recovery_key_digest(memberships, steps)
 
 
 def _mapping(value: object) -> dict[str, Any]:

--- a/workers/automation/src/jobctrl/infrastructure/discovery/recovery_manifest.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/recovery_manifest.py
@@ -1,0 +1,216 @@
+"""Keep native Discover recovery proofs aligned with canonical live writes.
+
+The Temporal history reconciler proves the historical boundary.  After that
+boundary, native writers carry the exact Discover execution identity and can
+advance the same key-set proof in their own transaction.  Reconstructed
+histories remain owned exclusively by the reconciler.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from collections.abc import Iterable
+from datetime import UTC, datetime
+
+
+CURRENT_DISCOVERY_EXECUTION_DECODER_VERSION = 3
+
+
+def recovery_key_digest(
+    membership_keys: Iterable[str],
+    step_keys: Iterable[tuple[str, str]],
+) -> str:
+    """Return the cross-runtime digest for one execution's exact key sets."""
+
+    def key_hex(value: str) -> str:
+        return value.encode("utf-8").hex()
+
+    canonical = json.dumps(
+        {
+            "memberships": sorted(key_hex(value) for value in set(membership_keys)),
+            "steps": sorted(
+                key_hex(
+                    json.dumps(
+                        [step_kind, item_key],
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    )
+                )
+                for step_kind, item_key in set(step_keys)
+            ),
+        },
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def advance_ready_native_recovery_manifest(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    workflow_id: str,
+    temporal_run_id: str,
+    updated_at: str | None = None,
+) -> bool:
+    """Advance one verified native proof inside the caller's transaction.
+
+    Missing recovery/projection tables mean the repository is running against
+    a deliberately minimal compatibility fixture and therefore has no proof to
+    advance.  Other database errors are allowed to escape so the canonical
+    write and its proof roll back together.
+    """
+
+    try:
+        manifest = conn.execute(
+            """
+            SELECT state, mode, decoder_version
+            FROM discovery_execution_recoveries
+            WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?
+            """,
+            (tenant_id, workflow_id, temporal_run_id),
+        ).fetchone()
+    except sqlite3.OperationalError as exc:
+        if _is_missing_table(exc):
+            return False
+        raise
+    if manifest is None:
+        return False
+
+    state = str(_row_value(manifest, "state", 0))
+    mode = str(_row_value(manifest, "mode", 1))
+    try:
+        decoder_version = int(_row_value(manifest, "decoder_version", 2))
+    except (TypeError, ValueError):
+        return False
+    if state != "ready" or mode != "native" or decoder_version != CURRENT_DISCOVERY_EXECUTION_DECODER_VERSION:
+        return False
+
+    memberships = _membership_keys(conn, tenant_id, workflow_id, temporal_run_id)
+    steps = _step_keys(conn, tenant_id, workflow_id, temporal_run_id)
+    membership_count = len(memberships)
+    step_count = len(steps)
+    cursor = conn.execute(
+        """
+        UPDATE discovery_execution_recoveries
+        SET expected_membership_count = ?, persisted_membership_count = ?,
+            expected_step_count = ?, persisted_step_count = ?,
+            key_digest = ?, last_error_code = NULL, updated_at = ?
+        WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?
+          AND state = 'ready' AND mode = 'native' AND decoder_version = ?
+        """,
+        (
+            membership_count,
+            membership_count,
+            step_count,
+            step_count,
+            recovery_key_digest(memberships, steps),
+            updated_at or datetime.now(UTC).isoformat(),
+            tenant_id,
+            workflow_id,
+            temporal_run_id,
+            CURRENT_DISCOVERY_EXECUTION_DECODER_VERSION,
+        ),
+    )
+    return bool(cursor.rowcount)
+
+
+def advance_ready_native_recovery_manifests_for_tenant(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    updated_at: str | None = None,
+) -> int:
+    """Advance every ready native proof after a tenant step-projection fold."""
+
+    try:
+        rows = conn.execute(
+            """
+            SELECT discover_workflow_id, discover_run_id
+            FROM discovery_execution_recoveries
+            WHERE tenant_id = ? AND state = 'ready' AND mode = 'native'
+              AND decoder_version = ?
+            """,
+            (tenant_id, CURRENT_DISCOVERY_EXECUTION_DECODER_VERSION),
+        ).fetchall()
+    except sqlite3.OperationalError as exc:
+        if _is_missing_table(exc):
+            return 0
+        raise
+
+    changed = 0
+    for row in rows:
+        workflow_id = str(_row_value(row, "discover_workflow_id", 0))
+        temporal_run_id = str(_row_value(row, "discover_run_id", 1))
+        changed += int(
+            advance_ready_native_recovery_manifest(
+                conn,
+                tenant_id=tenant_id,
+                workflow_id=workflow_id,
+                temporal_run_id=temporal_run_id,
+                updated_at=updated_at,
+            )
+        )
+    return changed
+
+
+def _membership_keys(
+    conn: sqlite3.Connection,
+    tenant_id: str,
+    workflow_id: str,
+    temporal_run_id: str,
+) -> set[str]:
+    rows = conn.execute(
+        """
+        SELECT job_id FROM discovery_execution_jobs
+        WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?
+        """,
+        (tenant_id, workflow_id, temporal_run_id),
+    ).fetchall()
+    return {str(_row_value(row, "job_id", 0)) for row in rows}
+
+
+def _step_keys(
+    conn: sqlite3.Connection,
+    tenant_id: str,
+    workflow_id: str,
+    temporal_run_id: str,
+) -> set[tuple[str, str]]:
+    try:
+        rows = conn.execute(
+            """
+            SELECT step_kind, item_key FROM pipeline_step_projections
+            WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?
+            """,
+            (tenant_id, workflow_id, temporal_run_id),
+        ).fetchall()
+    except sqlite3.OperationalError as exc:
+        if _is_missing_table(exc):
+            return set()
+        raise
+    return {
+        (
+            str(_row_value(row, "step_kind", 0)),
+            str(_row_value(row, "item_key", 1)),
+        )
+        for row in rows
+    }
+
+
+def _row_value(row: object, key: str, index: int) -> object:
+    if isinstance(row, sqlite3.Row):
+        return row[key]
+    return row[index]  # type: ignore[index]
+
+
+def _is_missing_table(exc: sqlite3.OperationalError) -> bool:
+    return "no such table" in str(exc).lower()
+
+
+__all__ = [
+    "CURRENT_DISCOVERY_EXECUTION_DECODER_VERSION",
+    "advance_ready_native_recovery_manifest",
+    "advance_ready_native_recovery_manifests_for_tenant",
+    "recovery_key_digest",
+]

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_execution_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_execution_repository.py
@@ -18,6 +18,9 @@ from jobctrl.domain.discovery.execution import (
     validate_work_plan_state,
 )
 from jobctrl.domain.identifiers import JobId, canonical_job_id
+from jobctrl.infrastructure.discovery.recovery_manifest import (
+    advance_ready_native_recovery_manifest,
+)
 
 
 _SELECT_COLUMNS = """
@@ -104,6 +107,12 @@ class SqliteDiscoveryExecutionRepository:
                     linked,
                 ),
             )
+            advance_ready_native_recovery_manifest(
+                self._conn,
+                tenant_id=execution.tenant_id,
+                workflow_id=execution.workflow_id,
+                temporal_run_id=execution.temporal_run_id,
+            )
 
         result = self.get(execution, stable_job_id)
         if result is None:  # pragma: no cover - defensive database invariant
@@ -154,9 +163,7 @@ class SqliteDiscoveryExecutionRepository:
             raise KeyError(f"Job is not linked to discovery execution: {stable_job_id}")
 
         desired_steps_json = (
-            json.dumps(list(normalized_steps), separators=(",", ":"))
-            if normalized_steps is not None
-            else None
+            json.dumps(list(normalized_steps), separators=(",", ":")) if normalized_steps is not None else None
         )
         if existing.work_plan_state in {"planned", "not_eligible"}:
             desired = (
@@ -175,10 +182,7 @@ class SqliteDiscoveryExecutionRepository:
                 raise ValueError("A decided discovery execution work plan is immutable")
             return existing
 
-        if (
-            existing.preparation_workflow_id is not None
-            and normalized_workflow_id != existing.preparation_workflow_id
-        ):
+        if existing.preparation_workflow_id is not None and normalized_workflow_id != existing.preparation_workflow_id:
             raise ValueError("preparation_workflow_id is immutable once assigned")
 
         with self._conn:

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -67,6 +67,9 @@ from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.compensation.benchmark_lineage import (
     load_market_benchmark_lineage,
 )
+from jobctrl.infrastructure.discovery.recovery_manifest import (
+    advance_ready_native_recovery_manifests_for_tenant,
+)
 from jobctrl.infrastructure.events.watermark import SqliteEventWatermarkRepository
 from jobctrl.infrastructure.projections.location_normalization import (
     normalize_job_location,
@@ -3531,49 +3534,61 @@ class ProjectionBuilder:
                 last_updated_at=event["occurred_at"],
             )
 
-        self._conn.execute(
-            "DELETE FROM pipeline_step_projections WHERE tenant_id = ?",
-            (str(self._tenant_id),),
-        )
-        insert = self._conn.execute
-        for projection in sorted(
-            folded.values(),
-            key=lambda item: (
-                item.workflow_id,
-                item.temporal_run_id,
-                item.step_kind,
-                item.item_key,
-            ),
-        ):
-            insert(
-                """
-                INSERT INTO pipeline_step_projections (
-                    tenant_id, discover_workflow_id, discover_run_id, step_kind,
-                    item_key, state, attempt, queued_at, started_at, finished_at,
-                    duration_ms, error_code, retryable, detail_code, detail_count,
-                    last_event_id, last_updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    projection.tenant_id,
-                    projection.workflow_id,
-                    projection.temporal_run_id,
-                    projection.step_kind,
-                    projection.item_key,
-                    projection.state,
-                    projection.attempt,
-                    projection.queued_at,
-                    projection.started_at,
-                    projection.finished_at,
-                    projection.duration_ms,
-                    projection.error_code,
-                    1 if projection.retryable else 0,
-                    projection.detail_code,
-                    projection.detail_count,
-                    projection.last_event_id,
-                    projection.last_updated_at,
-                ),
+        savepoint = "pipeline_step_recovery_proof_fold"
+        self._conn.execute(f"SAVEPOINT {savepoint}")
+        try:
+            self._conn.execute(
+                "DELETE FROM pipeline_step_projections WHERE tenant_id = ?",
+                (str(self._tenant_id),),
             )
+            insert = self._conn.execute
+            for projection in sorted(
+                folded.values(),
+                key=lambda item: (
+                    item.workflow_id,
+                    item.temporal_run_id,
+                    item.step_kind,
+                    item.item_key,
+                ),
+            ):
+                insert(
+                    """
+                    INSERT INTO pipeline_step_projections (
+                        tenant_id, discover_workflow_id, discover_run_id, step_kind,
+                        item_key, state, attempt, queued_at, started_at, finished_at,
+                        duration_ms, error_code, retryable, detail_code, detail_count,
+                        last_event_id, last_updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        projection.tenant_id,
+                        projection.workflow_id,
+                        projection.temporal_run_id,
+                        projection.step_kind,
+                        projection.item_key,
+                        projection.state,
+                        projection.attempt,
+                        projection.queued_at,
+                        projection.started_at,
+                        projection.finished_at,
+                        projection.duration_ms,
+                        projection.error_code,
+                        1 if projection.retryable else 0,
+                        projection.detail_code,
+                        projection.detail_count,
+                        projection.last_event_id,
+                        projection.last_updated_at,
+                    ),
+                )
+            advance_ready_native_recovery_manifests_for_tenant(
+                self._conn,
+                tenant_id=str(self._tenant_id),
+            )
+        except BaseException:
+            self._conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+            self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+            raise
+        self._conn.execute(f"RELEASE SAVEPOINT {savepoint}")
 
     def _parse_pipeline_step_event(self, row: object) -> dict[str, Any] | None:
         if isinstance(row, tuple):

--- a/workers/automation/tests/test_discovery_execution_identity.py
+++ b/workers/automation/tests/test_discovery_execution_identity.py
@@ -7,6 +7,8 @@ import pytest
 from jobctrl.database import close_connection, init_db
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.identifiers import JobId
+from jobctrl.infrastructure.discovery import sqlite_execution_repository
+from jobctrl.infrastructure.discovery.recovery_manifest import recovery_key_digest
 from jobctrl.infrastructure.discovery.sqlite_execution_repository import (
     SqliteDiscoveryExecutionRepository,
 )
@@ -94,6 +96,68 @@ def test_execution_membership_is_tenant_scoped_and_keyed_by_job_id(
     assert tuple(row) == ("local", str(job_id))
 
 
+def test_native_membership_write_advances_ready_recovery_proof_atomically(
+    execution_db,
+    monkeypatch,
+) -> None:
+    first_id = JobId("00000000-0000-4000-8000-000000000011")
+    second_id = JobId("00000000-0000-4000-8000-000000000012")
+    _insert_job(execution_db, first_id)
+    _insert_job(execution_db, second_id)
+    repository = SqliteDiscoveryExecutionRepository(execution_db)
+    execution = _execution()
+    repository.link_job(execution, first_id, cohort_kind="existing_backlog")
+    initial_digest = recovery_key_digest({str(first_id)}, set())
+    execution_db.execute(
+        """
+        INSERT INTO discovery_execution_recoveries (
+            tenant_id, discover_workflow_id, discover_run_id, state, mode,
+            decoder_version, history_event_id, expected_membership_count,
+            persisted_membership_count, expected_step_count,
+            persisted_step_count, key_digest, last_error_code, updated_at
+        ) VALUES (?, ?, ?, 'ready', 'native', 3, 12, 1, 1, 0, 0, ?, NULL, ?)
+        """,
+        (
+            execution.tenant_id,
+            execution.workflow_id,
+            execution.temporal_run_id,
+            initial_digest,
+            "2026-08-13T12:00:00+00:00",
+        ),
+    )
+    execution_db.commit()
+
+    repository.link_job(execution, second_id, cohort_kind="existing_backlog")
+
+    manifest = execution_db.execute("SELECT * FROM discovery_execution_recoveries").fetchone()
+    assert manifest["state"] == "ready"
+    assert manifest["history_event_id"] == 12
+    assert manifest["expected_membership_count"] == 2
+    assert manifest["persisted_membership_count"] == 2
+    assert manifest["expected_step_count"] == 0
+    assert manifest["persisted_step_count"] == 0
+    assert manifest["key_digest"] == recovery_key_digest({str(first_id), str(second_id)}, set())
+
+    def interrupt_proof(*_args, **_kwargs):
+        raise KeyboardInterrupt
+
+    third_id = JobId("00000000-0000-4000-8000-000000000013")
+    _insert_job(execution_db, third_id)
+    monkeypatch.setattr(
+        sqlite_execution_repository,
+        "advance_ready_native_recovery_manifest",
+        interrupt_proof,
+    )
+    with pytest.raises(KeyboardInterrupt):
+        repository.link_job(execution, third_id, cohort_kind="existing_backlog")
+
+    assert repository.get(execution, third_id) is None
+    unchanged = execution_db.execute("SELECT * FROM discovery_execution_recoveries").fetchone()
+    assert unchanged["expected_membership_count"] == 2
+    assert unchanged["persisted_membership_count"] == 2
+    assert unchanged["key_digest"] == manifest["key_digest"]
+
+
 def test_execution_membership_rejects_url_shaped_and_unknown_identity(
     execution_db,
 ) -> None:
@@ -114,9 +178,7 @@ def test_execution_membership_rejects_url_shaped_and_unknown_identity(
             cohort_kind="existing_backlog",
         )
 
-    assert execution_db.execute(
-        "SELECT COUNT(*) FROM discovery_execution_jobs"
-    ).fetchone()[0] == 0
+    assert execution_db.execute("SELECT COUNT(*) FROM discovery_execution_jobs").fetchone()[0] == 0
 
 
 @pytest.mark.parametrize(
@@ -139,9 +201,7 @@ def test_execution_membership_rejects_whitespace_wrapped_identity(
             cohort_kind="existing_backlog",
         )
 
-    assert execution_db.execute(
-        "SELECT COUNT(*) FROM discovery_execution_jobs"
-    ).fetchone()[0] == 0
+    assert execution_db.execute("SELECT COUNT(*) FROM discovery_execution_jobs").fetchone()[0] == 0
 
 
 def test_execution_membership_cannot_cross_tenants(execution_db) -> None:
@@ -156,9 +216,7 @@ def test_execution_membership_cannot_cross_tenants(execution_db) -> None:
             cohort_kind="existing_backlog",
         )
 
-    assert execution_db.execute(
-        "SELECT COUNT(*) FROM discovery_execution_jobs"
-    ).fetchone()[0] == 0
+    assert execution_db.execute("SELECT COUNT(*) FROM discovery_execution_jobs").fetchone()[0] == 0
 
 
 def test_work_plan_retry_is_exact_and_memberships_order_by_job_id(
@@ -198,10 +256,7 @@ def test_work_plan_retry_is_exact_and_memberships_order_by_job_id(
 
     assert replay == planned
     assert planned.required_steps == ("score", "tailor")
-    assert [
-        membership.job_id
-        for membership in repository.list_for_execution(execution)
-    ] == [first_id, second_id]
+    assert [membership.job_id for membership in repository.list_for_execution(execution)] == [first_id, second_id]
     with pytest.raises(ValueError, match="immutable"):
         repository.set_work_plan(
             execution,

--- a/workers/automation/tests/test_discovery_execution_reconciliation.py
+++ b/workers/automation/tests/test_discovery_execution_reconciliation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import sqlite3
 import uuid
@@ -7,6 +8,7 @@ import uuid
 import pytest
 
 import jobctrl.discovery.execution_reconciliation as execution_reconciliation
+import jobctrl.infrastructure.projections.projection_builder as projection_builder_module
 from jobctrl.database import init_db
 from jobctrl.discovery.execution_reconciliation import (
     LegacyActivityAttempt,
@@ -1217,7 +1219,6 @@ async def test_ready_manifest_retries_history_read_without_losing_durable_proof(
         table: [dict(row) for row in conn.execute(f"SELECT * FROM {table} ORDER BY rowid").fetchall()]
         for table in durable_rows
     } == durable_rows
-
     result = await execution_reconciliation.reconcile_legacy_discovery_execution(
         FakeClient(),
         workflow_id=execution.workflow_id,
@@ -1246,6 +1247,373 @@ async def test_ready_manifest_retries_history_read_without_losing_durable_proof(
         table: [dict(row) for row in conn.execute(f"SELECT * FROM {table} ORDER BY rowid").fetchall()]
         for table in durable_rows
     } == durable_rows
+
+
+@pytest.mark.asyncio
+async def test_verified_ready_manifest_stays_ready_while_history_is_probed(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    conn = init_db(tmp_path / "ready-history-probe.db")
+    execution = DiscoveryExecutionRef(
+        tenant_id="local",
+        workflow_id="discover-local",
+        temporal_run_id="run-ready-history-probe",
+    )
+    job_id = str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:ready-history-probe"))
+    _seed_v7_job(conn, job_id)
+    SqliteDiscoveryExecutionRepository(conn).link_job(
+        execution,
+        job_id,
+        cohort_kind="existing_backlog",
+    )
+    _write_recovery_manifest(
+        conn,
+        execution,
+        state="ready",
+        mode="native",
+        history_event_id=12,
+        expected_memberships=1,
+        persisted_memberships=1,
+        expected_steps=0,
+        persisted_steps=0,
+        key_digest=_recovery_key_digest({job_id}, set()),
+    )
+    ready_updated_at = conn.execute("SELECT updated_at FROM discovery_execution_recoveries").fetchone()[0]
+    probe_started = asyncio.Event()
+    release_probe = asyncio.Event()
+    recovery_states: list[str] = []
+
+    async def normalized_history(_handle, _converter):
+        probe_started.set()
+        await release_probe.wait()
+        return [
+            {
+                "kind": "watermark",
+                "history_event_id": 12,
+                "event_time": "2026-08-13T12:00:00+00:00",
+            }
+        ]
+
+    monkeypatch.setattr(
+        execution_reconciliation,
+        "_normalize_temporal_history",
+        normalized_history,
+    )
+    original_write_manifest = execution_reconciliation._write_recovery_manifest
+
+    def record_manifest_write(*args, **kwargs):
+        recovery_states.append(str(kwargs["state"]))
+        return original_write_manifest(*args, **kwargs)
+
+    monkeypatch.setattr(
+        execution_reconciliation,
+        "_write_recovery_manifest",
+        record_manifest_write,
+    )
+
+    class FakeClient:
+        data_converter = object()
+
+        @staticmethod
+        def get_workflow_handle(_workflow_id, *, run_id):
+            assert run_id == execution.temporal_run_id
+            return object()
+
+    task = asyncio.create_task(
+        execution_reconciliation.reconcile_legacy_discovery_execution(
+            FakeClient(),
+            workflow_id=execution.workflow_id,
+            temporal_run_id=execution.temporal_run_id,
+            conn=conn,
+        )
+    )
+    await probe_started.wait()
+    probing_manifest = conn.execute("SELECT state, updated_at FROM discovery_execution_recoveries").fetchone()
+    assert tuple(probing_manifest) == ("ready", ready_updated_at)
+
+    concurrent_job_id = str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:ready-history-probe-concurrent"))
+    _seed_v7_job(conn, concurrent_job_id)
+    SqliteDiscoveryExecutionRepository(conn).link_job(
+        execution,
+        concurrent_job_id,
+        cohort_kind="observed_this_run",
+        source_family="jobspy",
+    )
+    advanced_manifest = conn.execute(
+        """
+        SELECT state, expected_membership_count, persisted_membership_count
+        FROM discovery_execution_recoveries
+        """
+    ).fetchone()
+    assert tuple(advanced_manifest) == ("ready", 2, 2)
+
+    release_probe.set()
+    await task
+    final_manifest = conn.execute(
+        """
+        SELECT state, expected_membership_count, persisted_membership_count
+        FROM discovery_execution_recoveries
+        """
+    ).fetchone()
+    assert tuple(final_manifest) == ("ready", 2, 2)
+    assert "recovering" not in recovery_states
+
+
+@pytest.mark.asyncio
+async def test_verified_ready_manifest_retries_a_native_write_during_proof_validation(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    conn = init_db(tmp_path / "ready-proof-validation-race.db")
+    execution = DiscoveryExecutionRef(
+        tenant_id="local",
+        workflow_id="discover-local",
+        temporal_run_id="run-ready-proof-validation-race",
+    )
+    first_job_id = str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:ready-proof-validation-first"))
+    second_job_id = str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:ready-proof-validation-second"))
+    _seed_v7_job(conn, first_job_id)
+    _seed_v7_job(conn, second_job_id)
+    repository = SqliteDiscoveryExecutionRepository(conn)
+    repository.link_job(
+        execution,
+        first_job_id,
+        cohort_kind="existing_backlog",
+    )
+    _write_recovery_manifest(
+        conn,
+        execution,
+        state="ready",
+        mode="native",
+        history_event_id=12,
+        expected_memberships=1,
+        persisted_memberships=1,
+        expected_steps=0,
+        persisted_steps=0,
+        key_digest=_recovery_key_digest({first_job_id}, set()),
+    )
+    original_membership_keys = execution_reconciliation._persisted_membership_keys
+    inserted = False
+    recovery_states: list[str] = []
+
+    def membership_keys_with_native_write(*args, **kwargs):
+        nonlocal inserted
+        if not inserted:
+            inserted = True
+            repository.link_job(
+                execution,
+                second_job_id,
+                cohort_kind="observed_this_run",
+                source_family="jobspy",
+            )
+        return original_membership_keys(*args, **kwargs)
+
+    monkeypatch.setattr(
+        execution_reconciliation,
+        "_persisted_membership_keys",
+        membership_keys_with_native_write,
+    )
+    original_write_manifest = execution_reconciliation._write_recovery_manifest
+
+    def record_manifest_write(*args, **kwargs):
+        recovery_states.append(str(kwargs["state"]))
+        return original_write_manifest(*args, **kwargs)
+
+    monkeypatch.setattr(
+        execution_reconciliation,
+        "_write_recovery_manifest",
+        record_manifest_write,
+    )
+
+    class FakeClient:
+        data_converter = object()
+
+        @staticmethod
+        def get_workflow_handle(_workflow_id, *, run_id):
+            assert run_id == execution.temporal_run_id
+            return object()
+
+    async def normalized_history(_handle, _converter):
+        return [
+            {
+                "kind": "watermark",
+                "history_event_id": 12,
+                "event_time": "2026-08-13T12:00:00+00:00",
+            }
+        ]
+
+    monkeypatch.setattr(
+        execution_reconciliation,
+        "_normalize_temporal_history",
+        normalized_history,
+    )
+
+    await execution_reconciliation.reconcile_legacy_discovery_execution(
+        FakeClient(),
+        workflow_id=execution.workflow_id,
+        temporal_run_id=execution.temporal_run_id,
+        conn=conn,
+    )
+
+    manifest = conn.execute(
+        """
+        SELECT state, expected_membership_count, persisted_membership_count
+        FROM discovery_execution_recoveries
+        """
+    ).fetchone()
+    assert tuple(manifest) == ("ready", 2, 2)
+    assert "recovering" not in recovery_states
+
+
+def test_native_pipeline_step_fold_advances_ready_recovery_proof(tmp_path) -> None:
+    conn = init_db(tmp_path / "native-step-proof.db")
+    execution = DiscoveryExecutionRef(
+        tenant_id="local",
+        workflow_id="discover-local",
+        temporal_run_id="run-native-step-proof",
+    )
+    job_id = str(uuid.uuid5(uuid.NAMESPACE_URL, "jobctrl:native-step-proof"))
+    _seed_v7_job(conn, job_id)
+    SqliteDiscoveryExecutionRepository(conn).link_job(
+        execution,
+        job_id,
+        cohort_kind="observed_this_run",
+        source_family="jobspy",
+    )
+    _append_native_completed_step(
+        conn,
+        execution,
+        step_kind="source_planning",
+        item_key="plan",
+        detail_code="source_plan",
+    )
+    conn.commit()
+    builder = ProjectionBuilder(
+        conn_factory=lambda: conn,
+        tenant_id=TenantId(execution.tenant_id),
+    )
+    builder.refresh()
+    _write_recovery_manifest(
+        conn,
+        execution,
+        state="ready",
+        mode="native",
+        history_event_id=12,
+        expected_memberships=1,
+        persisted_memberships=1,
+        expected_steps=1,
+        persisted_steps=1,
+        key_digest=_recovery_key_digest(
+            {job_id},
+            {("source_planning", "plan")},
+        ),
+    )
+
+    _append_native_completed_step(
+        conn,
+        execution,
+        step_kind="source_family",
+        item_key="family:jobspy",
+        detail_code="source_family",
+    )
+    conn.commit()
+    builder.refresh()
+
+    manifest = conn.execute("SELECT * FROM discovery_execution_recoveries").fetchone()
+    assert manifest["state"] == "ready"
+    assert manifest["history_event_id"] == 12
+    assert manifest["expected_membership_count"] == 1
+    assert manifest["persisted_membership_count"] == 1
+    assert manifest["expected_step_count"] == 2
+    assert manifest["persisted_step_count"] == 2
+    assert manifest["key_digest"] == _recovery_key_digest(
+        {job_id},
+        {
+            ("source_planning", "plan"),
+            ("source_family", "family:jobspy"),
+        },
+    )
+
+
+@pytest.mark.parametrize("failure_type", [KeyboardInterrupt, sqlite3.OperationalError])
+def test_native_pipeline_step_fold_rolls_back_when_proof_update_fails(
+    tmp_path,
+    monkeypatch,
+    failure_type,
+) -> None:
+    conn = init_db(tmp_path / f"native-step-proof-rollback-{failure_type.__name__}.db")
+    execution = DiscoveryExecutionRef(
+        tenant_id="local",
+        workflow_id="discover-local",
+        temporal_run_id=f"run-native-step-proof-rollback-{failure_type.__name__}",
+    )
+    job_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f"jobctrl:{execution.temporal_run_id}"))
+    _seed_v7_job(conn, job_id)
+    SqliteDiscoveryExecutionRepository(conn).link_job(
+        execution,
+        job_id,
+        cohort_kind="observed_this_run",
+        source_family="jobspy",
+    )
+    _append_native_completed_step(
+        conn,
+        execution,
+        step_kind="source_planning",
+        item_key="plan",
+        detail_code="source_plan",
+    )
+    conn.commit()
+    builder = ProjectionBuilder(
+        conn_factory=lambda: conn,
+        tenant_id=TenantId(execution.tenant_id),
+    )
+    builder.refresh()
+    _write_recovery_manifest(
+        conn,
+        execution,
+        state="ready",
+        mode="native",
+        history_event_id=12,
+        expected_memberships=1,
+        persisted_memberships=1,
+        expected_steps=1,
+        persisted_steps=1,
+        key_digest=_recovery_key_digest(
+            {job_id},
+            {("source_planning", "plan")},
+        ),
+    )
+    _append_native_completed_step(
+        conn,
+        execution,
+        step_kind="source_family",
+        item_key="family:jobspy",
+        detail_code="source_family",
+    )
+    conn.commit()
+
+    def fail_proof_update(*_args, **_kwargs):
+        raise failure_type("simulated proof update failure")
+
+    monkeypatch.setattr(
+        projection_builder_module,
+        "advance_ready_native_recovery_manifests_for_tenant",
+        fail_proof_update,
+    )
+    with pytest.raises(failure_type, match="simulated proof update failure"):
+        builder.refresh()
+
+    assert conn.in_transaction is False
+    assert conn.execute("SELECT COUNT(*) FROM pipeline_step_projections WHERE tenant_id = 'local'").fetchone()[0] == 1
+    manifest = conn.execute("SELECT * FROM discovery_execution_recoveries").fetchone()
+    assert manifest["state"] == "ready"
+    assert manifest["expected_step_count"] == 1
+    assert manifest["persisted_step_count"] == 1
+    assert manifest["key_digest"] == _recovery_key_digest(
+        {job_id},
+        {("source_planning", "plan")},
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- advance verified native discovery recovery proofs atomically whenever canonical execution membership or pipeline-step keys grow
- share one decoder version and canonical key-digest algorithm across the Python worker and TypeScript projection owner
- keep an already verified checkpoint visible while heartbeat reconciliation reads history, including both concurrent native-write interleavings
- roll back Python pipeline-step replacement and proof advancement together on ordinary errors and process interruption
- document native proof advancement and the unchanged Temporal history watermark boundary

## Validation

- cumulative Python recovery/identity suites — 42 passed
- cumulative API projection/pipeline-operations suites — 95 passed
- deterministic concurrency proofs — native writes during the awaited history read and between manifest/key reads both remained `ready`, converged to 2/2, and emitted no `recovering`
- deterministic rollback proofs — `KeyboardInterrupt` and SQLite `OperationalError` preserved the prior projection/proof and left no transaction open
- API typecheck — passed
- targeted Ruff check and format check — passed
- docs build — 9,651 references validated across 359 files
- `git diff --check` — passed
- independent reviewer gate — PASS, Blocker 0 / High 0 / Medium 0 / Low 0
- independent operational QA gate — PASS, Blocker 0 / High 0 / Medium 0 / Low 0

## Stack

- depends on #808

## Checklist

- [x] Same-repository commit; DCO fork trailer does not apply
- [x] Relevant focused checks are listed above; cumulative CI is running on this stack head
- [x] No secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths are included