### PR TITLE
chore(release): prepare v0.1.1

### DIFF
--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -1,11 +1,10 @@
 # JobCtrl Public Launch Status
 
-JobCtrl's public application version is resetting to `v0.1.0` as an
-early-access release. The withdrawn pre-launch `2.0.x` numbering remains
-preserved in tags, releases, signatures, and immutable artifacts; the reset
-corrects maturity signaling and does not reset product data, database schemas,
-launcher protocols, or signed-release security counters. The detailed release
-and recovery record remains in
+JobCtrl's current early-access line is `0.1.x`; the `v0.1.1` release candidate
+advances the published `v0.1.0` build without changing product data, database
+schemas, launcher protocols, or signed-release security counters. The withdrawn
+pre-launch `2.0.x` numbering remains preserved in tags, releases, signatures,
+and immutable artifacts. The detailed release and recovery record remains in
 [`docs/publish-checklist.md`](docs/publish-checklist.md).
 
 ## Live Public Surfaces
@@ -21,8 +20,10 @@ and recovery record remains in
 
 ## Remaining Distribution Follow-Up
 
-- [ ] Publish and verify the `0.1.0` early-access Python package, then yank the
+- [x] Publish and verify the `0.1.0` early-access Python package, then yank the
   preserved `2.0.7` and `2.0.8` files without deleting them.
+- [ ] Publish and verify `v0.1.1` through signed stable sequence 4, then cut the
+  canonical installers over to its immutable release assets.
 - [ ] Complete the published-artifact, lifecycle, clean-machine, and real-path
   TTFV acceptance matrix recorded in `docs/publish-checklist.md`.
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ credentials, resumes, application data, logs, or other personal information.
 
 ## Get Started
 
-JobCtrl `0.1.0` is an early-access application release. The public version was
-reset from the pre-launch `2.0.x` numbering so the version communicates the
-product's actual maturity; this is not a product, data, database-schema,
-launcher-protocol, or security downgrade.
+JobCtrl `0.1.1` is the current early-access application release. The public
+version began at `0.1.0` after the pre-launch `2.0.x` numbering was withdrawn so
+the version communicates the product's actual maturity; this did not downgrade
+the product, data, database schema, launcher protocol, or security controls.
 
 Install the signed Apple-silicon macOS release with the bundled installer:
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/extension",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/extension/public/manifest.json
+++ b/apps/extension/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "JobCtrl",
   "description": "Save job postings from the browser into the local JobCtrl app.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "action": {
     "default_popup": "popup.html"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -6,7 +6,7 @@ This is the detailed engineering backlog. The public roadmap lives in
 `docs/plans/implemented/`. Delivery history lives in the git log and the
 implemented plan records.
 
-## Current State Snapshot (2026-08-12)
+## Current State Snapshot (2026-08-23)
 
 Delivered work is recorded in the git log and the implemented plan directory.
 Discovery RFC production wiring and scoring intelligence are implemented via
@@ -30,17 +30,19 @@ of legacy `jobs.*` storage fallbacks, table/artifact/profile UX improvements,
 browser QA gaps, frontend a11y deferrals, and tooling / CI enforcement gaps.
 Hosted product, hosted data, hosted automation, and cloud-mode frontend adapters
 remain deferred until the local product is solid. Native distribution is
-implemented. The public application version is resetting to the `0.1.0`
-early-access line while the withdrawn pre-launch `2.0.x` tags, releases, and
-immutable artifacts remain preserved. P7 clean-machine product QA remains an
-operational release follow-up rather than unfinished implementation.
+implemented. The published `0.1.0` build established the early-access line,
+and the `0.1.1` release candidate advances it while the withdrawn pre-launch
+`2.0.x` tags, releases, and immutable artifacts remain preserved. P7
+clean-machine product QA remains an operational release follow-up rather than
+unfinished implementation.
 
 ## Release Hardening Follow-Ups
 
-- Publish `v0.1.0` through the signed stable workflow as sequence 3 while
+- Publish `v0.1.1` through the signed stable workflow as sequence 4 while
   retaining minimum-safe sequence 2 and the existing `v2.0.7` revocation, then
-  run the published-artifact, lifecycle, clean-machine, and real-path TTFV
-  acceptance matrix recorded in `docs/publish-checklist.md`.
+  cut over the canonical installers and run the published-artifact, lifecycle,
+  clean-machine, and real-path TTFV acceptance matrix recorded in
+  `docs/publish-checklist.md`.
 - Treat analytics-optional public-demo access and post-accept
   withdrawal/current-visitor erasure as separately scoped privacy work. Keep
   the shipped consent-required behavior unchanged unless an explicit
