### PR TITLE
fix(ci): use a general Dependabot cooldown for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,10 +95,11 @@ updates:
       time: "04:00"
       timezone: "Europe/Madrid"
     open-pull-requests-limit: 3
+    # Dependabot rejects semver-granular cooldowns for github-actions
+    # (actions resolve as refs, not semver packages); only a general
+    # cooldown is supported here.
     cooldown:
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
+      default-days: 7
     groups:
       actions-minor-and-patch:
         patterns:


### PR DESCRIPTION
## What

Dependabot refused to parse `.github/dependabot.yml` after #835 merged:

```
The property '#/updates/3/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
(same for semver-minor-days and semver-patch-days)
```

The `github-actions` ecosystem resolves dependencies as refs/tags rather than semver packages, so Dependabot only supports a general cooldown there. The actions entry now uses `cooldown: default-days: 7`; the npm, uv, and gomod entries keep their 30/7/3 semver tiers, which the parser accepted (only `updates/3` was flagged).

## Why 7 days

It matches the minor-tier intent from #835: weekly grouped bumps stay tamed without over-delaying pinned-SHA refreshes.

## Validation

- YAML parses; all four update entries verified: npm/uv/gomod keep semver tiers, github-actions carries only `default-days`
- `git diff --check` clean
- Server-side acceptance is only provable by Dependabot's next parse after merge; the failing properties named in the error are gone