### PR TITLE
fix(web): clarify pipeline progress and recovery

### DIFF
--- a/apps/web/e2e/tests/route-visual-qa.spec.ts
+++ b/apps/web/e2e/tests/route-visual-qa.spec.ts
@@ -9,7 +9,10 @@ import {
   sampleJob,
   sampleResumeTemplateListResponse,
 } from "../../src/test/fixtures/projections.js";
-import { pipelinesDiscoveringSnapshot } from "../../src/views/pipelines/PipelinesView.fixtures.js";
+import {
+  pipelinesDiscoveringSnapshot,
+  pipelinesRecoveringProjectionSnapshot,
+} from "../../src/views/pipelines/PipelinesView.fixtures.js";
 
 type Density = "compact" | "regular" | "comfy";
 
@@ -1842,7 +1845,14 @@ test("Crawl sources keeps provider traversal separate from exact outcomes", asyn
   const crawl = page.getByRole("region", { name: "Crawl sources stage" });
   const trigger = crawl.getByRole("button", { name: /Crawl sources/i });
   await expect(trigger).toBeVisible({ timeout: 30_000 });
+  await expect(trigger).toContainText(
+    "Source family · 2 running · 0 waiting · 1 finished · 0 attention",
+  );
+  await expect(trigger).not.toContainText(/terminal/i);
   await trigger.click();
+  await expect(crawl.getByRole("progressbar", { name: "Stage completion" })).toBeVisible();
+  await expect(crawl).toContainText("1 of 3 finished");
+  await expect(crawl).not.toContainText(/terminal/i);
 
   const content = crawl.locator(".pipeline-stage-row__content");
   const provider = content.locator(".pipeline-stage-row__provider-progress");
@@ -1900,6 +1910,27 @@ test("Crawl sources keeps provider traversal separate from exact outcomes", asyn
   });
   expect(mobile.overlaps).toBe(false);
   expect(mobile.providerBottom).toBeLessThanOrEqual(mobile.outcomesTop + 1);
