### PR TITLE
chore(deps): adopt JobStreaming 0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ evidence, qualifications, and the complete capability matrix.
   posting before acknowledging its provider checkpoint. If the worker stops,
   the same Discover execution resumes unfinished query/location/board units;
   accepted postings and the run-wide new-job limit survive replay, and
-  Pipelines reports how many units resumed. JobStreaming 0.0.3 also supplies
+  Pipelines reports how many units resumed. JobStreaming 0.0.4 also supplies
   cursor-free provider page progress so the active crawl can show completed
   pages, raw listings, emitted jobs, and known continuation without guessing
   an unavailable provider total. JobCtrl can separately estimate source-family

--- a/docs/architecture/pipeline/envelope.md
+++ b/docs/architecture/pipeline/envelope.md
@@ -128,7 +128,7 @@ required-step list is never interpreted as proof of no work.
 ### Broad-Board Search Unit Envelope
 
 The `jobspy` source family name remains a compatibility key, but its provider is
-JobStreaming 0.0.3. At activity start, JobCtrl compiles or verifies an immutable
+JobStreaming 0.0.4. At activity start, JobCtrl compiles or verifies an immutable
 ordered plan of query/location/board units under the exact
 `DiscoveryExecutionRef`. Changing the live target-search configuration cannot
 rewrite a retrying execution's persisted plan.

--- a/docs/architecture/pipeline/operations.md
+++ b/docs/architecture/pipeline/operations.md
@@ -119,7 +119,7 @@ Broad-board progress uses `search units` as its source-level unit. Its
 `filteredJobs` comes from hashed filtered-result receipts, and `recoveredUnits`
 counts units reclaimed by a newer Temporal activity attempt.
 The TypeScript read model preserves that optional field and Pipelines renders
-it as `N resumed`. JobStreaming 0.0.3 `ProviderProgress` is a separate immutable
+it as `N resumed`. JobStreaming 0.0.4 `ProviderProgress` is a separate immutable
 value inside the source progress: provider, phase, unit, completed/total units,
 raw items seen, emitted jobs, and tri-state continuation. The worker stamps the
 exact Discover workflow/run identity onto the progress event, and Operations

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -503,7 +503,7 @@ draft leg.
 
 ### Broad-Board Provider Boundary
 
-JobStreaming 0.0.3 is the provider boundary for Indeed, LinkedIn, Glassdoor,
+JobStreaming 0.0.4 is the provider boundary for Indeed, LinkedIn, Glassdoor,
 and ZipRecruiter. The infrastructure gateway translates JobCtrl-owned immutable
 search specifications into provider requests and projects typed provider events
 back into the existing discovery ingestion shape. Provider types do not enter

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2154,6 +2154,12 @@ contention only when they are queued or observed as active work. Selected-run
 sweep demand reserves one slot per remaining preparation workflow and blocks
 the source range only when those workflows exceed currently spare capacity.
 
+Amended (2026-08-28): the provider pin advances to JobStreaming 0.0.4 without
+changing JobCtrl's request, typed-event, or checkpoint ownership. The provider
+release reduces LinkedIn continuation pacing, uses the observed ten-card page
+contract, stops after a partial final page, and avoids detail work for identities
+already present in the current or resumed provider checkpoint.
+
 ## 2026-07-29: Stable Job Identity And Human-Approved Feedback Learning
 
 Status: accepted

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -50,7 +50,7 @@ corepack pnpm dev:setup
 
 `corepack pnpm dev:setup` installs the Node workspace dependencies and runs
 `uv --project workers/automation sync --extra dev`, which installs the Python
-worker, the pinned `jobstreaming==0.0.3` provider, its locked transitive
+worker, the pinned `jobstreaming==0.0.4` provider, its locked transitive
 dependencies, and the Python dev tools used by local checks. It does not install Temporal or
 Playwright browser binaries. Do not set `UV_EXCLUDE_NEWER` (or a global uv
 `exclude-newer` config): it makes uv treat `uv.lock` as needing re-resolution,

