### PR TITLE
feat(discovery): admit broad-board listing leads

### DIFF
--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -207,8 +207,10 @@ def store_jobspy_results(
                 salary += f"/{interval}"
 
         description = _nullable_str(row.get("description"))
-        if not (description or "").strip():
-            continue
+        # Discovery metadata explicitly permits an empty listing snippet.
+        # Persist the accepted lead so canonical detail enrichment can fetch
+        # the full description; dropping it here would make listing-only
+        # provider search silently lose otherwise valid jobs.
         site_name = str(row.get("site", source_label))
         is_remote = _truthy_remote(row.get("is_remote", False))
         location_str = normalize_location_display(location_str, is_remote=is_remote)

--- a/workers/automation/src/jobctrl/infrastructure/discovery/jobstreaming_gateway.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/jobstreaming_gateway.py
@@ -114,6 +114,29 @@ class JobStreamingSearchError(RuntimeError):
 _TLS_CLIENT_SITES = frozenset({Site.GLASSDOOR, Site.ZIP_RECRUITER})
 
 
+def _apply_provider_filter_evidence(
+    frame: pd.DataFrame,
+    spec: JobStreamingSearchSpec,
+) -> pd.DataFrame:
+    """Preserve provider-owned facts that listing text cannot reconstruct.
+
+    LinkedIn applies its remote-only request as a provider filter. Its listing
+    card can still contain only a country/region, and JobStreaming otherwise
+    derives ``is_remote`` from the title, location, and optional description.
+    When description fetching is disabled, treating that derived false as
+    stronger than the provider-filter result would drop valid remote listings.
+    """
+
+    if frame.empty or not spec.remote_only or "site" not in frame.columns:
+        return frame
+    linkedin_rows = frame["site"].astype(str).str.casefold().eq(Site.LINKEDIN.value)
+    if not linkedin_rows.any():
+        return frame
+    projected = frame.copy()
+    projected.loc[linkedin_rows, "is_remote"] = True
+    return projected
+
+
 class _IntegralTlsTimeoutAdapter(Scraper):
     """Normalize the provider timeout for tls-client adapters that require ints."""
 
@@ -224,9 +247,12 @@ class JobStreamingGateway:
         and its operational discovery run id have changed.
         """
 
-        frame = jobs_to_dataframe(
-            [(event.site, event.job)],
-            cls.build_request(spec),
+        frame = _apply_provider_filter_evidence(
+            jobs_to_dataframe(
+                [(event.site, event.job)],
+                cls.build_request(spec),
+            ),
+            spec,
         )
         frame["jobstreaming_job_key"] = event.job_key
         return frame
@@ -288,7 +314,10 @@ class JobStreamingGateway:
                 stream.ack(event)
 
         return JobStreamingBatch(
-            frame=jobs_to_dataframe(jobs, request),
+            frame=_apply_provider_filter_evidence(
+                jobs_to_dataframe(jobs, request),
+                spec,
+            ),
             failures=tuple(failures),
             warnings=tuple(warnings),
             completed=completed,

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -816,6 +816,10 @@ def retire_invalid_source_jobs(
             accept_locs=accept_locs,
             reject_locs=reject_locs,
             locations=locations,
+            # Match the intake boundary: broad-board rows are durable listing
+            # leads even when Detail Enrichment is deferred or fails. Direct
+            # sources still promise usable content at discovery time.
+            require_description=family != "jobspy",
         )
         if not reasons:
             continue
@@ -897,6 +901,11 @@ def _posting_acceptance_policy(search_cfg: Mapping[str, Any]):
             accept_locs=accept_locs,
             reject_locs=reject_locs,
             locations=locations,
+            # Broad boards are lead generators. Their accepted listing metadata
+            # is enough to enter canonical Detail Enrichment, which owns the
+            # full-description requirement. Direct sources still need content
+            # at their intake boundary.
+            require_description=family != "jobspy",
         )
         if not reasons:
             return PostingAcceptance.accept()
@@ -967,11 +976,12 @@ def _source_rejection_reasons(
     accept_locs: list[str],
     reject_locs: list[str],
     locations: tuple[str, ...],
+    require_description: bool = True,
 ) -> list[str]:
     reasons: list[str] = []
     effective_accept_locs = accept_locs or [location for location in locations if location]
     location_evidence = " ".join(str(part).strip() for part in (location, title) if str(part or "").strip())
-    if not _usable_description_text(description):
+    if require_description and not _usable_description_text(description):
         reasons.append("missing_description")
     if query_specs and not title_matches_any_query(title, query_specs):
         reasons.append("title_mismatch")

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -656,7 +656,7 @@ def test_jobspy_stores_company_and_backfills_existing_job(tmp_path):
         close_connection(db_path)
 
 
-def test_jobspy_store_filters_rows_without_descriptions_before_limit(tmp_path):
+def test_jobspy_store_accepts_listing_without_description_before_limit(tmp_path):
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
     try:
@@ -681,8 +681,11 @@ def test_jobspy_store_filters_rows_without_descriptions_before_limit(tmp_path):
         )
 
         assert jobspy.store_jobspy_results(conn, results, "Head of Engineering", limit=1) == (1, 0)
-        urls = {row["url"] for row in conn.execute("SELECT url FROM jobs").fetchall()}
-        assert urls == {"https://www.linkedin.com/jobs/view/with-description"}
+        rows = conn.execute("SELECT url, description FROM jobs").fetchall()
+        assert [(row["url"], row["description"]) for row in rows] == [
+            ("https://www.linkedin.com/jobs/view/no-description", "")
+        ]
+        assert conn.execute("SELECT COUNT(*) FROM job_enrichments").fetchone()[0] == 0
     finally:
         close_connection(db_path)
 
@@ -750,7 +753,7 @@ def test_jobspy_rejects_location_mismatches_before_discovery_persistence(tmp_pat
         close_connection(db_path)
 
 
-def test_jobspy_store_filters_null_description_sentinels(tmp_path):
+def test_jobspy_store_normalizes_null_description_sentinels_for_enrichment(tmp_path):
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
     try:
@@ -783,8 +786,10 @@ def test_jobspy_store_filters_null_description_sentinels(tmp_path):
             ]
         )
 
-        assert jobspy.store_jobspy_results(conn, results, "Head of Engineering", limit=10) == (0, 0)
-        assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 0
+        assert jobspy.store_jobspy_results(conn, results, "Head of Engineering", limit=10) == (3, 0)
+        descriptions = conn.execute("SELECT description FROM jobs").fetchall()
+        assert [row["description"] for row in descriptions] == ["", "", ""]
+        assert conn.execute("SELECT COUNT(*) FROM job_enrichments").fetchone()[0] == 0
     finally:
         close_connection(db_path)
 

--- a/workers/automation/tests/test_discovery_production_wiring.py
+++ b/workers/automation/tests/test_discovery_production_wiring.py
@@ -903,7 +903,7 @@ def test_discovery_hygiene_retires_invalid_jobspy_rows(
     assert "location_mismatch" in deleted["https://www.linkedin.com/jobs/view/us-engineering-manager"]
 
 
-def test_discovery_hygiene_treats_serialized_null_descriptions_as_missing(
+def test_discovery_hygiene_retains_jobspy_listing_leads_without_descriptions(
     conn: sqlite3.Connection,
 ) -> None:
     rows = [
@@ -989,22 +989,9 @@ def test_discovery_hygiene_treats_serialized_null_descriptions_as_missing(
         run_id="hygiene:serialized-null",
     )
 
-    assert result["retired_jobs"] == 3
+    assert result["retired_jobs"] == 0
     deleted = _deleted_reasons_by_url(conn)
-    assert "https://www.linkedin.com/jobs/view/valid-head-engineering" not in deleted
-    assert (
-        "https://www.linkedin.com/jobs/view/enrichment-sentinel-with-fallback"
-        not in deleted
-    )
-    assert "missing_description" in deleted[
-        "https://www.linkedin.com/jobs/view/none-description"
-    ]
-    assert "missing_description" in deleted[
-        "https://www.linkedin.com/jobs/view/pandas-na-description"
-    ]
-    assert "missing_description" in deleted[
-        "https://www.linkedin.com/jobs/view/nan-description"
-    ]
+    assert not deleted
 
 
 def test_discovery_hygiene_applies_to_workday_and_smart_extract_rows(

--- a/workers/automation/tests/test_jobstreaming_gateway.py
+++ b/workers/automation/tests/test_jobstreaming_gateway.py
@@ -7,6 +7,7 @@ from jobstreaming import (
     JobPost,
     JobEvent,
     JobResponse,
+    Location,
     MemoryCheckpointStore,
     RateLimitError,
     Scraper,
@@ -50,6 +51,30 @@ class _RateLimitedAdapter(Scraper):
 
     def scrape(self, request, context=None) -> JobResponse:
         raise RateLimitError("slow down")
+
+
+class _RemoteFilterLinkedIn(Scraper):
+    capabilities = AdapterCapabilities(filters=frozenset({"location", "is_remote"}))
+
+    def __init__(self, **_: object) -> None:
+        super().__init__(Site.LINKEDIN)
+
+    def scrape(self, request, context=None) -> JobResponse:
+        assert request.is_remote is True
+        assert context is not None
+        context.emit_job(
+            JobPost(
+                id="linkedin-remote-1",
+                title="Engineering Manager",
+                company_name="Example",
+                job_url="https://www.linkedin.com/jobs/view/linkedin-remote-1",
+                location=Location(city="Spain"),
+                description="",
+                is_remote=False,
+            ),
+            {"start": 1},
+        )
+        return JobResponse()
 
 
 class _TlsTimeoutInspectingAdapter(Scraper):
@@ -201,6 +226,32 @@ def test_job_event_projection_preserves_the_provider_idempotency_key() -> None:
 
     assert frame.loc[0, "job_url"] == "https://example.test/jobs/1"
     assert frame.loc[0, "jobstreaming_job_key"] == event.job_key
+
+
+def test_linkedin_remote_filter_evidence_survives_batch_and_event_projection() -> None:
+    registry = AdapterRegistry()
+    registry.register(Site.LINKEDIN, _RemoteFilterLinkedIn)
+    gateway = JobStreamingGateway()
+    spec = JobStreamingSearchSpec(
+        sites=("linkedin",),
+        query="Engineering Manager",
+        location="European Union",
+        results_per_site=10,
+        remote_only=True,
+        linkedin_fetch_description=False,
+    )
+
+    batch = gateway.collect(spec, registry=registry)
+    assert batch.frame.loc[0, "location"] == "Spain"
+    assert bool(batch.frame.loc[0, "is_remote"]) is True
+
+    with gateway.open_stream(spec, registry=registry, resume=False) as stream:
+        event = next(stream)
+        assert isinstance(event, JobEvent)
+        frame = gateway.frame_for_job_event(event, spec)
+
+    assert frame.loc[0, "location"] == "Spain"
+    assert bool(frame.loc[0, "is_remote"]) is True
 
 
 def test_proxy_and_user_agent_reach_the_provider_constructor() -> None:


### PR DESCRIPTION
## Outcome

Retain viable broad-board listing cards even when the provider search response has no description, so canonical Detail Enrichment can fetch the posting instead of Discovery silently dropping it.

## Changes

- remove the legacy missing-description rejection from broad-board storage
- normalize null-like description sentinels to an empty listing description
- keep the existing title, location, age, identity, and limit behavior intact
- prove admitted sparse leads remain eligible for `pending_detail`

Admission here means permission to persist and enrich; it is not a relevance score or a claim that the job is suitable.

## Validation

- focused discovery admission and limit regressions: passed
- cumulative discovery integration QA: 118 passed
- complete locked worker suite: 3,729 passed, 2 skipped
- whole-worker Ruff lint, uv lock check, documentation build, and diff check: passed
- independent cumulative review and Tier 2 QA: PASS with zero findings

## Stack

Part 2 of stack #853. Base: #848.

## Safety

No live provider crawl, production data access, release, deployment, or application submission was performed.