@@ -51,7 +53,7 @@ operational release follow-up rather than unfinished implementation.
   capability checks, connection verification, model discovery, telemetry and
   spend semantics, every core `LlmPort` operation, employer-analysis synthesis,
   and fail-closed readiness before `LLM_URL` or an equivalent setting can return
-  to the product surface. The `0.1.0` early-access release supports only Codex,
+  to the product surface. The `0.1.x` early-access line supports only Codex,
   Claude, and Google.
 - Implement the explicitly deferred W2.4 spend-control delta after the initial
   public release:

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -407,6 +407,29 @@ especially §§11–14. This is a release precondition, not permission to publis
   with a yank warning. Update the existing GitHub release descriptions without
   changing their immutable assets: label `v2.0.7` withdrawn and revoked, and
   label `v2.0.8` a safe historical build superseded by the numbering reset.
+- **Approved `v0.1.1` stable increment.** Publish the merged release-preparation
+  commit as annotated tag `v0.1.1`, then manually dispatch the signed workflow
+  at that tag ref. This is an additive patch release on the established `0.1.x`
+  line. Advance the signed anti-rollback sequence to 4, retain minimum-safe
+  sequence 2, carry the bytewise-sorted `v2.0.7` revocation, and keep the safe
+  `v0.1.0` build unrevoked. Use these promotion inputs:
+
+  ```text
+  release_tag=v0.1.1
+  channel=stable
+  pypi_recovery_only=false
+  sequence=4
+  minimum_safe_sequence=2
+  revoked_build_ids=["2.0.7-db257efe1087ec00ac2ec49b846a95d2423aecc2-darwin-arm64"]
+  expected_channel_pointer_sha256=38dd07f0473bf6f8ad6c0931e42eaf1791774a2c17267eda3e425bb405fc130a
+  ```
+
+  Re-read the public stable pointer immediately before dispatch. If its digest
+  changed, stop and reconcile the intervening signed release instead of
+  weakening the compare-and-swap guard. After the workflow succeeds, verify
+  the immutable GitHub Release, signed R2 descriptor and stable pointer,
+  Homebrew formula, and `0.1.1` wheel and source distribution on PyPI before
+  starting the separate canonical-installer cutover in 9.6.
 - **Rollback.** Preserve the immutable Release and tag as audit evidence. Yank
   a bad PyPI file/version when necessary, then publish a new higher-sequence
   signed release that explicitly revokes or supersedes the affected build.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -9,10 +9,11 @@ files stay on your computer unless you explicitly connect an external provider.
 Install it once, then use the same `jobctrl` command from any directory.
 
 ::: warning Early access