--- a/docs/user/discovery.md
+++ b/docs/user/discovery.md
@@ -196,7 +196,7 @@ Temporal run ID, and the bounded repair reason code remain available under
 
 ### Resumable Broad-Board Searches
 
-Broad-board discovery uses JobStreaming 0.0.3. At the beginning of the source
+Broad-board discovery uses JobStreaming 0.0.4. At the beginning of the source
 activity, JobCtrl compiles an immutable unit for every query, target/provider
 location, and board under the exact Discover workflow/run identity. JobCtrl,
 not the provider, owns whether that unit is pending, running, completed, failed,

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "opentelemetry-instrumentation-httpx>=0.48b0",
     # Typed, concurrent job-board events plus resumable checkpoints. Pin the
     # integration contract so JobCtrl's durable adapter changes deliberately.
-    "jobstreaming==0.0.3",
+    "jobstreaming==0.0.4",
     # Pydantic backs the canonical employer-analysis domain model
     # (``domain/materials/analysis.py``) and is also pulled transitively by
     # the agent SDKs below. Declared explicitly because the domain layer
@@ -145,4 +145,4 @@ default-groups = ["provider-runtime"]
 # as a relative timestamp would make an unchanged lockfile fail `uv --locked`
 # as time passes. Provider runtimes and the audited JobStreaming integration
 # retain their explicit reviewed cutoffs.
-exclude-newer-package = { "google-antigravity" = "2026-06-04T21:19:27Z", "claude-agent-sdk" = "2026-07-10T00:00:00Z", "jobstreaming" = "2026-08-10T23:59:59Z" }
+exclude-newer-package = { "google-antigravity" = "2026-06-04T21:19:27Z", "claude-agent-sdk" = "2026-07-10T00:00:00Z", "jobstreaming" = "2026-08-28T23:59:59Z" }

--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -95,7 +95,10 @@ def _scrape_with_retry(kwargs: dict, max_retries: int = 2, backoff: float = 5.0)
             scrape_legacy_options,
         )
     except ImportError as exc:
