### PR TITLE
fix(discovery): preserve provider remote evidence

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/discovery/jobstreaming_gateway.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/jobstreaming_gateway.py
@@ -114,6 +114,29 @@ class JobStreamingSearchError(RuntimeError):
 _TLS_CLIENT_SITES = frozenset({Site.GLASSDOOR, Site.ZIP_RECRUITER})
 
 
+def _apply_provider_filter_evidence(
+    frame: pd.DataFrame,
+    spec: JobStreamingSearchSpec,
+) -> pd.DataFrame:
+    """Preserve provider-owned facts that listing text cannot reconstruct.
+
+    LinkedIn applies its remote-only request as a provider filter. Its listing
+    card can still contain only a country/region, and JobStreaming otherwise
+    derives ``is_remote`` from the title, location, and optional description.
+    When description fetching is disabled, treating that derived false as
+    stronger than the provider-filter result would drop valid remote listings.
+    """
+
+    if frame.empty or not spec.remote_only or "site" not in frame.columns:
+        return frame
+    linkedin_rows = frame["site"].astype(str).str.casefold().eq(Site.LINKEDIN.value)
+    if not linkedin_rows.any():
+        return frame
+    projected = frame.copy()
+    projected.loc[linkedin_rows, "is_remote"] = True
+    return projected
+
+
 class _IntegralTlsTimeoutAdapter(Scraper):
     """Normalize the provider timeout for tls-client adapters that require ints."""
 
@@ -224,9 +247,12 @@ class JobStreamingGateway:
         and its operational discovery run id have changed.
         """
 
-        frame = jobs_to_dataframe(
-            [(event.site, event.job)],
-            cls.build_request(spec),
+        frame = _apply_provider_filter_evidence(
+            jobs_to_dataframe(
+                [(event.site, event.job)],
+                cls.build_request(spec),
+            ),
+            spec,
         )
         frame["jobstreaming_job_key"] = event.job_key
         return frame
@@ -288,7 +314,10 @@ class JobStreamingGateway:
                 stream.ack(event)
 
         return JobStreamingBatch(
-            frame=jobs_to_dataframe(jobs, request),
+            frame=_apply_provider_filter_evidence(
+                jobs_to_dataframe(jobs, request),
+                spec,
+            ),
             failures=tuple(failures),
             warnings=tuple(warnings),
             completed=completed,

--- a/workers/automation/tests/test_jobstreaming_gateway.py
+++ b/workers/automation/tests/test_jobstreaming_gateway.py
@@ -7,6 +7,7 @@ from jobstreaming import (
     JobPost,
     JobEvent,
     JobResponse,
+    Location,
     MemoryCheckpointStore,
     RateLimitError,
     Scraper,
@@ -50,6 +51,30 @@ class _RateLimitedAdapter(Scraper):
 
     def scrape(self, request, context=None) -> JobResponse:
         raise RateLimitError("slow down")
+
+
+class _RemoteFilterLinkedIn(Scraper):
+    capabilities = AdapterCapabilities(filters=frozenset({"location", "is_remote"}))
+
+    def __init__(self, **_: object) -> None:
+        super().__init__(Site.LINKEDIN)
+
+    def scrape(self, request, context=None) -> JobResponse:
+        assert request.is_remote is True
+        assert context is not None
+        context.emit_job(
+            JobPost(
+                id="linkedin-remote-1",
+                title="Engineering Manager",
+                company_name="Example",
+                job_url="https://www.linkedin.com/jobs/view/linkedin-remote-1",
+                location=Location(city="Spain"),
+                description="",
+                is_remote=False,
+            ),
+            {"start": 1},
+        )
+        return JobResponse()
 
 
 class _TlsTimeoutInspectingAdapter(Scraper):
@@ -201,6 +226,32 @@ def test_job_event_projection_preserves_the_provider_idempotency_key() -> None:
 
     assert frame.loc[0, "job_url"] == "https://example.test/jobs/1"
     assert frame.loc[0, "jobstreaming_job_key"] == event.job_key
+
+
+def test_linkedin_remote_filter_evidence_survives_batch_and_event_projection() -> None:
+    registry = AdapterRegistry()
+    registry.register(Site.LINKEDIN, _RemoteFilterLinkedIn)
+    gateway = JobStreamingGateway()
+    spec = JobStreamingSearchSpec(
+        sites=("linkedin",),
+        query="Engineering Manager",
+        location="European Union",
+        results_per_site=10,
+        remote_only=True,
+        linkedin_fetch_description=False,
+    )
+
+    batch = gateway.collect(spec, registry=registry)
+    assert batch.frame.loc[0, "location"] == "Spain"
+    assert bool(batch.frame.loc[0, "is_remote"]) is True
+
+    with gateway.open_stream(spec, registry=registry, resume=False) as stream:
+        event = next(stream)
+        assert isinstance(event, JobEvent)
+        frame = gateway.frame_for_job_event(event, spec)
+
+    assert frame.loc[0, "location"] == "Spain"
+    assert bool(frame.loc[0, "is_remote"]) is True
 
 
 def test_proxy_and_user_agent_reach_the_provider_constructor() -> None:


### PR DESCRIPTION
## Outcome

Preserve provider-applied remote-only evidence when a LinkedIn listing card exposes only a country or region, so an otherwise valid remote lead is not rejected by JobCtrl's location admission.

## Changes

- apply the frozen remote-only request fact during both streamed-event and compatibility-batch projection
- keep this provider evidence separate from final relevance and suitability
- add a deterministic gateway regression for a sparse LinkedIn card

## Validation

- focused gateway tests: passed
- cumulative discovery integration QA: 118 passed
- complete locked worker suite: 3,729 passed, 2 skipped
- whole-worker Ruff lint, uv lock check, documentation build, and diff check: passed
- independent cumulative review and Tier 2 QA: PASS with zero findings

## Stack

Part 1 of stack #853. This PR is independently useful and is based on `main`.

## Safety

No live provider crawl, production data access, release, deployment, or application submission was performed.