+});
+
+test("pipeline recovery explains the automatic previous-run check in plain language", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1491, height: 1245 });
+  await page.route("**/v1/pipeline/operations", async (route) => {
+    await route.fulfill({ json: pipelinesRecoveringProjectionSnapshot });
+  });
+  await page.goto("/pipelines");
+
+  const alert = page.getByRole("alert");
+  await expect(alert).toContainText("Checking previous run records");
+  await expect(alert).toContainText("15 of 72 linked jobs checked");
+  await expect(alert).toContainText("3 of 8 stage records checked");
+  await expect(alert).toContainText("finishes automatically and needs no restart");
+  await expect(alert).not.toContainText(/restoring history|terminal/i);
+
+  const summary = page.getByLabel("Pipeline operations summary");
+  await expect(summary).toContainText("Checking previous run");
+  await expect(summary).not.toContainText("Restoring history");
 });
 
 test("busy replacement guidance keeps its title readable without an action", async ({

--- a/apps/web/e2e/tests/route-visual-qa.spec.ts
+++ b/apps/web/e2e/tests/route-visual-qa.spec.ts
@@ -1921,7 +1921,9 @@ test("pipeline recovery explains the automatic previous-run check in plain langu
   });
   await page.goto("/pipelines");
 
-  const alert = page.getByRole("alert");
+  const alert = page
+    .getByRole("alert")
+    .filter({ hasText: "Checking previous run records" });
   await expect(alert).toContainText("Checking previous run records");
   await expect(alert).toContainText("15 of 72 linked jobs checked");
   await expect(alert).toContainText("3 of 8 stage records checked");

--- a/apps/web/src/views/pipelines/PipelinesView.test.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.test.tsx
@@ -117,7 +117,7 @@ describe("PipelinesView", () => {
     });
     expect(crawlTrigger).toHaveAttribute("aria-expanded", "false");
     expect(crawlTrigger).toHaveTextContent(
-      "Source family · 2 active · 1 terminal · 0 attention",
+      "Source family · 2 running · 0 waiting · 1 finished · 0 attention",
     );
     expect(crawlTrigger).toHaveTextContent("20 min–21 min");
     await user.click(crawlTrigger);
@@ -125,14 +125,18 @@ describe("PipelinesView", () => {
     expect(
       within(crawl).getByLabelText("Crawl sources stage summary"),
     ).toBeInTheDocument();
-    expect(crawl).toHaveTextContent("Active2");
+    expect(crawl).toHaveTextContent("Running2");
     expect(crawl).toHaveTextContent("Waiting0");
-    expect(crawl).toHaveTextContent("Processing2");
-    expect(crawl).toHaveTextContent("Terminal1");
+    expect(crawl).toHaveTextContent("Finished1");
     expect(crawl).toHaveTextContent("Attention0");
     expect(
-      within(crawl).getByRole("progressbar", { name: "Stage progress" }),
+      within(crawl).getByRole("progressbar", { name: "Stage completion" }),
     ).toHaveAttribute("aria-valuenow", "33");
+    expect(
+      within(crawl).getByRole("progressbar", { name: "Stage completion" }),
+    ).toHaveAttribute("aria-valuetext", "1 of 3 finished");
+    expect(crawl).toHaveTextContent("1 of 3 finished");
+    expect(crawl).not.toHaveTextContent(/terminal/i);
     expect(
       within(crawl).getByRole("heading", { name: "Provider traversal" }),
     ).toBeInTheDocument();
@@ -224,12 +228,12 @@ describe("PipelinesView", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps terminal outcomes honest and exposes every public stage-state count", async () => {
+  it("keeps finished outcomes honest and exposes every public stage-state count", async () => {
     const user = userEvent.setup();
     await renderPipelineOperations(pipelinesMixedFailureSnapshot);
 
     const crawl = screen.getByRole("region", { name: "Crawl sources stage" });
-    expect(crawl).toHaveTextContent("Terminal6");
+    expect(crawl).toHaveTextContent("Finished6");
     expect(crawl).not.toHaveTextContent("Done6");
     expect(crawl).toHaveTextContent("Attention3");
     await user.click(
@@ -240,7 +244,7 @@ describe("PipelinesView", () => {
     );
     expect(outcomes).toHaveTextContent("Eligible8");
     expect(outcomes).toHaveTextContent("Waiting1");
-    expect(outcomes).toHaveTextContent("Processing1");
+    expect(outcomes).toHaveTextContent("Running1");
     expect(outcomes).toHaveTextContent("Succeeded2");
     expect(outcomes).toHaveTextContent("Skipped0");
     expect(outcomes).toHaveTextContent("Blocked1");
@@ -252,7 +256,7 @@ describe("PipelinesView", () => {
     expect(outcomes).toHaveTextContent("Unknown0");
   });
 
-  it("renders a closed timed-out crawl as a terminal failure instead of active work", async () => {
+  it("renders a closed timed-out crawl as a finished failure instead of active work", async () => {
     const user = userEvent.setup();
     const closedTimeoutSnapshot: PipelineOperationsSnapshot = {
       ...pipelinesCompletedWithIssuesSnapshot,
@@ -286,14 +290,15 @@ describe("PipelinesView", () => {
     expect(crawl).toHaveAttribute("data-stage-status", "blocked");
     expect(within(crawl).getByText("Attention required")).toBeInTheDocument();
     expect(within(crawl).queryByText("In progress")).not.toBeInTheDocument();
-    expect(crawl).not.toHaveTextContent("50% terminal");
+    expect(crawl).not.toHaveTextContent("1 of 2 finished");
 
     await user.click(within(crawl).getByRole("button", { name: /Crawl sources/i }));
-    expect(within(crawl).getByRole("progressbar", { name: "Stage progress" })).toHaveAttribute(
+    expect(within(crawl).getByRole("progressbar", { name: "Stage completion" })).toHaveAttribute(
       "aria-valuenow",
       "100",
     );
-    expect(crawl).toHaveTextContent("100% terminal");
+    expect(crawl).toHaveTextContent("2 of 2 finished");
+    expect(crawl).not.toHaveTextContent(/terminal/i);
     expect(crawl).toHaveTextContent("Failed1");
     expect(crawl).not.toHaveTextContent("Exhausted");
   });
@@ -405,29 +410,29 @@ describe("PipelinesView", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps live runtime truth visible while exact history is restored", async () => {
+  it("keeps live runtime truth visible while the previous run is checked", async () => {
     await renderPipelineOperations(pipelinesRecoveringProjectionSnapshot);
 
     const coverageAlert = screen.getByRole("alert");
-    expect(coverageAlert).toHaveTextContent("Restoring pipeline history");
+    expect(coverageAlert).toHaveTextContent("Checking previous run records");
     expect(coverageAlert).toHaveTextContent(
-      "15 of 72 membership records restored",
+      "15 of 72 linked jobs checked",
     );
     expect(coverageAlert).toHaveTextContent(
-      "3 of 8 stage records restored",
+      "3 of 8 stage records checked",
     );
-    expect(coverageAlert).toHaveTextContent("no manual restart is needed");
+    expect(coverageAlert).toHaveTextContent("needs no restart");
     expect(coverageAlert).toHaveTextContent(
-      "Global worker, queue, and activity facts remain live below",
+      "Live worker, queue, and activity facts remain visible below",
     );
     expect(coverageAlert.querySelector("svg")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Stop discovery" })).toBeEnabled();
 
     const summary = screen.getByLabelText("Pipeline operations summary");
-    expect(summary).toHaveTextContent("Current cohortRestoring history");
-    expect(summary).toHaveTextContent("Execution sweepRestoring history");
-    expect(summary).toHaveTextContent("Source familiesRestoring history");
-    expect(summary).toHaveTextContent("Overall ETARestoring history");
+    expect(summary).toHaveTextContent("Current cohortChecking previous run");
+    expect(summary).toHaveTextContent("Execution sweepChecking previous run");
+    expect(summary).toHaveTextContent("Source familiesChecking previous run");
+    expect(summary).toHaveTextContent("Overall ETAChecking previous run");
     expect(summary).toHaveTextContent("TelemetryFresh");
 
     expect(getLivePipelineMetric("Workers online")).toHaveTextContent(
@@ -443,7 +448,7 @@ describe("PipelinesView", () => {
       "Queue backlog41 queuedOldest queued task 2 min",
     );
 
-    expect(screen.queryByText("0% terminal")).not.toBeInTheDocument();
+    expect(coverageAlert).not.toHaveTextContent(/terminal/i);
     expect(screen.queryByText("No work remaining")).not.toBeInTheDocument();
     expect(screen.queryByText(/tracking unavailable/i)).not.toBeInTheDocument();
     expect(
@@ -474,27 +479,27 @@ describe("PipelinesView", () => {
     expect(activeWork).toHaveTextContent("tailor-runtime-3");
   });
 
-  it("retries history repair automatically without hiding global telemetry or backlog", async () => {
+  it("retries the previous-run check automatically without hiding live telemetry", async () => {
     const user = userEvent.setup();
     await renderPipelineOperations(pipelinesRetryingProjectionSnapshot);
 
     const coverageAlert = screen.getByRole("alert");
     expect(coverageAlert).toHaveTextContent(
-      "Pipeline history repair will retry automatically",
+      "Previous run check will retry automatically",
     );
     expect(coverageAlert).toHaveTextContent(
-      "Last safe repair result: Recovery manifest set mismatch",
+      "Last check result: Recovery manifest set mismatch",
     );
     expect(coverageAlert).toHaveTextContent(
-      "Recovery runs at worker startup and on every worker heartbeat",
+      "This check finishes automatically and needs no restart",
     );
     expect(coverageAlert.querySelector("svg")).toBeInTheDocument();
 
     const summary = screen.getByLabelText("Pipeline operations summary");
-    expect(summary).toHaveTextContent("Current cohortRepair retry scheduled");
-    expect(summary).toHaveTextContent("Execution sweepRepair retry scheduled");
-    expect(summary).toHaveTextContent("Source familiesRepair retry scheduled");
-    expect(summary).toHaveTextContent("Overall ETARepair retry scheduled");
+    expect(summary).toHaveTextContent("Current cohortCheck will retry");
+    expect(summary).toHaveTextContent("Execution sweepCheck will retry");
+    expect(summary).toHaveTextContent("Source familiesCheck will retry");
+    expect(summary).toHaveTextContent("Overall ETACheck will retry");
     expect(summary).toHaveTextContent("TelemetryFresh");
 
     expect(getLivePipelineMetric("Workers online")).toHaveTextContent(
@@ -523,22 +528,22 @@ describe("PipelinesView", () => {
       screen.queryByRole("region", { name: "Global outside execution ledger table" }),
     ).not.toBeInTheDocument();
 
-    expect(screen.queryByText("0% terminal")).not.toBeInTheDocument();
+    expect(screen.queryByText(/terminal/i)).not.toBeInTheDocument();
     expect(screen.queryByText("No work remaining")).not.toBeInTheDocument();
     expect(screen.queryByText(/tracking unavailable/i)).not.toBeInTheDocument();
   });
 
-  it("preserves terminal incomplete history and offers a safe new Discover run", async () => {
+  it("preserves incomplete previous-run history and offers a safe new Discover run", async () => {
     const user = userEvent.setup();
     useStageTriggerStore.getState().setActiveStage("apply");
     await renderPipelineOperations(pipelinesIncompleteProjectionSnapshot);
 
     const alert = screen.getByRole("alert");
-    expect(alert).toHaveTextContent("Historical pipeline record is incomplete");
+    expect(alert).toHaveTextContent("Previous run record is incomplete");
     expect(alert).toHaveTextContent("preserved every exact record it can prove");
     expect(alert).toHaveTextContent("will not be retried automatically");
     expect(alert).not.toHaveTextContent("will retry automatically");
-    expect(screen.queryByText(/0% terminal/i)).not.toBeInTheDocument();
+    expect(alert).not.toHaveTextContent(/terminal/i);
     expect(screen.queryByText(/No work remaining/i)).not.toBeInTheDocument();
 
     const restart = within(alert).getByRole("link", {
@@ -588,15 +593,15 @@ describe("PipelinesView", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("lets recovery dominate a terminal-looking incomplete projection", async () => {
+  it("lets a previous-run check dominate an apparently finished incomplete projection", async () => {
     await renderPipelineOperations(pipelinesTerminalRecoveringProjectionSnapshot);
 
     const coverageAlert = screen.getByRole("alert");
-    expect(coverageAlert).toHaveTextContent("Restoring pipeline history");
+    expect(coverageAlert).toHaveTextContent("Checking previous run records");
     expect(coverageAlert).not.toHaveTextContent("Discovery completed with source issues");
 
     const phase = document.querySelector(".pipeline-phase-message");
-    expect(phase).toHaveTextContent("Recovering");
+    expect(phase).toHaveTextContent("Checking previous run");
     expect(phase).not.toHaveTextContent("Completed with issues");
     expect(
       screen.queryByRole("link", { name: "Set up a new Discover run" }),
@@ -625,10 +630,10 @@ describe("PipelinesView", () => {
     await renderPipelineOperations(pipelinesPartialSweepRecoveringSnapshot);
 
     const summary = screen.getByLabelText("Pipeline operations summary");
-    expect(summary).toHaveTextContent("Current cohortRestoring history");
-    expect(summary).toHaveTextContent("Execution sweepRestoring history");
-    expect(summary).toHaveTextContent("Source familiesRestoring history");
-    expect(summary).toHaveTextContent("Overall ETARestoring history");
+    expect(summary).toHaveTextContent("Current cohortChecking previous run");
+    expect(summary).toHaveTextContent("Execution sweepChecking previous run");
+    expect(summary).toHaveTextContent("Source familiesChecking previous run");
+    expect(summary).toHaveTextContent("Overall ETAChecking previous run");
 
     expect(screen.queryByText("41 remaining")).not.toBeInTheDocument();
     expect(screen.queryByText("83 remaining")).not.toBeInTheDocument();
@@ -693,7 +698,7 @@ describe("PipelinesView", () => {
       within(crawlSources).getByRole("button", { name: /Crawl sources/i }),
     );
     expect(
-      within(crawlSources).getByRole("progressbar", { name: "Stage progress" }),
+      within(crawlSources).getByRole("progressbar", { name: "Stage completion" }),
     ).toHaveAttribute("aria-valuenow", "33");
   });
 
@@ -806,7 +811,7 @@ describe("PipelinesView", () => {
     expect(alert).toHaveTextContent("exact stage outcomes");
     expect(alert).not.toHaveTextContent("source_retry_exhausted");
 
-    const sourceStatus = screen.getByText("2/3 succeeded · 1 needs attention", {
+    const sourceStatus = screen.getByText("3 of 3 finished · 1 needs attention", {
       selector: '[data-slot="status-badge"]',
     });
     expect(sourceStatus).toHaveAttribute("data-status-tone", "warn");
@@ -1071,12 +1076,17 @@ describe("PipelinesView", () => {
       sourceHeading.closest<HTMLElement>(".pipeline-source-ledger");
     if (!sourceLedger) throw new Error("Expected source and reconciliation ledger.");
 
-    expect(sourceLedger).toHaveTextContent("3/3 succeeded");
+    expect(sourceLedger).toHaveTextContent("3 of 3 finished");
     expect(
       within(sourceLedger).getByRole("progressbar", {
-        name: "Source-family progress",
+        name: "Source-family completion",
       }),
     ).toHaveAttribute("aria-valuenow", "100");
+    expect(
+      within(sourceLedger).getByRole("progressbar", {
+        name: "Source-family completion",
+      }),
+    ).toHaveAttribute("aria-valuetext", "3 of 3 finished");
     expect(sourceLedger).toHaveTextContent(
       "Runs one final enrichment pass for stragglers, then hands every ready job to preparation.",
     );

--- a/apps/web/src/views/pipelines/PipelinesView.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.tsx
@@ -69,7 +69,7 @@ import { ToolRow } from "../../shared/ui/tool-row.js";
 const COUNT_FIELDS = [
   ["eligible", "Eligible"],
   ["waiting", "Waiting"],
-  ["processing", "Processing"],
+  ["processing", "Running"],
   ["succeeded", "Succeeded"],
   ["skipped", "Skipped"],
   ["blocked", "Blocked"],
@@ -86,7 +86,7 @@ const COHORT_FIELDS = [
   ["notEligible", "Not eligible"],
   ["pending", "Pending plan"],
   ["failedPlan", "Failed plan"],
-  ["terminal", "Terminal"],
+  ["terminal", "Finished"],
   ["remaining", "Remaining"],
 ] as const;
 
@@ -161,11 +161,11 @@ function recoveryCoverage(
 
 function recoveryStateLabel(snapshot: PipelineOperationsSnapshot): string {
   return snapshot.projectionCoverage?.status === "incomplete"
-    ? "Historical run incomplete"
+    ? "Previous run incomplete"
     : snapshot.projectionCoverage?.status === "retrying"
-    ? "Repair retry scheduled"
+    ? "Check will retry"
     : snapshot.projectionCoverage?.status === "recovering" || snapshot.execution
-      ? "Restoring history"
+      ? "Checking previous run"
       : "No selected execution";
 }
 
@@ -291,16 +291,19 @@ function stageStatusLabel(status: PipelineStageStatus): string {
 }
 
 function CountSummary({ counts }: { readonly counts: PipelineStageCounts }) {
-  const active = counts.waiting + counts.processing;
+  const finished = completedCount(counts);
   const issues = issueCount(counts);
 
   return (
     <span className="pipeline-count-summary" data-typography="body">
       <span>
-        <b data-typography="strong-body">{active}</b> active
+        <b data-typography="strong-body">{counts.processing}</b> running
       </span>
       <span>
-        <b data-typography="strong-body">{counts.succeeded}</b> done
+        <b data-typography="strong-body">{counts.waiting}</b> waiting
+      </span>
+      <span>
+        <b data-typography="strong-body">{finished}</b> finished
       </span>
       {issues > 0 ? (
         <span>
@@ -701,7 +704,7 @@ function StageRows({
                     title={
                       trackingReady
                         ? "No tracked work is available for an ETA."
-                        : "The estimate will appear after pipeline history restoration completes."
+                        : "The estimate will appear after JobCtrl finishes checking the previous run."
                     }
                   />
                 )}
@@ -728,9 +731,11 @@ function PipelineStageRow({
   const counts = stage.currentExecution;
   const progress = stageProgress(counts);
   const status = stageStatus(counts);
-  const hasProgressDenominator = trackedCount(counts) > 0;
+  const tracked = trackedCount(counts);
+  const finished = completedCount(counts);
+  const hasProgressDenominator = tracked > 0;
   const summary = trackingReady
-    ? `${sentenceCase(stage.stage)} · ${activeCount(counts)} active · ${completedCount(counts)} terminal · ${issueCount(counts)} attention${hasProgressDenominator ? ` · ${etaLabel(stage.eta)}` : ""}`
+    ? `${sentenceCase(stage.stage)} · ${counts.processing} running · ${counts.waiting} waiting · ${finished} finished · ${issueCount(counts)} attention${hasProgressDenominator ? ` · ${etaLabel(stage.eta)}` : ""}`
     : `${sentenceCase(stage.stage)} · ${recoveryLabel}`;
 
   return (
@@ -756,12 +761,16 @@ function PipelineStageRow({
               className="pipeline-stage-row__facts"
             >
               <div>
-                <dt data-typography="label">Active</dt>
-                <dd data-typography="strong-body">{activeCount(counts)}</dd>
+                <dt data-typography="label">Running</dt>
+                <dd data-typography="strong-body">{counts.processing}</dd>
               </div>
               <div>
-                <dt data-typography="label">Terminal</dt>
-                <dd data-typography="strong-body">{completedCount(counts)}</dd>
+                <dt data-typography="label">Waiting</dt>
+                <dd data-typography="strong-body">{counts.waiting}</dd>
+              </div>
+              <div>
+                <dt data-typography="label">Finished</dt>
+                <dd data-typography="strong-body">{finished}</dd>
               </div>
               <div>
                 <dt data-typography="label">Attention</dt>
@@ -769,10 +778,13 @@ function PipelineStageRow({
               </div>
             </dl>
             {hasProgressDenominator ? (
-              <Progress value={progress}>
-                <ProgressLabel data-typography="label">Stage progress</ProgressLabel>
+              <Progress
+                aria-valuetext={`${finished} of ${tracked} finished`}
+                value={progress}
+              >
+                <ProgressLabel data-typography="label">Stage completion</ProgressLabel>
                 <ProgressValue data-typography="label">
-                  {progress}% terminal
+                  {finished} of {tracked} finished
                 </ProgressValue>
               </Progress>
             ) : null}
@@ -798,8 +810,8 @@ function PipelineStageRow({
           </>
         ) : (
           <p className="pipeline-stage-row__recovery-copy" data-typography="body">
-            Exact stage counts and estimates will appear automatically when history
-            restoration completes.
+            Completion counts and estimates will appear automatically after JobCtrl
+            finishes checking the previous run.
           </p>
         )}
       </div>
@@ -1016,15 +1028,15 @@ function ProjectionCoverageNotice({
   const canStartNewRun = isIncomplete && canSafelyPrepareNewDiscoverRun(snapshot);
   const membershipProgress =
     coverage.expectedMembershipCount === null
-      ? `${coverage.persistedMembershipCount} membership records restored so far`
-      : `${coverage.persistedMembershipCount} of ${coverage.expectedMembershipCount} membership records restored`;
+      ? `${coverage.persistedMembershipCount} linked jobs checked so far`
+      : `${coverage.persistedMembershipCount} of ${coverage.expectedMembershipCount} linked jobs checked`;
   const stepProgress =
     coverage.expectedStepCount === null
-      ? `${coverage.persistedStepCount} stage records restored so far`
-      : `${coverage.persistedStepCount} of ${coverage.expectedStepCount} stage records restored`;
+      ? `${coverage.persistedStepCount} stage records checked so far`
+      : `${coverage.persistedStepCount} of ${coverage.expectedStepCount} stage records checked`;
   const errorCopy =
     isRetrying && coverage.errorCode
-      ? ` Last safe repair result: ${sentenceCase(coverage.errorCode)}.`
+      ? ` Last check result: ${sentenceCase(coverage.errorCode)}.`
       : "";
 
   return (
@@ -1038,10 +1050,10 @@ function ProjectionCoverageNotice({
       <IconAlertTriangle aria-hidden="true" />
       <AlertTitle>
         {isIncomplete
-          ? "Historical pipeline record is incomplete"
+          ? "Previous run record is incomplete"
           : isRetrying
-          ? "Pipeline history repair will retry automatically"
-          : "Restoring pipeline history"}
+          ? "Previous run check will retry automatically"
+          : "Checking previous run records"}
       </AlertTitle>
       <AlertDescription>
         {isIncomplete ? (
@@ -1055,11 +1067,10 @@ function ProjectionCoverageNotice({
           </>
         ) : (
           <>
-            JobCtrl is rebuilding exact selected-run ownership from durable Temporal
-            history: {membershipProgress}; {stepProgress}. Selected-run percentages and
-            estimates stay hidden until that proof is complete.{errorCopy} Recovery runs
-            at worker startup and on every worker heartbeat; no manual restart is needed.
-            Global worker, queue, and activity facts remain live below.
+            JobCtrl is verifying the previous Discover run before showing its completion
+            counts and estimates: {membershipProgress}; {stepProgress}.{errorCopy} This
+            check finishes automatically and needs no restart. Live worker, queue, and
+            activity facts remain visible below.
           </>
         )}
       </AlertDescription>
@@ -1107,7 +1118,7 @@ function PipelineLiveFlow({
           <p data-typography="body">
             {trackingReady
               ? "Current discovery stages, shared workers, and work that needs attention."
-              : "Shared workers, queue pressure, and active runtime work remain live during recovery."}
+              : "Shared workers, queue pressure, and active runtime work remain visible while the previous run is checked."}
           </p>
         </div>
         {isActive && snapshot.execution?.discoverWorkflowId ? (
@@ -1178,7 +1189,7 @@ function PipelineLiveFlow({
                         snapshot.sourceFamilies.providerProgress,
                     }
                   : {})}
-                recoveryLabel="Restoring history"
+                recoveryLabel="Checking previous run"
                 stage={stage}
                 trackingReady
               />
@@ -1297,9 +1308,9 @@ function PipelineSources({
           : "pending";
   const sourceStatusLabel =
     sources && sourceIssues > 0
-      ? `${sources.counts.succeeded}/${sources.planned} succeeded · ${sourceIssues} need${sourceIssues === 1 ? "s" : ""} attention`
+      ? `${completedCount(sources.counts)} of ${sources.planned} finished · ${sourceIssues} need${sourceIssues === 1 ? "s" : ""} attention`
       : sources
-        ? `${sources.counts.succeeded}/${sources.planned} succeeded`
+        ? `${completedCount(sources.counts)} of ${sources.planned} finished`
         : "";
 
   return (
@@ -1309,10 +1320,10 @@ function PipelineSources({
         !trackingReady
           ? recoveryLabel
           : sources
-          ? `${sources.counts.succeeded}/${sources.planned} source families succeeded`
+          ? `${completedCount(sources.counts)} of ${sources.planned} source families finished`
           : "Source plan unavailable"
       }
-      description="Discovery intake and the terminal enrichment reconciliation are reported independently."
+      description="Discovery intake and the final enrichment check are reported independently."
       title="Source families and enrichment reconciliation"
     >
       <div className="pipeline-source-reconciliation">
@@ -1333,9 +1344,14 @@ function PipelineSources({
           {sources && trackingReady ? (
             <>
               {sources.planned > 0 ? (
-                <Progress value={completion}>
-                  <ProgressLabel>Source-family progress</ProgressLabel>
-                  <ProgressValue>{completion}% terminal</ProgressValue>
+                <Progress
+                  aria-valuetext={`${completedCount(sources.counts)} of ${sources.planned} finished`}
+                  value={completion}
+                >
+                  <ProgressLabel>Source-family completion</ProgressLabel>
+                  <ProgressValue>
+                    {completedCount(sources.counts)} of {sources.planned} finished
+                  </ProgressValue>
                 </Progress>
               ) : null}
               <CountSummary counts={sources.counts} />
@@ -1661,7 +1677,7 @@ function PipelineHeader({
   const recoveryLabel = recoveryStateLabel(snapshot);
   const sourceLabel = trackingReady
     ? snapshot.sourceFamilies
-      ? `${snapshot.sourceFamilies.counts.succeeded}/${snapshot.sourceFamilies.planned}`
+      ? `${completedCount(snapshot.sourceFamilies.counts)} of ${snapshot.sourceFamilies.planned} finished`
       : execution
         ? "Not available"
         : "No selected execution"
@@ -1680,7 +1696,9 @@ function PipelineHeader({
     <div className="pipeline-operations-header">
       <output className="pipeline-phase-message" aria-live="polite" aria-atomic="true">
         <span data-typography="label">Phase</span>
-        <PipelineStatus status={phase}>{sentenceCase(phase)}</PipelineStatus>
+        <PipelineStatus status={phase}>
+          {trackingReady ? sentenceCase(phase) : recoveryLabel}
+        </PipelineStatus>
       </output>
       <dl className="pipeline-summary-strip" aria-label="Pipeline operations summary">
         <div data-summary-priority="primary">

--- a/docs/developer/qa/regression-catalog.md
+++ b/docs/developer/qa/regression-catalog.md
@@ -178,10 +178,14 @@ must not enter the read model or DOM. Verify event invalidation, bounded polling
 ETA/freshness/capacity/task-queue degraded states, observation time, and active
 inventory without replacing unavailable evidence with a numeric guess. Exact
 stage outcomes must remain available even when the primary view summarizes them
-as terminal and attention totals. Stopping active discovery must refresh the
-pipeline snapshot. Replacement-run setup is allowed only for an exact zero
-active-work inventory, never for a positive or unavailable inventory, and it
-must not dispatch until the user submits the Discover controls.
+as running, waiting, finished, and attention totals. The UI must use **N of M
+finished**, never **N% terminal**, and must keep source-family counts visibly
+separate from worker and browser capacity. A genuine coverage rebuild must say
+**Checking previous run records**, explain that it finishes automatically, and
+must not present the internal recovery state as ongoing work. Stopping active
+discovery must refresh the pipeline snapshot. Replacement-run setup is allowed
+only for an exact zero active-work inventory, never for a positive or unavailable
+inventory, and it must not dispatch until the user submits the Discover controls.
 
 Browser reads may detect installations only to return opaque kinds and labels.
 They must not disclose paths, launch, adopt, or persist a browser. Enablement is

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -418,10 +418,10 @@ live tailoring activities, and an approximate activity backlog of 41. Verify:
 
 - the durable checkpoint and operations response remain `recovering`; partial
   row counts, active slots, and fresh telemetry never promote it to `ready`;
-- the UI renders **Restoring pipeline history**, the 15/72 and 4/16 restoration
-  progress, and the live worker/queue/activity facts;
-- selected-run counts, stage percentages, source/reconciliation ledgers, ETAs,
-  **0%**, and **No work remaining** stay hidden until the checkpoint is `ready`;
+- the UI renders **Checking previous run records**, the 15/72 linked-job and
+  4/16 stage-record check progress, and the live worker/queue/activity facts;
+- selected-run counts, source/reconciliation ledgers, ETAs, **0% terminal**,
+  and **No work remaining** stay hidden until the checkpoint is `ready`;
   and
 - a stale `ready` row whose exact key digest no longer matches is downgraded to
   `recovering` by the API and selected for worker repair;

--- a/docs/user/discovery.md
+++ b/docs/user/discovery.md
@@ -137,7 +137,9 @@ The workspace deliberately keeps different scopes and units separate:
 - **Execution sweep** is eligible pre-existing backlog that execution adopted.
 - **Global outside execution** is unrelated backlog and is not part of the
   selected execution's completion claim.
-- **Source-family progress** reports source intake; enrichment and preparation
+- **Source-family completion** reports source intake as separate **running**,
+  **waiting**, and **finished** family counts; these are source families, not
+  browser processes or Temporal workers. Enrichment and preparation
   reconciliation report the downstream drain. A finished crawl can therefore
   coexist with preparation that is still running. Broad-board progress also
   reports how many interrupted search units resumed. While a board is active,
@@ -150,19 +152,21 @@ The workspace deliberately keeps different scopes and units separate:
   task-queue depth is not a count of domain jobs.
 
 Per-stage rows expose outcomes, existing backlog, capacity, observation time,
-and ETA. ETA is an observed range with confidence and basis when enough evidence
-exists; calibrating, paused, stale, unavailable, and no-work states stay explicit
-instead of becoming a guessed finish time. Freshness and the bounded active-work
-inventory show whether the operational facts are current.
+and ETA. Their completion bar uses an exact **N of M finished** count rather
+than the internal term “terminal” or a percentage that can look like active
+progress. ETA is an observed range with confidence and basis when enough
+evidence exists; calibrating, paused, stale, unavailable, and no-work states
+stay explicit instead of becoming a guessed finish time. Freshness and the
+bounded active-work inventory show whether the operational facts are current.
 
 Exact selected-run stage tracking is durable. New executions record their
 membership and stage lineage natively. For an execution created by an older
 JobCtrl version, worker startup and heartbeats rebuild the same lineage from the
-exact Temporal workflow/run history. During that bounded repair, Pipelines shows
-**Restoring pipeline history**, keeps fresh shared-worker and queue facts visible,
-and hides selected-run counts, percentages, and ETAs until the recovered key sets
-have been verified. Partial rows or live-worker telemetry never become a false
-completion claim.
+exact Temporal workflow/run history. During that bounded check, Pipelines shows
+**Checking previous run records**, keeps fresh shared-worker and queue facts
+visible, and hides selected-run counts and ETAs until the recovered key sets have
+been verified. The check finishes automatically and needs no restart. Partial
+rows or live-worker telemetry never become a false completion claim.
 
 ### Stop Or Recover A Discover Run
 
@@ -175,11 +179,12 @@ When an execution fails, Pipelines reports whether the runtime inventory shows
 active work before suggesting another run. A positive total tells you to review
 that work first; unavailable inventory is reported as unknown, never as idle.
 If an authoritative history read is temporarily unavailable or cannot yet be
-mapped unambiguously, JobCtrl shows that history repair will retry automatically.
+mapped unambiguously, JobCtrl says that the previous-run check will retry
+automatically.
 It does not present permanent missing tracking, infer completion from partial
 rows, or require a manual retry. Reconnecting to the exact history restores that
 run or records its actual closed outcome. If an older run ended before its
-history recorded every target, JobCtrl marks that run **Historical run
+history recorded every target, JobCtrl marks that run **Previous run
 incomplete**, preserves all exact recovered evidence, and does not invent or
 repeatedly retry the missing remainder. **Set up a new Discover run** is
 appropriate only when the prior execution is closed or genuinely absent and


### PR DESCRIPTION
## Summary

- replace internal terminal percentages with exact running, waiting, and finished counts
- distinguish source-family progress from worker and browser capacity
- explain previous-run verification in plain language, including automatic retry and no-restart behavior
- align visible and screen-reader progress semantics with exact N of M finished values
- update the owning user and QA documentation

## Validation

- corepack pnpm --filter @jobctrl/web exec vitest run src/views/pipelines/PipelinesView.test.tsx --reporter=dot (39 passed)
- corepack pnpm --filter @jobctrl/web check
- corepack pnpm docs:build (9,651 references across 359 files)
- isolated Playwright route regressions at 1491x1245 and 720x900 (2 passed)
- git diff --check
- independent reviewer gate: PASS, Blocker 0, High 0, Medium 0, Low 0
- independent QA gate: PASS, Blocker 0, High 0, Medium 0, Low 0

## Checklist

- [x] External contributor commits include a DCO Signed-off-by trailer when applicable.
- [x] I ran the relevant local checks and listed them above.
- [x] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.