-        raise ImportError("jobstreaming 0.0.3 is not installed. Run the JobCtrl setup again.") from exc
+        raise ImportError(
+            "The pinned jobstreaming dependency is not installed. "
+            "Run the JobCtrl setup again."
+        ) from exc
     return scrape_legacy_options(
         kwargs,
         max_retries=max_retries,

--- a/workers/automation/src/jobctrl/infrastructure/discovery/jobstreaming_gateway.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/jobstreaming_gateway.py
@@ -162,7 +162,7 @@ def _normalize_tls_adapter_timeouts(
 
 
 class JobStreamingGateway:
-    """Build and consume the pinned JobStreaming 0.0.3 event contract."""
+    """Build and consume the pinned JobStreaming event contract."""
 
     @staticmethod
     def build_request(spec: JobStreamingSearchSpec) -> SearchRequest:

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -1704,11 +1704,11 @@ def test_jobspy_normalizes_source_locations_before_storage(tmp_path):
 
 def test_jobspy_missing_dependency_is_not_reported_as_empty_success(monkeypatch):
     def missing_jobspy(_kwargs: dict, max_retries: int = 2, backoff: float = 5.0):
-        raise ImportError("jobstreaming 0.0.3 is not installed")
+        raise ImportError("The pinned jobstreaming dependency is not installed")
 
     monkeypatch.setattr(jobspy, "_scrape_with_retry", missing_jobspy)
 
-    with pytest.raises(ImportError, match="jobstreaming 0.0.3"):
+    with pytest.raises(ImportError, match="pinned jobstreaming dependency"):
         jobspy._run_one_search(
             {"query": "Director of Engineering", "location": "Barcelona, Spain", "remote": True},
             ["indeed"],

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -18,7 +18,7 @@ resolution-markers = [
 [options.exclude-newer-package]
 claude-agent-sdk = "2026-07-10T00:00:00Z"
 google-antigravity = "2026-06-04T21:19:27Z"
-jobstreaming = "2026-08-10T23:59:59Z"
+jobstreaming = "2026-08-28T23:59:59Z"
 
 [[package]]
 name = "absl-py"
@@ -658,7 +658,7 @@ requires-dist = [
     { name = "google-auth", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "hatchling", marker = "extra == 'dev'", specifier = "==1.29.0" },
     { name = "httpx", specifier = ">=0.24" },
-    { name = "jobstreaming", specifier = "==0.0.3" },
+    { name = "jobstreaming", specifier = "==0.0.4" },
     { name = "mcp", marker = "extra == 'providers'", specifier = ">=1.28.1" },
     { name = "openai-codex", marker = "extra == 'providers'", specifier = "==0.144.4" },
     { name = "openai-codex-cli-bin", marker = "extra == 'providers'", specifier = "==0.144.4" },
@@ -701,7 +701,7 @@ release-check = [{ name = "pytest", specifier = ">=7.0" }]
 
 [[package]]
 name = "jobstreaming"
-version = "0.0.3"
+version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -710,9 +710,9 @@ dependencies = [
     { name = "requests" },
     { name = "tls-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/a2/704c4f44db95e987721b31757384cab8a8bcb86026e50e7cddc5fec441e2/jobstreaming-0.0.3.tar.gz", hash = "sha256:5a83cc6b1fc039a2f5bb2bf24d85c505c669659d2bb20c1d4a857a2b41af3ada", size = 99735, upload-time = "2026-08-10T10:15:56.91Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/07/f4bdbe4693438d4aab3133db26b12df0dd920bb34da4c546cd2a60abcc0d/jobstreaming-0.0.4.tar.gz", hash = "sha256:0775d31da84ad88536949df47364011a955e9e19bb1f1ea8bc338380b8dd0bd0", size = 100515, upload-time = "2026-08-28T20:07:33.347Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/46/2abc6e7b2ad1b672982ff270399cce7a92cc1293f3a543407b21ad401a0b/jobstreaming-0.0.3-py3-none-any.whl", hash = "sha256:4eb23380badae578ab9c43479be3fd544424368bcc91be2d2643834a660c2345", size = 105533, upload-time = "2026-08-10T10:15:55.48Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c9/5003954d668a564f89b914bcdf26b2758e31f21aabbe6165d4b81929b6ab/jobstreaming-0.0.4-py3-none-any.whl", hash = "sha256:466f65443e8eddc44a706ab6e71b5282c46103e811f890913c707a8b49d6f741", size = 105952, upload-time = "2026-08-28T20:07:31.678Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Outcome

Adopt the published JobStreaming 0.0.4 provider release in JobCtrl.

## Changes

- pin the worker dependency to jobstreaming 0.0.4
- advance only the reviewed JobStreaming package cutoff and lock the published wheel and source archive hashes
- update current product, user, architecture, operations, and contributor documentation to identify the active provider version
- preserve the dated 0.0.3 decision amendment and add a dated 0.0.4 amendment
- make the missing-provider diagnostic and gateway docstring version-neutral so they cannot drift on the next pin update

## Compatibility

JobStreaming 0.0.4 preserves the request, typed-event, acknowledgement, checkpoint, cursor-schema, and checkpoint-store contracts consumed by JobCtrl. The release changes LinkedIn transport behavior inside the provider boundary: corrected ten-card pagination, partial-page termination, randomized continuation pacing, and pre-detail suppression for already-seen identities.

## Validation

- published PyPI wheel and source hashes match the lockfile and GitHub release assets
- GitHub attestations verify for both published artifacts
- locked installation imports jobstreaming 0.0.4 from the managed registry environment
- focused JobStreaming gateway, search-unit, durability, replay, cancellation, and discovery integration suite: 90 passed
- Ruff worker lint: passed
- uv lock check and frozen sync: passed
- documentation build: passed; 9,653 references and redirects validated
- distribution audit: passed
- git diff check: passed
- independent review and QA gates: PASS with no findings

## Safety

No live job-provider crawl, JobCtrl release, or deployment was performed.