### PR TITLE
feat(observability): expose provider failure diagnostics

### DIFF
--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -62,6 +62,8 @@ import type {
   StageSummary,
   VoicePassAudit,
   WorkflowRunDetail,
+  WorkflowRunFailureDiagnostics,
+  WorkflowRunProviderFailureDiagnostic,
   WorkflowRunStatus,
   WorkflowRunSummary,
   WorkflowRunTimelineEvent,
@@ -5955,6 +5957,9 @@ export function getWorkflowRunDetail(
   // (including the superseded execution's terminal events).
   const row = applyWorkflowLifecycleFold(rawRow, loadWorkflowRunLifecycleFolds(db).get(runId));
   const summary = rowToWorkflowRunSummary(row);
+  const automaticRetryable = Boolean(row.retryable);
+  const inputSummary = parseInputSummary(row.input_summary_json);
+  const temporalRunId = nullableString(row.temporal_run_id);
   return {
     workflowId: summary.workflowId,
     runId: summary.runId,
@@ -5968,14 +5973,287 @@ export function getWorkflowRunDetail(
     result: summary.result,
     errorCode: nullableString(row.error_code),
     errorMessage: nullableString(row.error_message),
-    retryable: Boolean(row.retryable),
-    inputSummary: parseInputSummary(row.input_summary_json),
-    temporalRunId: nullableString(row.temporal_run_id),
+    retryable: automaticRetryable,
+    failureDiagnostics: providerFailureDiagnosticsForWorkflowRun(
+      db,
+      summary.jobKey,
+      temporalRunId,
+      automaticRetryable,
+      manualTailorRecoveryAvailable(
+        db,
+        summary.jobKey,
+        summary.workflowType,
+        summary.status,
+        inputSummary,
+      ),
+    ),
+    inputSummary,
+    temporalRunId,
     startedAt: summary.startedAt,
     finishedAt: summary.finishedAt,
     durationMs: summary.durationMs,
     events: parseWorkflowRunTimeline(row.events_json),
   };
+}
+
+const PROVIDER_FAILURE_MAX_TOTAL = 100;
+const PROVIDER_FAILURE_MAX_COUNTS = 12;
+const SAFE_PROVIDER_FAILURE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$/;
+const SAFE_TRACE_ID = /^[a-f0-9]{32}$/;
+const SAFE_SPAN_ID = /^[a-f0-9]{16}$/;
+const SAFE_PROMPT_FINGERPRINT = /^sha256:[a-f0-9]{64}$/;
+
+/**
+ * Project only the allowlisted provider envelope from a run-bound tailoring
+ * audit. The materials metadata is an internal audit store and can contain
+ * prompts or generated content; this boundary must never return either.
+ */
+function providerFailureDiagnosticsForWorkflowRun(
+  db: SqliteDatabase,
+  jobId: string,
+  temporalRunId: string | null,
+  automaticRetryable: boolean,
+  manualRecoveryAvailable: boolean,
+): WorkflowRunFailureDiagnostics {
+  const base: WorkflowRunFailureDiagnostics = {
+    automaticRetryable,
+    manualRecoveryAvailable,
+    providerFailures: null,
+  };
+  // Tailoring audits store the Temporal execution ID, not the logical
+  // workflow ID. Fail closed when an older projection lacks this identity.
+  if (!jobId || !temporalRunId || !tableExists(db, "job_materials")) return base;
+
+  const rows = allRows<{ metadata_json: string | null }>(
+    db,
+    `SELECT metadata_json
+       FROM job_materials
+      WHERE tenant_id = ? AND job_id = ?
+      ORDER BY generation DESC
+      LIMIT 20`,
+    [DEFAULT_TENANT, jobId],
+  );
+  const counts = new Map<string, {
+    source: "structured" | "legacy_inferred";
+    provider: string;
+    model: string;
+    operation: string;
+    category: string;
+    errorType: string;
+    code: string;
+    retryable: boolean | null;
+    count: number;
+  }>();
+  let total = 0;
+  let latest: WorkflowRunProviderFailureDiagnostic | null = null;
+
+  for (const row of rows) {
+    const metadata = parseJsonRecord(row.metadata_json);
+    const audits = metadata?.["tailoring_attempt_audits"];
+    if (!Array.isArray(audits)) continue;
+    // The append-only audit is oldest-to-newest. Process the newest matching
+    // execution first so `latest` remains the current bounded diagnostic.
+    for (const audit of [...audits].reverse()) {
+      if (!isRecord(audit) || audit["execution_id"] !== temporalRunId) continue;
+      const report = audit["report"];
+      if (!isRecord(report) || !Array.isArray(report["attempt_history"])) continue;
+      for (const attempt of [...report["attempt_history"]].reverse()) {
+        if (!isRecord(attempt) || !Array.isArray(attempt["candidates"])) continue;
+        for (const candidate of [...attempt["candidates"]].reverse()) {
+          if (total >= PROVIDER_FAILURE_MAX_TOTAL) break;
+          if (!isRecord(candidate)) continue;
+          const diagnostic = parseCandidateProviderFailureDiagnostic(candidate);
+          if (!diagnostic) continue;
+          total += 1;
+          if (latest === null) latest = diagnostic;
+          const key = [
+            diagnostic.source,
+            diagnostic.provider,
+            diagnostic.model,
+            diagnostic.operation,
+            diagnostic.category,
+            diagnostic.errorType,
+            diagnostic.code,
+            diagnostic.retryable === null
+              ? "retryability_unknown"
+              : diagnostic.retryable
+                ? "retryable"
+                : "not_retryable",
+          ].join("|");
+          const current = counts.get(key);
+          if (current) {
+            current.count += 1;
+          } else if (counts.size < PROVIDER_FAILURE_MAX_COUNTS) {
+            counts.set(key, {
+              source: diagnostic.source,
+              provider: diagnostic.provider,
+              model: diagnostic.model,
+              operation: diagnostic.operation,
+              category: diagnostic.category,
+              errorType: diagnostic.errorType,
+              code: diagnostic.code,
+              retryable: diagnostic.retryable,
+              count: 1,
+            });
+          }
+        }
+      }
+    }
+  }
+  if (!total) return base;
+  return {
+    ...base,
+    providerFailures: {
+      total,
+      counts: [...counts.values()].sort((left, right) =>
+        right.count - left.count || left.code.localeCompare(right.code),
+      ),
+      latest,
+    },
+  };
+}
+
+function parseCandidateProviderFailureDiagnostic(
+  candidate: Record<string, unknown>,
+): WorkflowRunProviderFailureDiagnostic | null {
+  if (candidate["status"] === "provider_error" && isRecord(candidate["provider_error"])) {
+    return parseProviderFailureDiagnostic(candidate["provider_error"]);
+  }
+  return parseLegacyCodexBuilderErrorDiagnostic(candidate);
+}
+
+/**
+ * Historical Codex executions recorded SDK turn failures as parse errors.
+ * This bridge is deliberately exact: no other parse error or free-form text
+ * may be reclassified as a provider failure.
+ */
+function parseLegacyCodexBuilderErrorDiagnostic(
+  candidate: Record<string, unknown>,
+): WorkflowRunProviderFailureDiagnostic | null {
+  const model = safeProviderFailureToken(candidate["model"]);
+  if (
+    candidate["status"] !== "parse_error" ||
+    candidate["parse_error"] !== "builder error" ||
+    !model ||
+    !model.startsWith("codex:") ||
+    model.length === "codex:".length
+  ) {
+    return null;
+  }
+  return {
+    source: "legacy_inferred",
+    provider: "codex",
+    model,
+    operation: "unknown",
+    category: "legacy_inferred",
+    errorType: "legacy_builder_error",
+    code: "builder_error",
+    retryable: null,
+    messageCode: null,
+    additionalDetailCode: null,
+    additionalDetailsPresent: null,
+    providerCode: null,
+    httpStatus: null,
+    candidateId: null,
+    innerAttempt: null,
+    durableAttempt: null,
+    promptFingerprint: null,
+    schemaVersion: null,
+    traceId: null,
+    spanId: null,
+  };
+}
+
+function manualTailorRecoveryAvailable(
+  db: SqliteDatabase,
+  jobId: string,
+  workflowType: string,
+  workflowStatus: WorkflowRunStatus,
+  inputSummary: Record<string, unknown>,
+): boolean {
+  if (
+    workflowType !== "JobPreparationWorkflow" ||
+    workflowStatus !== "failed" ||
+    !jobId ||
+    !tableExists(db, "job_stage_states")
+  ) {
+    return false;
+  }
+  const steps = inputSummary["steps"];
+  if (!Array.isArray(steps) || !steps.some((step) => step === "tailor")) return false;
+  const stage = getRow<{ state: string; retryable: number | null }>(
+    db,
+    `SELECT state, retryable
+       FROM job_stage_states
+      WHERE tenant_id = ? AND job_id = ? AND stage = 'tailor'
+      LIMIT 1`,
+    [DEFAULT_TENANT, jobId],
+  );
+  if (!stage || !["failed", "exhausted"].includes(stage.state)) return false;
+  if (stage.state === "exhausted") return true;
+  return stage.retryable !== 0 && latestStageRetryabilityByEvent(db, jobId).get("tailor") !== false;
+}
+
+function parseProviderFailureDiagnostic(
+  value: Record<string, unknown>,
+): WorkflowRunProviderFailureDiagnostic | null {
+  const provider = safeProviderFailureToken(value["provider"]);
+  const model = safeProviderFailureToken(value["model"]);
+  const operation = safeProviderFailureToken(value["operation"]);
+  const category = safeProviderFailureToken(value["category"]);
+  const errorType = safeProviderFailureToken(value["error_type"]);
+  const code = safeProviderFailureToken(value["code"]);
+  if (!provider || !model || !operation || !category || !errorType || !code) return null;
+  return {
+    source: "structured",
+    provider,
+    model,
+    operation,
+    category,
+    errorType,
+    code,
+    retryable: typeof value["retryable"] === "boolean" ? value["retryable"] : null,
+    messageCode: safeProviderFailureToken(value["message_code"]),
+    additionalDetailCode: safeProviderFailureToken(value["additional_detail_code"]),
+    additionalDetailsPresent: value["additional_details_present"] === true,
+    providerCode: safeProviderFailureToken(value["codex_error_code"]),
+    httpStatus: safeHttpStatus(value["http_status"]),
+    candidateId: safeProviderFailureToken(value["candidate_id"]),
+    innerAttempt: safePositiveInteger(value["inner_attempt"]),
+    durableAttempt: safePositiveInteger(value["durable_attempt"]),
+    promptFingerprint: safeFingerprint(value["prompt_fingerprint"]),
+    schemaVersion: safeProviderFailureToken(value["schema_version"]),
+    traceId: safeTraceId(value["trace_id"]),
+    spanId: safeSpanId(value["span_id"]),
+  };
+}
+
+function safeProviderFailureToken(value: unknown): string | null {
+  return typeof value === "string" && SAFE_PROVIDER_FAILURE_TOKEN.test(value) ? value : null;
+}
+
+function safeHttpStatus(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 100 && value <= 599
+    ? value
+    : null;
+}
+
+function safePositiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 && value <= 1000
+    ? value
+    : null;
+}
+
+function safeFingerprint(value: unknown): string | null {
+  return typeof value === "string" && SAFE_PROMPT_FINGERPRINT.test(value) ? value : null;
+}
+
+function safeTraceId(value: unknown): string | null {
+  return typeof value === "string" && SAFE_TRACE_ID.test(value) ? value : null;
+}
+
+function safeSpanId(value: unknown): string | null {
+  return typeof value === "string" && SAFE_SPAN_ID.test(value) ? value : null;
 }
 
 function parseInputSummary(value: unknown): Record<string, unknown> {

--- a/apps/api/test/read-model-v7.test.ts
+++ b/apps/api/test/read-model-v7.test.ts
@@ -9,6 +9,7 @@ import type { JobListQuery } from "../src/contracts.js";
 import {
   buildDashboardSummary,
   getJobDetail,
+  getWorkflowRunDetail,
   listActivity,
   listJobs,
   listScoringKeywords,
@@ -255,6 +256,294 @@ describe("exact-v7 read model job ids", () => {
       retryable: true,
       failureReason: "attempt_budget_exhausted",
     });
+  });
+
+  it("projects repeated run-bound provider failures without exposing audit payload content", () => {
+    const db = seededDatabase();
+    const privateSentinel = "PRIVATE_PROVIDER_SDK_DETAILS";
+    const providerError = {
+      provider: "openai",
+      model: "codex-test-model",
+      operation: "chat_json",
+      category: "provider_turn",
+      error_type: "codex_turn_error",
+      code: "builder_error",
+      retryable: true,
+      message_code: "builder_error",
+      additional_detail_code: "schema_validation_failed",
+      additional_details_present: true,
+      codex_error_code: "server_overloaded",
+      candidate_id: "candidate-1",
+      inner_attempt: 4,
+      durable_attempt: 2,
+      prompt_fingerprint: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      schema_version: "tailored-resume.v3",
+      trace_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      span_id: "aaaaaaaaaaaaaaaa",
+      raw_sdk_message: privateSentinel,
+      raw_sdk_url: "https://provider.example.test/private",
+    };
+    const matchingCandidates = Array.from({ length: 8 }, () => ({
+      status: "provider_error",
+      provider_error: providerError,
+    }));
+    db.prepare(
+      `UPDATE job_materials
+          SET metadata_json = ?
+        WHERE tenant_id = 'local' AND job_id = ?`,
+    ).run(
+      JSON.stringify({
+        tailoring_attempt_audits: [
+          {
+            // Audits are bound to the Temporal execution, never the logical
+            // workflow ID. This row must not leak into the matching run.
+            execution_id: "prepare-builder-failure",
+            durable_attempt: 1,
+            report: { attempt_history: [{ candidates: [matchingCandidates[0]] }] },
+          },
+          {
+            // A legacy projection without a Temporal run ID must also fail
+            // closed rather than falling back to this logical workflow ID.
+            execution_id: "unrelated-attempt-budget",
+            durable_attempt: 1,
+            report: { attempt_history: [{ candidates: [matchingCandidates[0]] }] },
+          },
+          {
+            execution_id: "temporal-builder-failure-run",
+            durable_attempt: 2,
+            report: {
+              attempt_history: [
+                { candidates: matchingCandidates.slice(0, 4) },
+                { candidates: matchingCandidates.slice(4) },
+              ],
+            },
+          },
+        ],
+        system_prompt: privateSentinel,
+        job_text: privateSentinel,
+      }),
+      JOB_ID,
+    );
+    db.prepare(
+      `INSERT INTO workflow_run_projections (
+         workflow_id, tenant_id, workflow_type, status, input_summary_json,
+         error_code, error_message, retryable, started_at, temporal_run_id, events_json
+       ) VALUES (?, 'local', 'JobPreparationWorkflow', 'failed', ?, ?, ?, 0, ?, ?, '[]')`,
+    ).run(
+      "prepare-builder-failure",
+      JSON.stringify({ jobId: JOB_ID, steps: ["tailor"] }),
+      "attempt_budget_exhausted",
+      "Tailor durable attempt budget exhausted.",
+      NOW,
+      "temporal-builder-failure-run",
+    );
+    db.prepare(
+      `INSERT INTO job_stage_states (
+         tenant_id, job_id, stage, state, updated_at, retryable, version
+       ) VALUES ('local', ?, 'tailor', 'failed', ?, 1, 1)`,
+    ).run(JOB_ID, NOW);
+
+    const detail = getWorkflowRunDetail(db, "prepare-builder-failure");
+
+    expect(detail?.failureDiagnostics).toEqual({
+      automaticRetryable: false,
+      manualRecoveryAvailable: true,
+      providerFailures: {
+        total: 8,
+        counts: [
+          {
+            source: "structured",
+            provider: "openai",
+            model: "codex-test-model",
+            operation: "chat_json",
+            category: "provider_turn",
+            errorType: "codex_turn_error",
+            code: "builder_error",
+            retryable: true,
+            count: 8,
+          },
+        ],
+        latest: expect.objectContaining({
+          source: "structured",
+          code: "builder_error",
+          messageCode: "builder_error",
+          additionalDetailCode: "schema_validation_failed",
+          providerCode: "server_overloaded",
+          innerAttempt: 4,
+          durableAttempt: 2,
+          traceId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          spanId: "aaaaaaaaaaaaaaaa",
+        }),
+      },
+    });
+    expect(JSON.stringify(detail)).not.toContain(privateSentinel);
+    expect(JSON.stringify(detail)).not.toContain("provider.example.test");
+
+    db.prepare(
+      `INSERT INTO workflow_run_projections (
+         workflow_id, tenant_id, workflow_type, status, input_summary_json,
+         error_code, error_message, retryable, started_at, events_json
+       ) VALUES (?, 'local', 'DiscoverWorkflow', 'failed', ?, ?, ?, 0, ?, '[]')`,
+    ).run(
+      "unrelated-attempt-budget",
+      JSON.stringify({ jobId: JOB_ID }),
+      "attempt_budget_exhausted",
+      "Unrelated durable attempt budget exhausted.",
+      NOW,
+    );
+
+    expect(getWorkflowRunDetail(db, "unrelated-attempt-budget")?.failureDiagnostics).toEqual({
+      automaticRetryable: false,
+      manualRecoveryAvailable: false,
+      providerFailures: null,
+    });
+  });
+
+  it("derives manual Tailor recovery from the canonical failed stage state", () => {
+    const db = seededDatabase();
+    db.prepare(
+      `INSERT INTO workflow_run_projections (
+         workflow_id, tenant_id, workflow_type, status, input_summary_json,
+         error_code, error_message, retryable, started_at, temporal_run_id, events_json
+       ) VALUES (?, 'local', 'JobPreparationWorkflow', 'failed', ?, ?, ?, 0, ?, ?, '[]')`,
+    ).run(
+      "prep-preparation:llm-transient",
+      JSON.stringify({ jobId: JOB_ID, steps: ["tailor"] }),
+      "llm_transient",
+      "Tailor activity retries exhausted.",
+      NOW,
+      "temporal-llm-transient-run",
+    );
+    db.prepare(
+      `INSERT INTO job_stage_states (
+         tenant_id, job_id, stage, state, updated_at, retryable, version
+       ) VALUES ('local', ?, 'tailor', 'failed', ?, 1, 1)`,
+    ).run(JOB_ID, NOW);
+
+    const recovery = () => getWorkflowRunDetail(db, "prep-preparation:llm-transient")
+      ?.failureDiagnostics?.manualRecoveryAvailable;
+
+    expect(recovery()).toBe(true);
+    db.prepare(
+      `UPDATE job_stage_states SET state = 'succeeded', retryable = 0
+        WHERE tenant_id = 'local' AND job_id = ? AND stage = 'tailor'`,
+    ).run(JOB_ID);
+    expect(recovery()).toBe(false);
+    db.prepare(
+      `UPDATE job_stage_states SET state = 'running', retryable = 1
+        WHERE tenant_id = 'local' AND job_id = ? AND stage = 'tailor'`,
+    ).run(JOB_ID);
+    expect(recovery()).toBe(false);
+    db.prepare(
+      `UPDATE job_stage_states SET state = 'failed', retryable = 0
+        WHERE tenant_id = 'local' AND job_id = ? AND stage = 'tailor'`,
+    ).run(JOB_ID);
+    expect(recovery()).toBe(false);
+  });
+
+  it("projects only the exact legacy Codex builder-error audit shape for its Temporal execution", () => {
+    const db = seededDatabase();
+    const temporalRunId = "01a014e6-cbfc-70b3-a2c0-0aab28f5c7d4";
+    const legacyCandidate = {
+      model: "codex:gpt-5.6-sol",
+      status: "parse_error",
+      parse_error: "builder error",
+      raw_sdk_message: "PRIVATE_LEGACY_SDK_MESSAGE",
+    };
+    db.prepare(
+      `UPDATE job_materials
+          SET metadata_json = ?
+        WHERE tenant_id = 'local' AND job_id = ?`,
+    ).run(
+      JSON.stringify({
+        tailoring_attempt_audits: [
+          {
+            // The logical workflow ID never qualifies as an execution match.
+            execution_id: "prep-preparation:legacy-builder-error",
+            report: { attempt_history: [{ candidates: [legacyCandidate] }] },
+          },
+          {
+            execution_id: temporalRunId,
+            report: {
+              attempt_history: [
+                {
+                  candidates: [
+                    ...Array.from({ length: 8 }, () => legacyCandidate),
+                    { ...legacyCandidate, parse_error: "builder error " },
+                    { ...legacyCandidate, model: "claude:sonnet" },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      }),
+      JOB_ID,
+    );
+    db.prepare(
+      `INSERT INTO workflow_run_projections (
+         workflow_id, tenant_id, workflow_type, status, input_summary_json,
+         error_code, error_message, retryable, started_at, temporal_run_id, events_json
+       ) VALUES (?, 'local', 'JobPreparationWorkflow', 'failed', ?, ?, ?, 0, ?, ?, '[]')`,
+    ).run(
+      "prep-preparation:legacy-builder-error",
+      JSON.stringify({ jobId: JOB_ID, steps: ["tailor"] }),
+      "attempt_budget_exhausted",
+      "Tailor durable attempt budget exhausted.",
+      NOW,
+      temporalRunId,
+    );
+    db.prepare(
+      `INSERT INTO job_stage_states (
+         tenant_id, job_id, stage, state, updated_at, retryable, version
+       ) VALUES ('local', ?, 'tailor', 'exhausted', ?, 0, 1)`,
+    ).run(JOB_ID, NOW);
+
+    const detail = getWorkflowRunDetail(db, "prep-preparation:legacy-builder-error");
+
+    expect(detail?.failureDiagnostics).toEqual({
+      automaticRetryable: false,
+      manualRecoveryAvailable: true,
+      providerFailures: {
+        total: 8,
+        counts: [
+          {
+            source: "legacy_inferred",
+            provider: "codex",
+            model: "codex:gpt-5.6-sol",
+            operation: "unknown",
+            category: "legacy_inferred",
+            errorType: "legacy_builder_error",
+            code: "builder_error",
+            retryable: null,
+            count: 8,
+          },
+        ],
+        latest: {
+          source: "legacy_inferred",
+          provider: "codex",
+          model: "codex:gpt-5.6-sol",
+          operation: "unknown",
+          category: "legacy_inferred",
+          errorType: "legacy_builder_error",
+          code: "builder_error",
+          retryable: null,
+          messageCode: null,
+          additionalDetailCode: null,
+          additionalDetailsPresent: null,
+          providerCode: null,
+          httpStatus: null,
+          candidateId: null,
+          innerAttempt: null,
+          durableAttempt: null,
+          promptFingerprint: null,
+          schemaVersion: null,
+          traceId: null,
+          spanId: null,
+        },
+      },
+    });
+    expect(JSON.stringify(detail)).not.toContain("PRIVATE_LEGACY_SDK_MESSAGE");
   });
 
   it("filters hidden and deleted jobs and uses only tenant-scoped events and audit rows", () => {

--- a/apps/web/src/test/fixtures/projections.ts
+++ b/apps/web/src/test/fixtures/projections.ts
@@ -1985,6 +1985,11 @@ export const sampleWorkflowRunDetail: WorkflowRunDetail = {
   errorCode: "activity_error",
   errorMessage: "discover activity failed",
   retryable: true,
+  failureDiagnostics: {
+    automaticRetryable: true,
+    manualRecoveryAvailable: false,
+    providerFailures: null,
+  },
   inputSummary: { stages: ["discover"] },
   temporalRunId: "temporal-run-1",
   startedAt: "2026-05-06T05:00:00Z",

--- a/apps/web/src/views/runs/WorkflowRunDrawer.test.tsx
+++ b/apps/web/src/views/runs/WorkflowRunDrawer.test.tsx
@@ -129,6 +129,76 @@ describe("<WorkflowRunDrawer>", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
+  it("labels legacy-inferred provider failures separately from automatic retry and manual recovery", async () => {
+    const workflowRun = vi.fn(async () =>
+      makeWorkflowRunDetail({
+        errorCode: "attempt_budget_exhausted",
+        errorMessage: "Tailor durable attempt budget exhausted.",
+        retryable: false,
+        failureDiagnostics: {
+          automaticRetryable: false,
+          manualRecoveryAvailable: true,
+          providerFailures: {
+            total: 8,
+            counts: [
+              {
+                source: "legacy_inferred",
+                provider: "codex",
+                model: "codex:gpt-5.6-sol",
+                operation: "unknown",
+                category: "legacy_inferred",
+                errorType: "legacy_builder_error",
+                code: "builder_error",
+                retryable: null,
+                count: 8,
+              },
+            ],
+            latest: {
+              source: "legacy_inferred",
+              provider: "codex",
+              model: "codex:gpt-5.6-sol",
+              operation: "unknown",
+              category: "legacy_inferred",
+              errorType: "legacy_builder_error",
+              code: "builder_error",
+              retryable: null,
+              messageCode: null,
+              additionalDetailCode: null,
+              additionalDetailsPresent: null,
+              providerCode: null,
+              httpStatus: null,
+              candidateId: null,
+              innerAttempt: null,
+              durableAttempt: null,
+              promptFingerprint: null,
+              schemaVersion: null,
+              traceId: null,
+              spanId: null,
+            },
+          },
+        },
+      }),
+    );
+    const harness = buildProviderHarness({
+      ports: buildTestPorts({ api: { workflowRun } }),
+    });
+    const router = buildRouter();
+    render(<RouterProvider router={router} />, { wrapper: harness.Wrapper });
+
+    const failure = await screen.findByRole("region", { name: "Failure details" });
+    expect(within(failure).getByText("Automatic retry")).toBeInTheDocument();
+    expect(within(failure).getByText("Manual recovery")).toBeInTheDocument();
+    expect(within(failure).getByText("Available")).toBeInTheDocument();
+    expect(within(failure).getByRole("heading", { level: 4, name: "Provider diagnostics" })).toBeInTheDocument();
+    expect(within(failure).getByText("8 provider failures recorded")).toBeInTheDocument();
+    expect(within(failure).getByText("legacy_inferred: builder_error")).toBeInTheDocument();
+    expect(within(failure).getByText(/recorded before structured provider instrumentation/i)).toBeInTheDocument();
+    expect(within(failure).getByText("Legacy inferred")).toBeInTheDocument();
+    expect(within(failure).getByRole("list", { name: "Provider failure counts" })).toHaveTextContent(
+      "8 codex / codex:gpt-5.6-sol / unknown: legacy_inferred: builder_error (legacy inferred)",
+    );
+  });
+
   it("names a maintenance pipeline from its selected stage scope", async () => {
     const workflowRun = vi.fn(async () =>
       makeWorkflowRunDetail({

--- a/apps/web/src/views/runs/WorkflowRunDrawer.tsx
+++ b/apps/web/src/views/runs/WorkflowRunDrawer.tsx
@@ -349,6 +349,15 @@ function FailureDetails({
   readonly run: WorkflowRunDetail;
   readonly eventMessage: string | null;
 }) {
+  const failureDiagnostics = run.failureDiagnostics ?? {
+    automaticRetryable: run.retryable,
+    manualRecoveryAvailable: false,
+    providerFailures: null,
+  };
+  const providerFailures = failureDiagnostics.providerFailures;
+  const hasLegacyProviderFailures = Boolean(
+    providerFailures?.counts.some((failure) => failure.source === "legacy_inferred"),
+  );
   const showProjectedMessage = Boolean(
     run.errorMessage && run.errorMessage !== eventMessage,
   );
@@ -369,10 +378,68 @@ function FailureDetails({
           </div>
         ) : null}
         <div>
-          <dt data-typography="label">Retryable</dt>
-          <dd data-typography="body">{run.retryable ? "Yes" : "No"}</dd>
+          <dt data-typography="label">Automatic retry</dt>
+          <dd data-typography="body">
+            {failureDiagnostics.automaticRetryable ? "Yes" : "No"}
+          </dd>
         </div>
+        {failureDiagnostics.manualRecoveryAvailable ? (
+          <div>
+            <dt data-typography="label">Manual recovery</dt>
+            <dd data-typography="body">Available</dd>
+          </div>
+        ) : null}
       </dl>
+      {providerFailures ? (
+        <div className="workflow-run-failure__provider-diagnostics">
+          <h4 data-typography="component-title">Provider diagnostics</h4>
+          <p data-typography="body">
+            {providerFailures.total} provider {providerFailures.total === 1 ? "failure" : "failures"} recorded
+          </p>
+          {hasLegacyProviderFailures ? (
+            <p data-typography="body">
+              Legacy-inferred diagnostics: this execution was recorded before structured provider
+              instrumentation, so structured provider details were unavailable.
+            </p>
+          ) : null}
+          {providerFailures.latest ? (
+            <dl>
+              <div>
+                <dt data-typography="label">Latest provider call</dt>
+                <dd data-typography="code">
+                  {providerFailures.latest.provider} / {providerFailures.latest.model} / {providerFailures.latest.operation}
+                </dd>
+              </div>
+              <div>
+                <dt data-typography="label">Latest failure</dt>
+                <dd data-typography="code">
+                  {providerFailures.latest.category}: {providerFailures.latest.code}
+                </dd>
+              </div>
+              {providerFailures.latest.source === "legacy_inferred" ? (
+                <div>
+                  <dt data-typography="label">Diagnostic source</dt>
+                  <dd data-typography="body">Legacy inferred</dd>
+                </div>
+              ) : null}
+              {providerFailures.latest.innerAttempt ? (
+                <div>
+                  <dt data-typography="label">Candidate attempt</dt>
+                  <dd data-typography="body">{providerFailures.latest.innerAttempt}</dd>
+                </div>
+              ) : null}
+            </dl>
+          ) : null}
+          <ul aria-label="Provider failure counts">
+            {providerFailures.counts.map((failure) => (
+              <li key={`${failure.source}-${failure.provider}-${failure.model}-${failure.operation}-${failure.category}-${failure.code}`}>
+                <code>{failure.count}</code> {failure.provider} / {failure.model} / {failure.operation}: {failure.category}: {failure.code}
+                {failure.source === "legacy_inferred" ? " (legacy inferred)" : ""}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/docs/api/operations-and-events.md
+++ b/docs/api/operations-and-events.md
@@ -203,6 +203,19 @@ and task-queue observations are runtime telemetry, not domain events.
 /v1/workflow-runs/:runId` returns the projection-backed detail and timeline.
 `POST /v1/workflow-runs/:runId/actions/cancel` requests Temporal cancellation.
 
+Run detail separates `failureDiagnostics.automaticRetryable` from
+`failureDiagnostics.manualRecoveryAvailable`; the latter means an operator can
+start a new Tailor recovery attempt and is not a Temporal automatic retry. It
+is derived from the canonical failed/retryable or exhausted Tailor stage for a
+failed JobPreparation Tailor run, rather than from the workflow error code. For
+a matching tailoring execution, `failureDiagnostics.providerFailures` contains
+only bounded provider failure counts plus the latest safe diagnostic
+(provider/model/operation/category/type/code, retryability, attempt and
+correlation identifiers). A `source` of `legacy_inferred` is the narrowly
+allowlisted pre-instrumentation Codex `parse_error: "builder error"` record;
+its per-call retryability and structured provider fields are unavailable. It never returns prompts, resume/job content,
+provider messages, raw SDK fields, paths, URLs, or secrets.
+
 Discover, job preparation, and Apply use this same history contract: one status
 vocabulary, ordered lifecycle timeline, terminal-state interpretation, and
 cancellation boundary. Product views may present different workflow details,

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -45,8 +45,11 @@ Langfuse instance for LLM tracing. The wiring lives under
   `gen_ai.response.model`, `gen_ai.usage.input_tokens`,
   `gen_ai.usage.output_tokens`) so OTel-native dashboards work too. Exported
   LLM attributes are metadata-only: provider/model, operation/scope, outcome,
-  token counts, and safe request/response sizes. Raw messages, parameters,
-  completions, and exception messages are omitted.
+  token counts, and safe request/response sizes. Typed provider failures add
+  bounded `jobctrl.llm.failure.*` dimensions for provider, model, operation,
+  category, type, code, retryability, and an allowlisted provider code or HTTP
+  status; structured calls also carry a schema fingerprint. Raw messages,
+  parameters, completions, SDK objects, and exception messages are omitted.
 
 ## Span Sources
 

--- a/docs/architecture/tailoring.md
+++ b/docs/architecture/tailoring.md
@@ -389,6 +389,23 @@ The retry loop is separate from the durable preparation work-item retry budget.
 The inner loop improves one tailoring run. The durable work item controls how
 many failed runs the background preparation queue auto-requeues.
 
+A provider-call failure is not a JSON parse failure. Candidate attempt audit
+records use `provider_error` only for an application-owned, allowlisted failure
+envelope: provider/model/operation, category/type/code, retryability, known
+structured provider codes, candidate and inner/durable attempt, workflow
+identity, prompt fingerprint, schema version, and available trace/span IDs.
+Provider messages, `additional_details` text, SDK objects, prompts, responses,
+resume/job text, paths, URLs, and secrets are never copied into that envelope.
+The workflow-run detail projects bounded counts and the latest safe summary for
+the matching execution, so repeated provider failures remain distinguishable
+from a validation or parsing failure.
+
+For pre-instrumentation records only, the run detail has one deliberately exact
+legacy bridge: a matching Temporal execution whose candidate is a Codex-routed
+model with `status: "parse_error"` and literal `parse_error: "builder error"`.
+It is labeled `legacy_inferred`, has unknown per-call retryability, and omits
+all structured provider fields. No other parse error is reclassified.
+
 ## Validation Layers
 
 Tailoring has multiple gates. Some are deterministic, some are LLM-judged.

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -131,6 +131,17 @@ an exact `workflowType` match, inclusive `startedSince`, and exclusive
 optional filter values are ignored. The list response echoes the effective
 filters in its `filter` object (`null` when an optional filter is inactive).
 
+`GET /v1/workflow-runs/:runId` returns `failureDiagnostics` when available.
+`automaticRetryable` describes Temporal retry behavior; `manualRecoveryAvailable`
+describes whether the canonical Tailor stage is failed/retryable or exhausted
+for a failed JobPreparation Tailor run, so a new recovery can be started. Its optional
+`providerFailures` summary is limited to safe provider/model/operation failure
+dimensions, counts, and the latest correlated attempt; it excludes all prompt,
+generated-content, SDK-message, path, URL, and secret data.
+For matching pre-instrumentation Codex records only, the exact legacy
+`parse_error: "builder error"` shape is returned with `source: "legacy_inferred"`;
+per-call retryability and structured provider fields remain unavailable.
+
 Discover, job preparation, and Apply share the same statuses, lifecycle
 timeline, terminal-state rules, and cancellation command. Cancellation is
 cooperative and idempotent: repeated requests do not replace terminal results

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2478,6 +2478,62 @@ export interface WorkflowRunTimelineEvent {
   readonly message: string | null;
 }
 
+/**
+ * Privacy-safe aggregation of provider failures recorded for one tailoring
+ * workflow. No prompts, provider messages, SDK objects, or generated content
+ * cross this boundary.
+ */
+export interface WorkflowRunProviderFailureCount {
+  /** Whether this count came from a structured envelope or the narrow legacy bridge. */
+  readonly source: "structured" | "legacy_inferred";
+  readonly provider: string;
+  readonly model: string;
+  readonly operation: string;
+  readonly category: string;
+  readonly errorType: string;
+  readonly code: string;
+  /** Per-call retryability is unavailable in legacy audit records. */
+  readonly retryable: boolean | null;
+  readonly count: number;
+}
+
+export interface WorkflowRunProviderFailureDiagnostic {
+  /** Structured provider envelope, or the exact legacy Codex builder-error bridge. */
+  readonly source: "structured" | "legacy_inferred";
+  readonly provider: string;
+  readonly model: string;
+  readonly operation: string;
+  readonly category: string;
+  readonly errorType: string;
+  readonly code: string;
+  /** Per-call retryability is unavailable in legacy audit records. */
+  readonly retryable: boolean | null;
+  readonly messageCode: string | null;
+  readonly additionalDetailCode: string | null;
+  readonly additionalDetailsPresent: boolean | null;
+  readonly providerCode: string | null;
+  readonly httpStatus: number | null;
+  readonly candidateId: string | null;
+  readonly innerAttempt: number | null;
+  readonly durableAttempt: number | null;
+  readonly promptFingerprint: string | null;
+  readonly schemaVersion: string | null;
+  readonly traceId: string | null;
+  readonly spanId: string | null;
+}
+
+export interface WorkflowRunFailureDiagnostics {
+  /** Whether Temporal will automatically retry this workflow failure. */
+  readonly automaticRetryable: boolean;
+  /** Whether the operator can start a new Tailor recovery attempt. */
+  readonly manualRecoveryAvailable: boolean;
+  readonly providerFailures: {
+    readonly total: number;
+    readonly counts: readonly WorkflowRunProviderFailureCount[];
+    readonly latest: WorkflowRunProviderFailureDiagnostic | null;
+  } | null;
+}
+
 export interface WorkflowRunDetail {
   readonly workflowId: string;
   readonly runId: string;
@@ -2491,7 +2547,9 @@ export interface WorkflowRunDetail {
   readonly result: string | null;
   readonly errorCode: string | null;
   readonly errorMessage: string | null;
+  /** @deprecated Use failureDiagnostics.automaticRetryable for the exact meaning. */
   readonly retryable: boolean;
+  readonly failureDiagnostics?: WorkflowRunFailureDiagnostics;
   readonly inputSummary: Record<string, unknown>;
   readonly temporalRunId: string | null;
   readonly startedAt: string | null;

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -1415,10 +1415,97 @@ def _safe_candidate_summary(record: dict[str, Any]) -> dict[str, Any]:
         "judge": record.get("judge"),
         "fabrication_gate": record.get("fabrication_gate"),
         "parse_error": record.get("parse_error"),
+        "provider_error": record.get("provider_error"),
         "post_generation_fit": record.get("post_generation_fit"),
         "bullet_limit_overflows": record.get("bullet_limit_overflows") or [],
         "summary": _candidate_payload_summary(payload),
     }
+
+
+class _LlmPayloadParseError(ValueError):
+    """The provider returned text, but no valid JSON payload could be decoded."""
+
+
+def _safe_provider_audit_token(value: object, *, fallback: str) -> str:
+    if isinstance(value, str) and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}", value):
+        return value
+    return fallback
+
+
+def _provider_for_model(model: object) -> str:
+    value = str(model or "").lower()
+    if value.startswith(("gpt-", "o1", "o3", "o4", "codex")):
+        return "openai"
+    if value.startswith("claude"):
+        return "anthropic"
+    if value.startswith("gemini"):
+        return "google"
+    return "unknown"
+
+
+def _safe_provider_error_record(
+    exc: BaseException,
+    *,
+    model: str,
+    candidate_id: str,
+    inner_attempt: int,
+    workflow_run_id: str | None,
+    durable_attempt: int | None,
+    prompt_fingerprint: str,
+) -> dict[str, Any]:
+    """Return a bounded audit record without serializing an exception or SDK object."""
+
+    envelope = getattr(exc, "envelope", None)
+    serialized = envelope.to_dict() if callable(getattr(envelope, "to_dict", None)) else {}
+    if not isinstance(serialized, dict):
+        serialized = {}
+    record: dict[str, Any] = {
+        "provider": _safe_provider_audit_token(
+            serialized.get("provider"),
+            fallback=_provider_for_model(serialized.get("model") or model),
+        ),
+        "model": _safe_provider_audit_token(
+            serialized.get("model") or model, fallback="unknown"
+        ),
+        "operation": _safe_provider_audit_token(
+            serialized.get("operation"), fallback="chat_json"
+        ),
+        "category": _safe_provider_audit_token(
+            serialized.get("category"), fallback="provider_exception"
+        ),
+        "error_type": _safe_provider_audit_token(
+            serialized.get("error_type"), fallback="unknown_exception"
+        ),
+        "code": _safe_provider_audit_token(
+            serialized.get("code"), fallback="unclassified_exception"
+        ),
+        "retryable": serialized.get("retryable") is True,
+        "candidate_id": candidate_id,
+        "inner_attempt": inner_attempt,
+        "prompt_fingerprint": prompt_fingerprint,
+        "schema_version": TAILORING_SCHEMA_VERSION,
+    }
+    for key, limit in (
+        ("message_code", 64),
+        ("additional_detail_code", 64),
+        ("codex_error_code", 64),
+        ("trace_id", 32),
+        ("span_id", 16),
+    ):
+        value = serialized.get(key)
+        if isinstance(value, str) and re.fullmatch(r"[a-zA-Z0-9_:-]{1," + str(limit) + r"}", value):
+            record[key] = value
+    http_status = serialized.get("http_status")
+    if isinstance(http_status, int) and 100 <= http_status <= 599:
+        record["http_status"] = http_status
+    if serialized.get("additional_details_present") is True:
+        record["additional_details_present"] = True
+    safe_workflow_id = _safe_provider_audit_token(workflow_run_id, fallback="")
+    if safe_workflow_id:
+        record["workflow_run_id"] = safe_workflow_id
+    if durable_attempt is not None:
+        record["durable_attempt"] = durable_attempt
+    return record
 
 
 def _with_tailoring_attempt_audit(
@@ -2215,6 +2302,8 @@ class TailorResumeUseCase:
             tailoring_plan=tailoring_plan,
             tailor_prompt_base=tailor_prompt_base,
             execution_guard=commit_guard,
+            audit_execution_id=audit_execution_id,
+            durable_attempt=durable_attempt,
         )
         if commit_guard is not None:
             commit_guard()
@@ -2235,13 +2324,22 @@ class TailorResumeUseCase:
                 if commit_guard is not None:
                     commit_guard()
                 self._repository.save(materials)
-            self._publish_failed(materials, validation_errors=("exhausted_retries",), attempt=attempts)
+            provider_failed = str(report.get("status")) == "provider_error"
+            self._publish_failed(
+                materials,
+                validation_errors=(("provider_error",) if provider_failed else ("exhausted_retries",)),
+                attempt=attempts,
+            )
             return TailorOutcome(
                 materials=materials,
-                status="exhausted_retries",
+                status="provider_error" if provider_failed else "exhausted_retries",
                 attempts=attempts,
                 report=report,
-                error="No parseable JSON in any attempt",
+                error=(
+                    "All candidate provider calls failed"
+                    if provider_failed
+                    else "No parseable JSON in any attempt"
+                ),
             )
 
         parsed_payload = mark_current_artifact_budget(parsed_payload)
@@ -2629,6 +2727,8 @@ class TailorResumeUseCase:
         tailoring_plan: TailoringPlan,
         tailor_prompt_base: str,
         execution_guard: Callable[[], None] | None = None,
+        audit_execution_id: str | None = None,
+        durable_attempt: int | None = None,
     ) -> tuple[dict, dict | None, ValidationResult, JudgeVerdict | None]:
         """Run the LLM ⇒ validate ⇒ judge attempt loop.
 
@@ -2762,6 +2862,8 @@ class TailorResumeUseCase:
                     job=job,
                     attempt=attempt + 1,
                     employer_analysis=employer_analysis,
+                    audit_execution_id=audit_execution_id,
+                    durable_attempt=durable_attempt,
                 )
                 attempt_record["candidates"].append(candidate.record)
                 last_payload = candidate.payload or last_payload
@@ -2922,7 +3024,17 @@ class TailorResumeUseCase:
                 "prompt_fingerprint"
             )
             return report, best_rejected.payload, best_rejected.validation, best_rejected.verdict
-        if last_payload is not None and not last_validation.passed:
+        provider_candidates = [
+            candidate
+            for attempt_record in report["attempt_history"]
+            for candidate in attempt_record.get("candidates") or []
+        ]
+        if last_payload is None and provider_candidates and all(
+            str(candidate.get("status") or "") == "provider_error"
+            for candidate in provider_candidates
+        ):
+            report["status"] = "provider_error"
+        elif last_payload is not None and not last_validation.passed:
             report["status"] = "failed_validation"
         return report, last_payload, last_validation, last_verdict
 
@@ -3004,12 +3116,15 @@ class TailorResumeUseCase:
         job: dict,
         attempt: int,
         employer_analysis: EmployerAnalysis,
+        audit_execution_id: str | None,
+        durable_attempt: int | None,
     ) -> _TailorCandidate:
         candidate_id = f"candidate-{abs(hash((model, len(messages), messages[-1].content[:80]))) % 10_000_000}"
         record: dict[str, Any] = {
             "candidate_id": candidate_id,
             "model": model,
             "schema_version": TAILORING_SCHEMA_VERSION,
+            "inner_attempt": attempt,
             "prompt_fingerprint": fingerprint_value(
                 [
                     {"role": message.role, "content": message.content}
@@ -3027,9 +3142,28 @@ class TailorResumeUseCase:
                 max_tokens=self._llm_policy.candidate_max_tokens,
                 thinking_budget=self._llm_policy.thinking_budget,
             )
-        except Exception as exc:  # noqa: BLE001
+        except (json.JSONDecodeError, _LlmPayloadParseError):
             record["status"] = "parse_error"
-            record["parse_error"] = str(exc)
+            record["parse_error"] = {"code": "invalid_json"}
+            return _TailorCandidate(
+                payload={},
+                validation=empty_validation,
+                verdict=None,
+                tailored_text="",
+                model=model,
+                record=record,
+            )
+        except Exception as exc:  # noqa: BLE001 - persist only a typed safe envelope
+            record["status"] = "provider_error"
+            record["provider_error"] = _safe_provider_error_record(
+                exc,
+                model=model,
+                candidate_id=candidate_id,
+                inner_attempt=attempt,
+                workflow_run_id=audit_execution_id,
+                durable_attempt=durable_attempt,
+                prompt_fingerprint=str(record["prompt_fingerprint"]),
+            )
             return _TailorCandidate(
                 payload={},
                 validation=empty_validation,
@@ -3220,7 +3354,10 @@ class TailorResumeUseCase:
                 response_schema=schema,
                 thinking_budget=thinking_budget,
             )
-            return _extract_json(raw)
+            try:
+                return _extract_json(raw)
+            except ValueError as exc:
+                raise _LlmPayloadParseError("invalid JSON payload") from exc
 
     def _judge_resume(
         self,

--- a/workers/automation/src/jobctrl/infrastructure/analysis/codex_analysis_adapter.py
+++ b/workers/automation/src/jobctrl/infrastructure/analysis/codex_analysis_adapter.py
@@ -3,8 +3,8 @@
 Mirrors the mestre vendor-lane pattern (``mestre/vendor_lane/backends/
 codex_sdk.py``): drive the official ``openai_codex`` Python SDK directly (no
 Node sidecar, no CLI-subprocess wrapper), forcing JSON-schema-constrained
-output via ``output_schema`` on ``thread.run`` and parsing the structured
-result off ``TurnResult.final_response``.
+output via ``output_schema`` and consuming the public turn stream. This keeps
+the SDK's structured ``TurnError`` available without serializing provider text.
 
 Codex isolation + permissions: the live factory redirects the SDK to a
 JobCtrl-owned ``CODEX_HOME`` so Codex app-server state does not pollute the
@@ -18,8 +18,8 @@ resolved through an injectable factory that defaults to a lazy import, so tests
 pass a fake context-manager whose thread returns a canned ``final_response``.
 No live Codex login / app-server is needed in the suite.
 
-No timeout (D-19): ``thread.run`` is awaited to completion; effort is pinned to
-``high`` (D-18). Cancellation = cancel the wrapping asyncio task.
+No timeout (D-19): the public turn stream is awaited to completion; effort is
+pinned to ``high`` (D-18). Cancellation = cancel the wrapping asyncio task.
 """
 
 from __future__ import annotations
@@ -36,6 +36,8 @@ from jobctrl.domain.materials.analysis import (
     JobAnalysisDraft,
 )
 from jobctrl.infrastructure.analysis.strict_schema import strict_json_schema
+from jobctrl.infrastructure.llm.codex_turn import run_codex_turn
+from jobctrl.infrastructure.llm.provider_errors import ProviderCallError, provider_exception_error
 from jobctrl.infrastructure.observability.llm_spans import llm_generation_span
 from jobctrl.infrastructure.setup_probes import (
     CODEX_NEUTRALIZED_AUTH_ENV,
@@ -259,40 +261,49 @@ class CodexAnalysisAdapter:
         with llm_generation_span(
             model=self._model,
             messages=span_input,
-            params={},
+            params={"structured": True},
             scope_name=_CODEX_SCOPE,
         ) as record:
-            async with factory() as codex:  # reuses existing Codex login (D-04)
-                thread = await codex.thread_start(
-                    # Analysis has no local-tool use case. Never auto-review or
-                    # approve an escalation even if a future runtime exposes a
-                    # tool despite the locked-down feature configuration.
-                    approval_mode=_deny_all_approval_mode(),
+            try:
+                async with factory() as codex:  # reuses existing Codex login (D-04)
+                    thread = await codex.thread_start(
+                        # Analysis has no local-tool use case. Never auto-review or
+                        # approve an escalation even if a future runtime exposes a
+                        # tool despite the locked-down feature configuration.
+                        approval_mode=_deny_all_approval_mode(),
+                        model=self._model,
+                        # Max reasoning effort (D-18). Command filesystem access is
+                        # governed by the configured Codex permissions profile.
+                        config={"model_reasoning_effort": "high"},
+                    )
+                    outcome = await run_codex_turn(
+                        thread,
+                        prompt,
+                        model=self._model,
+                        operation="chat_json",
+                        run_kwargs={
+                            # Codex/OpenAI strict structured output requires every object
+                            # to set additionalProperties:false and list all props in
+                            # required; Pydantic's model_json_schema() emits neither.
+                            "output_schema": strict_json_schema(JobAnalysis.model_json_schema()),
+                            "effort": "high",
+                        },
+                    )
+            except ProviderCallError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - preserve only safe provider fields
+                raise provider_exception_error(
+                    provider="openai",
                     model=self._model,
-                    # Max reasoning effort (D-18). Command filesystem access is
-                    # governed by the configured Codex permissions profile.
-                    config={"model_reasoning_effort": "high"},
-                )
-                result = await thread.run(
-                    prompt,
-                    # Codex/OpenAI strict structured output requires every object to
-                    # set additionalProperties:false and list all props in required;
-                    # Pydantic's model_json_schema() emits neither (live 400 otherwise).
-                    output_schema=strict_json_schema(JobAnalysis.model_json_schema()),
-                    effort="high",
-                )
-            # ``status`` is a ``TurnStatus`` enum whose ``str()`` is
-            # "TurnStatus.completed" — compare its ``.value`` ("completed"), not the
-            # enum repr, or a successful turn is wrongly rejected (live-caught bug).
-            status_obj = getattr(result, "status", None)
-            status = str(getattr(status_obj, "value", status_obj) or "")
-            final_response = getattr(result, "final_response", None)
-            if (status and status != "completed") or not final_response:
-                error = getattr(result, "error", None)
-                raise RuntimeError(f"Codex turn failed: status={status!r} err={error!r}")
-            input_tokens, output_tokens = _usage_from_result(result)
-            record(final_response, input_tokens=input_tokens, output_tokens=output_tokens)
-            analysis = JobAnalysis.model_validate_json(final_response)
+                    operation="chat_json",
+                    error=exc,
+                ) from exc
+            record(
+                outcome.final_response,
+                input_tokens=outcome.input_tokens,
+                output_tokens=outcome.output_tokens,
+            )
+            analysis = JobAnalysis.model_validate_json(outcome.final_response)
             return JobAnalysisDraft(model_id=self._model, **analysis.model_dump())
 
 

--- a/workers/automation/src/jobctrl/infrastructure/llm/codex_turn.py
+++ b/workers/automation/src/jobctrl/infrastructure/llm/codex_turn.py
@@ -1,0 +1,140 @@
+"""Application-owned Codex turn collection that retains safe failure fields."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from jobctrl.infrastructure.llm.provider_errors import (
+    codex_protocol_error,
+    codex_turn_error,
+)
+
+
+@dataclass(frozen=True)
+class CodexTurnOutcome:
+    final_response: str
+    input_tokens: int | None
+    output_tokens: int | None
+
+
+def _optional_int(value: object) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _usage_from(value: object) -> tuple[int | None, int | None]:
+    total = getattr(value, "total", value)
+    return _optional_int(getattr(total, "input_tokens", None)), _optional_int(
+        getattr(total, "output_tokens", None)
+    )
+
+
+def _status_value(turn: object) -> str:
+    status = getattr(turn, "status", None)
+    return str(getattr(status, "value", status) or "")
+
+
+def _final_response(items: list[object]) -> str | None:
+    fallback: str | None = None
+    for item in reversed(items):
+        value = getattr(item, "root", item)
+        text = getattr(value, "text", None)
+        if not isinstance(text, str) or not text:
+            continue
+        phase = getattr(value, "phase", None)
+        phase_value = str(getattr(phase, "value", phase) or "")
+        if phase_value == "final_answer":
+            return text
+        if not phase_value and fallback is None:
+            fallback = text
+    return fallback
+
+
+def _outcome_from_result(*, result: object, model: str, operation: str) -> CodexTurnOutcome:
+    if _status_value(result) != "completed":
+        raise codex_turn_error(model=model, operation=operation, error=getattr(result, "error", None))
+    final_response = getattr(result, "final_response", None)
+    if not isinstance(final_response, str) or not final_response:
+        raise codex_protocol_error(
+            model=model,
+            operation=operation,
+            code="final_response_missing",
+            retryable=True,
+        )
+    input_tokens, output_tokens = _usage_from(getattr(result, "usage", None))
+    return CodexTurnOutcome(final_response, input_tokens, output_tokens)
+
+
+async def run_codex_turn(
+    thread: Any,
+    prompt: str,
+    *,
+    model: str,
+    operation: str,
+    run_kwargs: dict[str, Any],
+) -> CodexTurnOutcome:
+    """Collect a Codex turn without the SDK's lossy ``thread.run()`` wrapper.
+
+    ``openai_codex`` raises a ``RuntimeError`` from ``thread.run()`` for a
+    failed turn, which loses the structured ``TurnError`` object.  Consuming the
+    public turn stream preserves that object while keeping provider internals
+    outside persistence and telemetry.  The ``run`` fallback supports existing
+    lightweight test doubles and older SDK shims.
+    """
+
+    turn_method = getattr(thread, "turn", None)
+    if not callable(turn_method):
+        result = await thread.run(prompt, **run_kwargs)
+        return _outcome_from_result(result=result, model=model, operation=operation)
+
+    handle = await turn_method(prompt, **run_kwargs)
+    stream = handle.stream()
+    completed_turn: object | None = None
+    items: list[object] = []
+    usage: object | None = None
+    try:
+        async for event in stream:
+            payload = getattr(event, "payload", None)
+            event_turn_id = getattr(payload, "turn_id", None)
+            if event_turn_id == getattr(handle, "id", None):
+                item = getattr(payload, "item", None)
+                if item is not None:
+                    items.append(item)
+                token_usage = getattr(payload, "token_usage", None)
+                if token_usage is not None:
+                    usage = token_usage
+            turn = getattr(payload, "turn", None)
+            if turn is not None and getattr(turn, "id", None) == getattr(handle, "id", None):
+                completed_turn = turn
+    finally:
+        await stream.aclose()
+
+    if completed_turn is None:
+        raise codex_protocol_error(
+            model=model,
+            operation=operation,
+            code="turn_completed_missing",
+            retryable=True,
+        )
+    if _status_value(completed_turn) != "completed":
+        raise codex_turn_error(
+            model=model,
+            operation=operation,
+            error=getattr(completed_turn, "error", None),
+        )
+    final_response = _final_response(items)
+    if not final_response:
+        raise codex_protocol_error(
+            model=model,
+            operation=operation,
+            code="final_response_missing",
+            retryable=True,
+        )
+    input_tokens, output_tokens = _usage_from(usage)
+    return CodexTurnOutcome(final_response, input_tokens, output_tokens)
+
+
+__all__ = ["CodexTurnOutcome", "run_codex_turn"]

--- a/workers/automation/src/jobctrl/infrastructure/llm/llm_client.py
+++ b/workers/automation/src/jobctrl/infrastructure/llm/llm_client.py
@@ -8,6 +8,7 @@ Raw OpenAI keys are Codex CLI enrollment input, never a direct model route.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import threading
 import warnings
@@ -15,6 +16,8 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any, Protocol
 
 from jobctrl.domain.ports.llm import LlmMessage
+from jobctrl.infrastructure.llm.codex_turn import run_codex_turn
+from jobctrl.infrastructure.llm.provider_errors import ProviderCallError, provider_exception_error
 _DEFAULT_MODEL_SENTINELS = {"", "default"}
 _ROUTED_PROVIDERS = {"claude", "codex", "gemini", "google"}
 
@@ -149,6 +152,15 @@ def _prompt_parts(messages: list[dict[str, str]]) -> tuple[str, str]:
         if item["role"] != "system"
     ]
     return "\n\n".join(systems), "\n\n".join(turns)
+
+
+def _schema_fingerprint(schema: dict | None) -> str | None:
+    """Return a non-reversible fingerprint for structured-output schema identity."""
+
+    if schema is None:
+        return None
+    encoded = json.dumps(schema, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return f"sha256:{hashlib.sha256(encoded.encode('utf-8')).hexdigest()}"
 
 
 def _claude_text(messages: list[Any]) -> str:
@@ -311,7 +323,6 @@ class CodexSdkBackend:
         from jobctrl.infrastructure.analysis.codex_analysis_adapter import (
             _deny_all_approval_mode,
             _load_async_codex_factory,
-            _usage_from_result,
         )
         from jobctrl.infrastructure.analysis.strict_schema import strict_json_schema
         from jobctrl.infrastructure.observability.llm_spans import llm_generation_span
@@ -333,34 +344,47 @@ class CodexSdkBackend:
             effort = "low"
         factory = self._async_codex_factory or _load_async_codex_factory()
         approval = self._approval_mode_factory or _deny_all_approval_mode
+        operation = "chat_json" if response_schema is not None else "chat"
+        schema_fingerprint = _schema_fingerprint(response_schema)
         with llm_generation_span(
             model=self.model,
             messages=messages,
             params={"structured": response_schema is not None, "effort": effort},
             scope_name="jobctrl.llm.codex",
+            schema_fingerprint=schema_fingerprint,
         ) as record:
-            async with factory() as codex:
-                thread = await codex.thread_start(
-                    approval_mode=approval(),
+            try:
+                async with factory() as codex:
+                    thread = await codex.thread_start(
+                        approval_mode=approval(),
+                        model=self.model,
+                        config={"model_reasoning_effort": effort},
+                    )
+                    run_kwargs: dict[str, Any] = {"effort": effort}
+                    if response_schema is not None:
+                        run_kwargs["output_schema"] = strict_json_schema(response_schema)
+                    outcome = await run_codex_turn(
+                        thread,
+                        combined,
+                        model=self.model,
+                        operation=operation,
+                        run_kwargs=run_kwargs,
+                    )
+            except ProviderCallError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - normalize only the provider boundary
+                raise provider_exception_error(
+                    provider="openai",
                     model=self.model,
-                    config={"model_reasoning_effort": effort},
-                )
-                run_kwargs: dict[str, Any] = {"effort": effort}
-                if response_schema is not None:
-                    run_kwargs["output_schema"] = strict_json_schema(response_schema)
-                result = await thread.run(combined, **run_kwargs)
-            status_obj = getattr(result, "status", None)
-            status = str(getattr(status_obj, "value", status_obj) or "")
-            final_response = getattr(result, "final_response", None)
-            if (status and status != "completed") or not isinstance(final_response, str) or not final_response:
-                raise RuntimeError(f"Codex turn failed: status={status!r}")
-            input_tokens, output_tokens = _usage_from_result(result)
+                    operation=operation,
+                    error=exc,
+                ) from exc
             record(
-                final_response,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
+                outcome.final_response,
+                input_tokens=outcome.input_tokens,
+                output_tokens=outcome.output_tokens,
             )
-            return final_response
+            return outcome.final_response
 
     def chat(self, messages: list[dict[str, str]], **kwargs: Any) -> str:
         return _run_sync(

--- a/workers/automation/src/jobctrl/infrastructure/llm/provider_errors.py
+++ b/workers/automation/src/jobctrl/infrastructure/llm/provider_errors.py
@@ -1,0 +1,281 @@
+"""Privacy-safe, provider-neutral LLM failure envelopes.
+
+The envelope deliberately carries only allowlisted provider metadata.  Provider
+messages, SDK objects, prompts, responses, and exception text can contain user
+data, so callers must never persist or export them directly.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+_MESSAGE_CODES = {
+    "builder error": "builder_error",
+    "invalid json": "invalid_json",
+    "invalid structured output": "invalid_structured_output",
+    "schema validation failed": "schema_validation_failed",
+    "structured output validation failed": "schema_validation_failed",
+}
+_CODEX_RETRYABLE_CODES = frozenset({"server_overloaded", "internal_server_error"})
+_CODEX_ERROR_INFO_CODES = {
+    "contextWindowExceeded": "context_window_exceeded",
+    "sessionBudgetExceeded": "session_budget_exceeded",
+    "usageLimitExceeded": "usage_limit_exceeded",
+    "serverOverloaded": "server_overloaded",
+    "cyberPolicy": "cyber_policy",
+    "internalServerError": "internal_server_error",
+    "unauthorized": "unauthorized",
+    "badRequest": "bad_request",
+    "threadRollbackFailed": "thread_rollback_failed",
+    "sandboxError": "sandbox_error",
+    "other": "other",
+}
+_CODEX_ERROR_INFO_VARIANTS = {
+    "httpconnectionfailedcodexerrorinfo": "http_connection_failed",
+    "responsestreamconnectionfailedcodexerrorinfo": "response_stream_connection_failed",
+    "responsestreamdisconnectedcodexerrorinfo": "response_stream_disconnected",
+    "responsetoomanyfailedattemptscodexerrorinfo": "response_too_many_failed_attempts",
+    "activeturnnotsteerablecodexerrorinfo": "active_turn_not_steerable",
+}
+_RETRYABLE_EXCEPTION_TYPES = frozenset({"TimeoutError", "ConnectionError", "OSError"})
+_SAFE_TOKEN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}")
+_TRACE_ID = re.compile(r"[a-f0-9]{32}")
+_SPAN_ID = re.compile(r"[a-f0-9]{16}")
+
+
+def _known_message_code(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = " ".join(value.lower().split())
+    return _MESSAGE_CODES.get(normalized)
+
+
+def _bounded_type_name(value: object) -> str:
+    name = type(value).__name__
+    if not re.fullmatch(r"[A-Za-z][A-Za-z0-9_]{0,63}", name):
+        return "unknown_exception"
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+
+
+def _safe_http_status(value: object) -> int | None:
+    if isinstance(value, int) and 100 <= value <= 599:
+        return value
+    return None
+
+
+def _safe_token(value: object, *, fallback: str = "unknown") -> str:
+    return value if isinstance(value, str) and _SAFE_TOKEN.fullmatch(value) else fallback
+
+
+def _codex_error_info(error_info: object) -> tuple[str | None, int | None]:
+    """Extract the only safe fields from SDK ``codex_error_info``.
+
+    The SDK models this as an enum or one of a small set of tagged objects.  We
+    retain the fixed tag and bounded HTTP status, never a serialized SDK object.
+    """
+
+    root = getattr(error_info, "root", error_info)
+    enum_value = getattr(root, "value", root if isinstance(root, str) else None)
+    if isinstance(enum_value, str) and enum_value in _CODEX_ERROR_INFO_CODES:
+        return _CODEX_ERROR_INFO_CODES[enum_value], None
+
+    variant = _CODEX_ERROR_INFO_VARIANTS.get(type(root).__name__.lower())
+    if variant is None:
+        return None, None
+    for attribute in (
+        "http_connection_failed",
+        "response_stream_connection_failed",
+        "response_stream_disconnected",
+        "response_too_many_failed_attempts",
+    ):
+        detail = getattr(root, attribute, None)
+        if detail is not None:
+            return variant, _safe_http_status(getattr(detail, "http_status_code", None))
+    return variant, None
+
+
+@dataclass
+class ProviderFailureEnvelope:
+    """Bounded metadata that can safely cross audit and telemetry boundaries."""
+
+    provider: str
+    model: str
+    operation: str
+    category: str
+    error_type: str
+    code: str
+    retryable: bool
+    message_code: str | None = None
+    additional_detail_code: str | None = None
+    additional_details_present: bool = False
+    codex_error_code: str | None = None
+    http_status: int | None = None
+    trace_id: str | None = None
+    span_id: str | None = None
+
+    def __post_init__(self) -> None:
+        # Provider/model values are configuration-derived but still cross an
+        # audit boundary. Reject paths, URLs, exception text, and other
+        # arbitrary strings rather than merely truncating them.
+        self.provider = _safe_token(self.provider)
+        self.model = _safe_token(self.model)
+        self.operation = _safe_token(self.operation)
+        self.category = _safe_token(self.category)
+        self.error_type = _safe_token(self.error_type)
+        self.code = _safe_token(self.code)
+        self.message_code = (
+            _safe_token(self.message_code) if self.message_code is not None else None
+        )
+        self.additional_detail_code = (
+            _safe_token(self.additional_detail_code)
+            if self.additional_detail_code is not None
+            else None
+        )
+        self.codex_error_code = (
+            _safe_token(self.codex_error_code) if self.codex_error_code is not None else None
+        )
+        self.http_status = _safe_http_status(self.http_status)
+
+    def attach_trace(self, *, trace_id: str | None, span_id: str | None) -> None:
+        if trace_id and _TRACE_ID.fullmatch(trace_id):
+            self.trace_id = trace_id
+        if span_id and _SPAN_ID.fullmatch(span_id):
+            self.span_id = span_id
+
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {
+            "provider": self.provider,
+            "model": self.model,
+            "operation": self.operation,
+            "category": self.category,
+            "error_type": self.error_type,
+            "code": self.code,
+            "retryable": self.retryable,
+            "additional_details_present": self.additional_details_present,
+        }
+        for key, value in (
+            ("message_code", self.message_code),
+            ("additional_detail_code", self.additional_detail_code),
+            ("codex_error_code", self.codex_error_code),
+            ("http_status", self.http_status),
+            ("trace_id", self.trace_id),
+            ("span_id", self.span_id),
+        ):
+            if value is not None:
+                result[key] = value
+        return result
+
+    def telemetry_attributes(self) -> dict[str, str | bool | int]:
+        attributes: dict[str, str | bool | int] = {
+            "jobctrl.llm.failure.provider": self.provider,
+            "jobctrl.llm.failure.model": self.model,
+            "jobctrl.llm.failure.operation": self.operation,
+            "jobctrl.llm.failure.category": self.category,
+            "jobctrl.llm.failure.type": self.error_type,
+            "jobctrl.llm.failure.code": self.code,
+            "jobctrl.llm.failure.retryable": self.retryable,
+            "jobctrl.llm.failure.additional_details_present": self.additional_details_present,
+        }
+        if self.message_code is not None:
+            attributes["jobctrl.llm.failure.message_code"] = self.message_code
+        if self.additional_detail_code is not None:
+            attributes["jobctrl.llm.failure.additional_detail_code"] = self.additional_detail_code
+        if self.codex_error_code is not None:
+            attributes["jobctrl.llm.failure.provider_code"] = self.codex_error_code
+        if self.http_status is not None:
+            attributes["jobctrl.llm.failure.http_status"] = self.http_status
+        return attributes
+
+
+class ProviderCallError(RuntimeError):
+    """Application-owned error that never embeds a provider message in ``str``."""
+
+    def __init__(self, envelope: ProviderFailureEnvelope) -> None:
+        self.envelope = envelope
+        super().__init__(
+            f"LLM provider call failed: {envelope.provider}/{envelope.operation} "
+            f"{envelope.category}:{envelope.code}"
+        )
+
+    def attach_trace(self, *, trace_id: str | None, span_id: str | None) -> None:
+        self.envelope.attach_trace(trace_id=trace_id, span_id=span_id)
+
+
+def codex_turn_error(*, model: str, operation: str, error: object | None) -> ProviderCallError:
+    """Convert a failed Codex ``Turn`` into the safe application envelope."""
+
+    message_code = _known_message_code(getattr(error, "message", None))
+    additional_details = getattr(error, "additional_details", None)
+    additional_detail_code = _known_message_code(additional_details)
+    codex_code, http_status = _codex_error_info(getattr(error, "codex_error_info", None))
+    code = message_code or additional_detail_code or codex_code or "turn_failed"
+    retryable = bool(
+        http_status == 429
+        or (http_status is not None and http_status >= 500)
+        or codex_code in _CODEX_RETRYABLE_CODES
+    )
+    return ProviderCallError(
+        ProviderFailureEnvelope(
+            provider="openai",
+            model=model,
+            operation=operation,
+            category="provider_turn",
+            error_type="codex_turn_error",
+            code=code,
+            retryable=retryable,
+            message_code=message_code,
+            additional_detail_code=additional_detail_code,
+            additional_details_present=additional_details is not None,
+            codex_error_code=codex_code,
+            http_status=http_status,
+        )
+    )
+
+
+def provider_exception_error(
+    *,
+    provider: str,
+    model: str,
+    operation: str,
+    error: BaseException,
+) -> ProviderCallError:
+    """Classify an SDK-boundary exception without retaining its text."""
+
+    type_name = _bounded_type_name(error)
+    retryable = type(error).__name__ in _RETRYABLE_EXCEPTION_TYPES
+    return ProviderCallError(
+        ProviderFailureEnvelope(
+            provider=provider,
+            model=model,
+            operation=operation,
+            category="provider_transport" if retryable else "provider_exception",
+            error_type=type_name,
+            code="transport_error" if retryable else "sdk_exception",
+            retryable=retryable,
+        )
+    )
+
+
+def codex_protocol_error(*, model: str, operation: str, code: str, retryable: bool) -> ProviderCallError:
+    """Create an allowlisted error for an incomplete or malformed SDK lifecycle."""
+
+    return ProviderCallError(
+        ProviderFailureEnvelope(
+            provider="openai",
+            model=model,
+            operation=operation,
+            category="provider_protocol",
+            error_type="codex_turn_protocol",
+            code=code,
+            retryable=retryable,
+        )
+    )
+
+
+__all__ = [
+    "ProviderCallError",
+    "ProviderFailureEnvelope",
+    "codex_protocol_error",
+    "codex_turn_error",
+    "provider_exception_error",
+]

--- a/workers/automation/src/jobctrl/infrastructure/observability/llm_spans.py
+++ b/workers/automation/src/jobctrl/infrastructure/observability/llm_spans.py
@@ -49,6 +49,7 @@ def llm_generation_span(
     messages: list[dict],
     params: dict,
     scope_name: str = "jobctrl.llm",
+    schema_fingerprint: str | None = None,
 ) -> Iterator[RecordResponse]:
     """Open a ``langfuse.observation.type=generation`` span around an LLM call.
 
@@ -66,8 +67,12 @@ def llm_generation_span(
         span.set_attribute("langfuse.observation.type", "generation")
         span.set_attribute("langfuse.observation.model.name", model)
         span.set_attribute("gen_ai.request.model", model)
-        span.set_attribute("gen_ai.operation.name", "chat")
+        operation = "chat_json" if params.get("structured") is True else "chat"
+        span.set_attribute("gen_ai.operation.name", operation)
+        span.set_attribute("jobctrl.llm.operation", operation)
         span.set_attribute("jobctrl.llm.stage", scope_name)
+        if schema_fingerprint is not None:
+            span.set_attribute("jobctrl.llm.schema_fingerprint", schema_fingerprint)
         span.set_attribute("jobctrl.llm.input.message_count", len(messages))
         span.set_attribute(
             "jobctrl.llm.input.character_count",
@@ -115,10 +120,39 @@ def llm_generation_span(
         try:
             yield record
         except Exception as exc:
+            from jobctrl.infrastructure.llm.provider_errors import ProviderCallError
+
             error_type = type(exc).__name__
-            span.set_attribute("error.type", error_type)
+            if isinstance(exc, ProviderCallError):
+                context = span.get_span_context()
+                trace_id = f"{context.trace_id:032x}" if context.is_valid else None
+                span_id = f"{context.span_id:016x}" if context.is_valid else None
+                exc.attach_trace(trace_id=trace_id, span_id=span_id)
+                for key, value in exc.envelope.telemetry_attributes().items():
+                    span.set_attribute(key, value)
+                span.set_attribute("error.type", exc.envelope.error_type)
+                status_description = (
+                    "LLM provider call failed "
+                    f"({exc.envelope.category}:{exc.envelope.code})"
+                )
+            else:
+                span.set_attribute("error.type", error_type)
+                # SDK adapters that do not expose a typed provider error still
+                # need the same bounded, queryable failure dimensions. Do not
+                # serialize their exception text or object graph.
+                for key, value in {
+                    "jobctrl.llm.failure.provider": provider or "unknown",
+                    "jobctrl.llm.failure.model": model,
+                    "jobctrl.llm.failure.operation": operation,
+                    "jobctrl.llm.failure.category": "provider_exception",
+                    "jobctrl.llm.failure.type": error_type,
+                    "jobctrl.llm.failure.code": "sdk_exception",
+                    "jobctrl.llm.failure.retryable": False,
+                }.items():
+                    span.set_attribute(key, value)
+                status_description = f"LLM call failed ({error_type})"
             span.set_attribute("jobctrl.llm.success", False)
-            span.set_status(Status(StatusCode.ERROR, f"LLM call failed ({error_type})"))
+            span.set_status(Status(StatusCode.ERROR, status_description))
             raise
         else:
             span.set_attribute("jobctrl.llm.success", True)

--- a/workers/automation/tests/test_codex_adapter_status.py
+++ b/workers/automation/tests/test_codex_adapter_status.py
@@ -83,5 +83,5 @@ async def test_enum_status_failed_raises() -> None:
         error="boom",
     )
     adapter = CodexAnalysisAdapter(async_codex_factory=_factory(result))
-    with pytest.raises(RuntimeError, match="Codex turn failed"):
+    with pytest.raises(RuntimeError, match="provider_turn:turn_failed"):
         await adapter.draft("system prompt", "JOB: x")

--- a/workers/automation/tests/test_employer_analysis_ensemble.py
+++ b/workers/automation/tests/test_employer_analysis_ensemble.py
@@ -357,7 +357,7 @@ class TestCodexAdapter:
         adapter = CodexAnalysisAdapter(
             async_codex_factory=lambda: _FakeAsyncCodex("", status="failed"),
         )
-        with pytest.raises(RuntimeError, match="Codex turn failed"):
+        with pytest.raises(RuntimeError, match="provider_turn:turn_failed"):
             await adapter.draft("system", JD)
 
     async def test_draft_opens_generation_span_with_model_and_tokens(self, in_memory_exporter) -> None:

--- a/workers/automation/tests/test_llm_provider_routing.py
+++ b/workers/automation/tests/test_llm_provider_routing.py
@@ -17,6 +17,7 @@ from jobctrl.infrastructure.llm.llm_client import (
     GoogleSdkBackend,
     SdkControlNormalizationWarning,
 )
+from jobctrl.infrastructure.llm.provider_errors import ProviderCallError
 
 
 class ResultMessage:
@@ -58,6 +59,34 @@ class _CodexThread:
         )
 
 
+class _FailedCodexTurnHandle:
+    id = "turn-builder-error"
+
+    async def stream(self):
+        # This mirrors the public SDK stream shape closely enough to prove we
+        # retain TurnError fields that AsyncThread.run() otherwise discards.
+        yield SimpleNamespace(
+            payload=SimpleNamespace(
+                turn=SimpleNamespace(
+                    id=self.id,
+                    status=SimpleNamespace(value="failed"),
+                    error=SimpleNamespace(
+                        message="builder error",
+                        additional_details="schema validation failed",
+                        codex_error_info=SimpleNamespace(
+                            root=SimpleNamespace(value="serverOverloaded")
+                        ),
+                    ),
+                )
+            )
+        )
+
+
+class _FailedCodexThread:
+    async def turn(self, prompt: str, **kwargs: Any) -> _FailedCodexTurnHandle:
+        return _FailedCodexTurnHandle()
+
+
 class _Codex:
     def __init__(self, calls: dict[str, Any] | None = None) -> None:
         self.calls = calls
@@ -72,6 +101,11 @@ class _Codex:
         if self.calls is not None:
             self.calls["thread_start"] = kwargs
         return _CodexThread(self.calls)
+
+
+class _FailedCodex(_Codex):
+    async def thread_start(self, **kwargs: Any) -> _FailedCodexThread:
+        return _FailedCodexThread()
 
 
 class _GoogleResponse:
@@ -261,6 +295,36 @@ def test_codex_sdk_maps_thinking_to_effort_and_normalizes_unsupported_controls()
     assert calls["run"]["effort"] == "medium"
     assert "temperature" not in calls["run"]
     assert "max_tokens" not in calls["run"]
+
+
+def test_codex_sdk_retains_safe_builder_error_fields_from_failed_turn() -> None:
+    backend = CodexSdkBackend(
+        model="codex-test-model",
+        async_codex_factory=lambda: _FailedCodex(),
+        approval_mode_factory=lambda: "deny",
+    )
+
+    with pytest.raises(ProviderCallError) as raised:
+        backend.chat_json(
+            [{"role": "user", "content": "synthetic request"}],
+            response_schema={"type": "object", "properties": {"answer": {"type": "integer"}}},
+        )
+
+    envelope = raised.value.envelope.to_dict()
+    assert envelope.items() >= {
+        "provider": "openai",
+        "model": "codex-test-model",
+        "operation": "chat_json",
+        "category": "provider_turn",
+        "error_type": "codex_turn_error",
+        "code": "builder_error",
+        "retryable": True,
+        "message_code": "builder_error",
+        "additional_detail_code": "schema_validation_failed",
+        "additional_details_present": True,
+        "codex_error_code": "server_overloaded",
+    }.items()
+    assert "schema validation failed" not in repr(envelope)
 
 
 def test_google_sdk_maps_thinking_level_and_normalizes_unsupported_controls(

--- a/workers/automation/tests/test_llm_spans.py
+++ b/workers/automation/tests/test_llm_spans.py
@@ -122,7 +122,70 @@ def test_llm_generation_span_records_content_free_failure(caplog, in_memory_expo
     assert span.status.status_code == StatusCode.ERROR
     assert span.status.description == "LLM call failed (RuntimeError)"
     assert attrs["error.type"] == "RuntimeError"
+    assert attrs["jobctrl.llm.failure.provider"] == "unknown"
+    assert attrs["jobctrl.llm.failure.model"] == "m"
+    assert attrs["jobctrl.llm.failure.operation"] == "chat"
+    assert attrs["jobctrl.llm.failure.category"] == "provider_exception"
+    assert attrs["jobctrl.llm.failure.type"] == "RuntimeError"
+    assert attrs["jobctrl.llm.failure.code"] == "sdk_exception"
+    assert attrs["jobctrl.llm.failure.retryable"] is False
     assert attrs["jobctrl.llm.success"] is False
     assert span.events == ()
     assert private_sentinel not in _exported_span_text(span)
     assert private_sentinel not in caplog.text
+
+
+def test_llm_generation_span_exports_safe_provider_failure_attributes(in_memory_exporter):
+    from opentelemetry.trace import StatusCode
+
+    from jobctrl.infrastructure.llm.provider_errors import (
+        ProviderCallError,
+        ProviderFailureEnvelope,
+    )
+    from jobctrl.infrastructure.observability.llm_spans import llm_generation_span
+
+    private_sentinel = "PRIVATE_PROVIDER_ERROR_TEXT"
+    failure = ProviderCallError(
+        ProviderFailureEnvelope(
+            provider="openai",
+            model="codex-test-model",
+            operation="chat_json",
+            category="provider_turn",
+            error_type="codex_turn_error",
+            code="builder_error",
+            retryable=True,
+            message_code="builder_error",
+            additional_detail_code="schema_validation_failed",
+            additional_details_present=True,
+            codex_error_code="server_overloaded",
+        )
+    )
+
+    with pytest.raises(ProviderCallError):
+        with llm_generation_span(
+            model="codex-test-model",
+            messages=[{"role": "user", "content": private_sentinel}],
+            params={"structured": True},
+            scope_name="jobctrl.llm.codex",
+            schema_fingerprint="schema-safe-fingerprint",
+        ):
+            raise failure
+
+    span = in_memory_exporter.get_finished_spans()[0]
+    attrs = _attrs(span)
+    assert span.status.status_code == StatusCode.ERROR
+    assert span.status.description == "LLM provider call failed (provider_turn:builder_error)"
+    assert attrs["jobctrl.llm.operation"] == "chat_json"
+    assert attrs["jobctrl.llm.schema_fingerprint"] == "schema-safe-fingerprint"
+    assert attrs["jobctrl.llm.failure.provider"] == "openai"
+    assert attrs["jobctrl.llm.failure.model"] == "codex-test-model"
+    assert attrs["jobctrl.llm.failure.operation"] == "chat_json"
+    assert attrs["jobctrl.llm.failure.category"] == "provider_turn"
+    assert attrs["jobctrl.llm.failure.type"] == "codex_turn_error"
+    assert attrs["jobctrl.llm.failure.code"] == "builder_error"
+    assert attrs["jobctrl.llm.failure.retryable"] is True
+    assert attrs["jobctrl.llm.failure.additional_details_present"] is True
+    assert attrs["jobctrl.llm.failure.provider_code"] == "server_overloaded"
+    assert failure.envelope.trace_id is not None
+    assert failure.envelope.span_id is not None
+    assert private_sentinel not in _exported_span_text(span)

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -59,6 +59,7 @@ from jobctrl.domain.ports.events import EventPublisher
 from jobctrl.domain.ports.llm import LlmMessage, LlmPort
 from jobctrl.domain.profile.aggregate import Profile
 from jobctrl.domain.profile.snapshot import ProfileSnapshot
+from jobctrl.infrastructure.llm.provider_errors import ProviderCallError, ProviderFailureEnvelope
 from jobctrl.domain.scoring import (
     FitScore,
     RequirementFitAssessment,
@@ -492,6 +493,36 @@ class _ScriptedLlm:
 
     def ask(self, prompt: str, **kwargs) -> str:
         return self.chat([LlmMessage(role="user", content=prompt)], **kwargs)
+
+
+class _ProviderFailingLlm:
+    """Raises an application-owned provider error for every candidate call."""
+
+    def __init__(self, private_provider_text: str) -> None:
+        self.private_provider_text = private_provider_text
+        self.calls = 0
+
+    def chat_json(self, messages: list[LlmMessage], **kwargs) -> dict:
+        self.calls += 1
+        error = ProviderCallError(
+            ProviderFailureEnvelope(
+                provider="openai",
+                model="codex-test-model",
+                operation="chat_json",
+                category="provider_turn",
+                error_type="codex_turn_error",
+                code="builder_error",
+                retryable=True,
+                message_code="builder_error",
+                additional_detail_code="schema_validation_failed",
+                additional_details_present=True,
+                codex_error_code="server_overloaded",
+            )
+        )
+        # Simulate a provider SDK object carrying sensitive diagnostics. The
+        # use case must persist only the envelope, never arbitrary fields.
+        error.raw_provider_message = self.private_provider_text
+        raise error
 
 
 class _RecordingPublisher:
@@ -2519,6 +2550,65 @@ def test_tailor_use_case_exhausted_when_no_parseable_json(
     assert audit["attempt_history"][0]["system_prompt"]
     assert audit["attempt_history"][0]["candidates"][0]["status"] == "parse_error"
     assert any(getattr(e, "event_type", "") == "ResumeFailed" for e in publisher.events)
+
+
+def test_tailor_use_case_persists_safe_provider_failures_without_calling_them_parse_errors(
+    tmp_path: Path, snapshot: ProfileSnapshot, job: dict
+) -> None:
+    private_sentinel = "PRIVATE_CODEX_ADDITIONAL_DETAILS"
+    repo = _FakeRepository()
+    llm = _ProviderFailingLlm(private_sentinel)
+    use_case = TailorResumeUseCase(
+        repository=repo,
+        llm=llm,
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+        analyze_use_case=_FakeAnalyzeUseCase(),
+    )
+
+    outcome = use_case.execute(
+        job=job,
+        profile_snapshot=snapshot,
+        tailored_dir=tmp_path,
+        audit_execution_id="temporal-run-builder-error",
+        durable_attempt=2,
+    )
+
+    assert outcome.status == "provider_error"
+    assert outcome.error == "All candidate provider calls failed"
+    assert llm.calls == 4
+    audit_entry = repo.saved[-1].metadata["tailoring_attempt_audits"][-1]
+    assert audit_entry["execution_id"] == "temporal-run-builder-error"
+    assert audit_entry["durable_attempt"] == 2
+    audit = audit_entry["report"]
+    assert audit["status"] == "provider_error"
+    candidates = [
+        attempt["candidates"][0]
+        for attempt in audit["attempt_history"]
+    ]
+    assert [candidate["status"] for candidate in candidates] == ["provider_error"] * 4
+    provider_error = candidates[-1]["provider_error"]
+    assert provider_error.items() >= {
+        "provider": "openai",
+        "model": "codex-test-model",
+        "operation": "chat_json",
+        "category": "provider_turn",
+        "error_type": "codex_turn_error",
+        "code": "builder_error",
+        "retryable": True,
+        "message_code": "builder_error",
+        "additional_detail_code": "schema_validation_failed",
+        "additional_details_present": True,
+        "codex_error_code": "server_overloaded",
+        "inner_attempt": 4,
+        "workflow_run_id": "temporal-run-builder-error",
+        "durable_attempt": 2,
+        "schema_version": "tailored-resume.v3",
+    }.items()
+    assert provider_error["candidate_id"]
+    assert provider_error["prompt_fingerprint"]
+    assert "parse_error" not in provider_error
+    assert private_sentinel not in json.dumps(audit, sort_keys=True)
 
 
 def test_tailor_use_case_preserves_attempt_audit_across_durable_executions(

--- a/workers/automation/tests/test_v7_tailor_runtime.py
+++ b/workers/automation/tests/test_v7_tailor_runtime.py
@@ -1508,7 +1508,9 @@ def test_tailor_one_job_passes_canonical_id_to_materials_use_case() -> None:
         SimpleNamespace(),
         "normal",
         use_case=FakeUseCase(),
+        audit_execution_id="temporal-run-owned",
     )
 
     assert result["status"] == "approved"
     assert captured["job_id"] == _JOB_ID
+    assert captured["audit_execution_id"] == "temporal-run-owned"

--- a/workers/automation/tests/test_workflow_job_preparation.py
+++ b/workers/automation/tests/test_workflow_job_preparation.py
@@ -873,7 +873,7 @@ async def test_preparation_tailor_failure_owns_the_temporal_execution_id(
     )
     logical_workflow_id = f"prep-{payload.idempotency_key}"
 
-    async with await WorkflowEnvironment.start_time_skipping() as env:
+    async with time_skipping_env() as env:
         async with Worker(
             env.client,
             task_queue=queue,

--- a/workers/automation/tests/test_workflow_job_preparation.py
+++ b/workers/automation/tests/test_workflow_job_preparation.py
@@ -833,3 +833,70 @@ async def test_preparation_workflow_retries_transient_tailor_failure(
     assert result.steps_completed == ["tailor"]
     assert result.steps_failed == []
     assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_preparation_tailor_failure_owns_the_temporal_execution_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A new Tailor audit must be owned by the execution UUID, not its logical ID."""
+
+    queue = f"prep-tailor-audit-owner-{uuid.uuid4()}"
+    observed_audit_execution_ids: list[str | None] = []
+
+    @activity.defn(name="record_workflow_started")
+    async def record_started(_payload) -> None:
+        return None
+
+    @activity.defn(name="record_workflow_outcome")
+    async def record_outcome(_payload) -> None:
+        return None
+
+    @activity.defn(name="recover_preparation_state")
+    async def recover_state(_payload) -> None:
+        return None
+
+    def exhausted_tailor(payload, **_kwargs) -> dict[str, object]:
+        observed_audit_execution_ids.append(payload.workflow_id)
+        return {
+            "status": "exhausted",
+            "error": "Tailor durable attempt budget exhausted.",
+        }
+
+    monkeypatch.setattr("jobctrl.materials.activities._tailor_one_job", exhausted_tailor)
+    payload = JobPreparationInput(
+        tenant_id="local",
+        job_id=_JOB_ID,
+        steps=["tailor"],
+        target_version="1",
+        idempotency_key=f"preparation:{uuid.uuid4().hex}",
+    )
+    logical_workflow_id = f"prep-{payload.idempotency_key}"
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=queue,
+            workflows=[JobPreparationWorkflow],
+            activities=[
+                _check_spend_budget,
+                record_started,
+                record_outcome,
+                recover_state,
+                tailor_job_activity,
+            ],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            handle = await env.client.start_workflow(
+                JobPreparationWorkflow.run,
+                payload,
+                id=logical_workflow_id,
+                task_queue=queue,
+                id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+            )
+            result = await asyncio.wait_for(handle.result(), timeout=30)
+
+    assert result.steps_failed == ["tailor"]
+    assert result.error_code == "attempt_budget_exhausted"
+    assert observed_audit_execution_ids == [handle.first_execution_run_id]
+    assert observed_audit_execution_ids[0] != logical_workflow_id


### PR DESCRIPTION
## Summary

- preserve bounded, privacy-safe provider failure details before SDK exceptions collapse them
- distinguish provider failures from JSON parse failures in tailoring audit records and existing telemetry spans
- correlate diagnostics to the exact Temporal execution and expose aggregated counts and latest failure details in run views
- distinguish automatic retryability from operator-initiated Tailor recovery
- provide a narrowly labeled compatibility bridge for historical structured-output builder failures

## Why

Provider turn failures were flattened into generic runtime exceptions, then recorded as parse errors. The audit records were not projected into workflow-run details, leaving operators with only a terminal attempt-budget error and no explanation of the underlying repeated failures.

## User impact

Run details now show the provider failure count, safe diagnostic dimensions, structured-details availability, and whether manual recovery is available. Prompts, outputs, arbitrary exception messages, paths, URLs, and secrets remain excluded.

## Validation

- 177 focused worker tests passed
- 9 API read-model tests passed
- 9 run-drawer tests passed
- contracts, API, and web typechecks passed
- targeted Ruff checks passed
- documentation build passed
- production web build passed
- independent review and QA gates passed with no Blocker or High findings

## Stack

This PR is based on #830 and should be reviewed after it.