-JobCtrl `0.1.0` resets the public application version from the pre-launch
-`2.0.x` numbering so the version reflects the product's actual maturity. The
-reset does not downgrade product behavior, local data, database schemas,
-launcher protocols, signed-release safety, or security controls.
+JobCtrl `0.1.1` is the current early-access application release. The public
+version began at `0.1.0` after the pre-launch `2.0.x` numbering was withdrawn so
+the version reflects the product's actual maturity. That change did not
+downgrade product behavior, local data, database schemas, launcher protocols,
+signed-release safety, or security controls.
 :::
 
 ::: tip Want to explore before installing?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jobctrl",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "AI-powered end-to-end job application pipeline",
   "type": "module",

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/api-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/contracts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/domain-types/package.json
+++ b/packages/domain-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/domain-types",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jobctrl/tsconfig",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "exports": {

--- a/scripts/distribution-manifest.test.mjs
+++ b/scripts/distribution-manifest.test.mjs
@@ -99,7 +99,7 @@ test("distribution contracts are complete and every version source resolves", as
   assert.equal(report.nodeLicenseEvidenceCount, 13);
   assert.equal(report.capabilityCount, 3);
   assert.deepEqual(report.platforms, ["darwin-arm64"]);
-  assert.equal(report.versions["jobctrl-launcher"], "0.1.0");
+  assert.equal(report.versions["jobctrl-launcher"], "0.1.1");
   assert.equal(report.versions["playwright-python"], "1.58.0");
   assert.equal(report.versions["font-geist"], "5.2.9");
   assert.equal(report.versions["font-jetbrains-mono"], "5.2.8");

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -298,10 +298,10 @@ test("local fixture release descriptor, signature, and curl contract bind one ZI
     minimumSafeSequence: 0,
     revokedBuildIds: [],
     buildId: "fixture-build-0001",
-    appVersion: "0.1.0",
+    appVersion: "0.1.1",
     platform: { id: "darwin-arm64", os: "darwin", arch: "arm64" },
     artifact: {
-      url: "file:///jobctrl-local-release/jobctrl-0.1.0-darwin-arm64.zip",
+      url: "file:///jobctrl-local-release/jobctrl-0.1.1-darwin-arm64.zip",
       sha256: build.archiveSha256,
       sizeBytes: build.compressedBytes,
       archiveType: "zip",

--- a/scripts/version-contract.test.mjs
+++ b/scripts/version-contract.test.mjs
@@ -8,7 +8,7 @@ const execFileAsync = promisify(execFile);
 const root = new URL("../", import.meta.url);
 const read = (path) => readFile(new URL(path, root), "utf8");
 const readJson = async (path) => JSON.parse(await read(path));
-const APP_VERSION = "0.1.0";
+const APP_VERSION = "0.1.1";
 
 test("public application versions agree without resetting compatibility counters", async () => {
   const packageVersions = await Promise.all([
@@ -26,11 +26,11 @@ test("public application versions agree without resetting compatibility counters
   }
 
   assert.equal((await readJson("apps/extension/public/manifest.json")).version, APP_VERSION);
-  assert.match(await read("workers/automation/pyproject.toml"), /^version = "0\.1\.0"$/m);
-  assert.match(await read("workers/automation/src/jobctrl/__init__.py"), /^__version__ = "0\.1\.0"$/m);
+  assert.match(await read("workers/automation/pyproject.toml"), /^version = "0\.1\.1"$/m);
+  assert.match(await read("workers/automation/src/jobctrl/__init__.py"), /^__version__ = "0\.1\.1"$/m);
   assert.match(
     await read("workers/automation/uv.lock"),
-    /\[\[package\]\]\nname = "jobctrl"\nversion = "0\.1\.0"\nsource = \{ editable = "\." \}/,
+    /\[\[package\]\]\nname = "jobctrl"\nversion = "0\.1\.1"\nsource = \{ editable = "\." \}/,
   );
 
   assert.match(await read("apps/api/src/schema-manifest.ts"), /EXACT_V9_SCHEMA_MANIFEST[\s\S]*?version: 9,/);
@@ -42,10 +42,10 @@ test("public application versions agree without resetting compatibility counters
   assert.deepEqual(platforms.platforms[0].launcherCompatibility, { minimum: 1, maximum: 1 });
 });
 
-test("release parity gate accepts the reset tag v0.1.0", async () => {
+test("release parity gate accepts the current tag v0.1.1", async () => {
   const { stdout, stderr } = await execFileAsync(
     "python3",
-    ["scripts/release_check.py", "--release-tag", "v0.1.0"],
+    ["scripts/release_check.py", "--release-tag", "v0.1.1"],
     { cwd: new URL("../", import.meta.url), maxBuffer: 16 * 1024 * 1024 },
   );
   assert.equal(stderr, "");

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jobctrl"
-version = "0.1.0"
+version = "0.1.1"
 description = "AI-powered end-to-end job application pipeline"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/workers/automation/src/jobctrl/__init__.py
+++ b/workers/automation/src/jobctrl/__init__.py
@@ -1,3 +1,3 @@
 """JobCtrl — AI-powered end-to-end job application pipeline."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -585,7 +585,7 @@ wheels = [
 
 [[package]]
 name = "jobctrl"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## What changed

- advances every canonical JobCtrl application version from 0.1.0 to 0.1.1 across the JavaScript workspaces, browser extension, Python package, and lock metadata
- updates current-version distribution fixtures and the version-parity gate while preserving historical v0.1.0 recovery and anti-rollback fixtures
- records the stable sequence-4 promotion inputs, existing revocation, current compare-and-swap digest, and post-release installer cutover requirement
- updates current public and contributor documentation for the 0.1.1 early-access release

## Why

This additive patch release ships the cumulative profile/Plate/PDF-export and provider-diagnostics work together with the explicitly selected pypdf and Mermaid dependency updates. It preserves database schema 9, launcher protocol/state schema 1, minimum-safe sequence 2, and the existing v2.0.7 revocation.

## Validation

- corepack pnpm scripts:test — 139 passed
- python3 scripts/release_check.py --strict-prompt --release-tag v0.1.1 — passed
- corepack pnpm distribution:audit — passed
- corepack pnpm docs:build — 9,653 references resolved
- corepack pnpm docs:check:runtime — passed
- env -u UV_EXCLUDE_NEWER uv --project workers/automation lock --check — passed
- isolated wheel and source distribution builds — both report Version: 0.1.1
- git diff --check — passed

Full hosted checks are required before merge and tagging.