### PR TITLE
perf(discovery): defer LinkedIn detail fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ evidence, qualifications, and the complete capability matrix.
   pages, raw listings, emitted jobs, and known continuation without guessing
   an unavailable provider total. JobCtrl can separately estimate source-family
   completion from recent whole-family durations when live queue and capacity
-  observations bound the shared worker contention.
+  observations bound the shared worker contention. LinkedIn search remains a
+  lightweight listing pass; full posting text is fetched by Detail Enrichment
+  only after a listing passes Discovery's acceptance checks.
 - Optionally reconcile a local Temporal Schedule for discovery; it is disabled
   by default and uses the configured cron only after you enable it.
 - Enrich postings with full descriptions, canonical posting URLs, and apply

--- a/docs/architecture/pipeline/stages.md
+++ b/docs/architecture/pipeline/stages.md
@@ -92,7 +92,10 @@ Key facts about the four activities:
 
   The broad-board family further decomposes the immutable search plan into one
   query/location/board unit per JobStreaming stream. Each posting is durably
-  accepted before explicit provider acknowledgement. The unit checkpoint,
+  accepted before explicit provider acknowledgement. Provider search captures
+  listing metadata only; in particular, LinkedIn full-description requests are
+  deferred until the accepted job reaches Detail Enrichment, so rejected and
+  duplicate listings do not pay the detail-fetch cost. The unit checkpoint,
   accepted-job receipts, result-limit count, typed board failure, and current
   Temporal activity-attempt fence live in SQLite. A hard worker loss leaves the
   unit `running` for the next activity attempt to reclaim; replay is idempotent.

--- a/docs/user/discovery.md
+++ b/docs/user/discovery.md
@@ -57,7 +57,9 @@ starts, so a change affects the next run rather than work already in progress.
 selected board for one search unit. This is a provider request limit, not a
 promise that every board will return that many accepted jobs; title, location,
 age, and deduplication checks still apply. The next Discover run snapshots the
-new value.
+new value. LinkedIn search does not download every result's full description:
+accepted listings enter Detail Enrichment, which fetches the posting content
+needed for scoring.
 
 <a id="runtime-setting-posting-lookback-hours"></a>
 **Posting lookback hours.** Limit broad-board discovery to postings no older

--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -1052,14 +1052,16 @@ def _run_one_search(
             "hours_old": hours_old,
             "description_format": "markdown",
             "country_indeed": defaults.get("country_indeed", "usa"),
+            # Detail enrichment owns full posting content. Keeping broad-board
+            # intake listing-only avoids one LinkedIn detail request for every
+            # raw result before title, location, and identity checks run.
+            "linkedin_fetch_description": False,
             "verbose": 0,
         }
         if s.get("remote"):
             kwargs["is_remote"] = True
         if proxy_config:
             kwargs["proxies"] = [proxy_config.jobspy]
-        if "linkedin" in other_sites:
-            kwargs["linkedin_fetch_description"] = True
         try:
             df, failures = _jobstreaming_frame_and_failures(_scrape_with_retry(kwargs, max_retries=max_retries))
             provider_errors += failures
@@ -1234,6 +1236,9 @@ def search_jobs(
         "hours_old": hours_old,
         "description_format": "markdown",
         "country_indeed": country_indeed,
+        # Full descriptions are fetched once, after listing acceptance, by the
+        # canonical detail-enrichment stage.
+        "linkedin_fetch_description": False,
         "verbose": 2,
     }
 
@@ -1242,9 +1247,6 @@ def search_jobs(
 
     if proxy_config:
         kwargs["proxies"] = [proxy_config.jobspy]
-
-    if "linkedin" in sites:
-        kwargs["linkedin_fetch_description"] = True
 
     # Pace this single manual search via the shared limiter (R10, D3). jobspy's
     # internal per-board transport remains unpoliced (documented residual).
@@ -1322,6 +1324,7 @@ def _durable_search_specs(
     sites: list[str],
     results_per_site: int,
     hours_old: int,
+    linkedin_fetch_description: bool = False,
 ) -> list[DiscoverySearchSpec]:
     """Split the crawl into immutable provider-location-compatible units."""
 
@@ -1367,7 +1370,9 @@ def _durable_search_specs(
                 DiscoverySearchSpec(
                     provider_location=provider_location,
                     sites=(site,),
-                    linkedin_fetch_description=site == "linkedin",
+                    linkedin_fetch_description=(
+                        site == "linkedin" and linkedin_fetch_description
+                    ),
                     **common,
                 )
             )
@@ -1695,6 +1700,18 @@ def _durable_full_crawl(
         SqliteDiscoverySearchUnitRepository,
     )
 
+    conn = init_db()
+    repository = SqliteDiscoverySearchUnitRepository(conn)
+    existing_units = repository.list_units(discovery_execution)
+    # New executions keep provider search listing-only. An interrupted
+    # execution must replay its already-frozen request exactly, including the
+    # legacy LinkedIn detail-fetch flag, or checkpoint fingerprints would no
+    # longer match after an upgrade.
+    persisted_linkedin_detail = any(
+        unit.spec.sites == ("linkedin",)
+        and unit.spec.linkedin_fetch_description
+        for unit in existing_units
+    )
     specs = _durable_search_specs(
         search_cfg,
         tiers=tiers,
@@ -1702,9 +1719,8 @@ def _durable_full_crawl(
         sites=sites,
         results_per_site=results_per_site,
         hours_old=hours_old,
+        linkedin_fetch_description=persisted_linkedin_detail,
     )
-    conn = init_db()
-    repository = SqliteDiscoverySearchUnitRepository(conn)
     repository.plan_units(discovery_execution, specs)
     proxy_config = parse_proxy(proxy) if proxy else None
     proxies = [proxy_config.jobspy] if proxy_config else None

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -450,7 +450,12 @@ def test_jobspy_retains_partial_results_and_counts_typed_board_failure(monkeypat
         completed=False,
     )
     stored: list[str] = []
-    monkeypatch.setattr(jobspy, "_scrape_with_retry", lambda *_args, **_kwargs: batch)
+
+    def fake_scrape(options: dict, *_args, **_kwargs):
+        assert options["linkedin_fetch_description"] is False
+        return batch
+
+    monkeypatch.setattr(jobspy, "_scrape_with_retry", fake_scrape)
     monkeypatch.setattr(jobspy, "get_connection", lambda: object())
     monkeypatch.setattr(
         jobspy,

--- a/workers/automation/tests/test_jobstreaming_resumable_discovery.py
+++ b/workers/automation/tests/test_jobstreaming_resumable_discovery.py
@@ -28,7 +28,7 @@ from jobstreaming import (
     Site,
 )
 
-from jobctrl.database import close_connection, init_db
+from jobctrl.database import close_connection, get_jobs_by_stage, init_db
 from jobctrl.discovery import jobspy
 from jobctrl.discovery.activities import (
     AutomaticCompensationRefreshActivityOutput,
@@ -176,6 +176,34 @@ class _InvalidLinkedIn(Scraper):
         raise InvalidRequestError("invalid request")
 
 
+class _ListingOnlyLinkedIn(Scraper):
+    capabilities = AdapterCapabilities(filters=frozenset({"location", "is_remote", "hours_old"}))
+    fetch_description_requests: list[bool] = []
+
+    def __init__(self, **_: object) -> None:
+        super().__init__(Site.LINKEDIN)
+
+    def scrape(self, request, context=None) -> JobResponse:
+        assert context is not None
+        fetch_description = bool(request.linkedin_fetch_description)
+        type(self).fetch_description_requests.append(fetch_description)
+        context.emit_job(
+            JobPost(
+                id="listing-only-1",
+                title=request.search_term,
+                company_name="Listing Only Example",
+                job_url="https://www.linkedin.com/jobs/view/listing-only-1",
+                # LinkedIn's remote-only filter is the evidence. Real listing
+                # cards can show only a region and contain no textual marker.
+                location=Location(city="Spain"),
+                description=_DESCRIPTION if fetch_description else "",
+                is_remote=False,
+            ),
+            {"start": 1},
+        )
+        return JobResponse()
+
+
 class _CursorThenPosting(_SuccessfulIndeed):
     calls = 0
 
@@ -257,6 +285,23 @@ def _config(
             "local_accept_patterns": ["Remote"],
         },
     }
+
+
+def _remote_eu_linkedin_config() -> dict:
+    cfg = _config(boards=("linkedin",))
+    cfg["locations"] = [
+        {
+            "label": "remote-eu",
+            "location": "European Union",
+            "remote": True,
+        }
+    ]
+    cfg["location"] = {
+        "accept_patterns": ["European Union"],
+        "reject_patterns": ["United States"],
+        "local_accept_patterns": ["Barcelona, Spain"],
+    }
+    return cfg
 
 
 def _registry(*, linkedin: bool = False, indeed_factory=_PagedIndeed):
@@ -821,6 +866,72 @@ def test_durable_plan_preserves_target_location_and_splits_glassdoor_request(
         "Barcelona",
     ]
     assert all(spec.target_location == "Barcelona, Catalonia, Spain" for spec in specs)
+    assert specs[1].sites == ("linkedin",)
+    assert specs[1].linkedin_fetch_description is False
+
+
+def test_linkedin_listing_only_discovery_persists_job_for_detail_enrichment(
+    discovery_db,
+) -> None:
+    conn, _db_path = discovery_db
+    execution = _execution("temporal-run-linkedin-listing-only")
+    cfg = _remote_eu_linkedin_config()
+    registry = AdapterRegistry()
+    registry.register(Site.LINKEDIN, _ListingOnlyLinkedIn)
+    _ListingOnlyLinkedIn.fetch_description_requests = []
+
+    result = jobspy.run_discovery(
+        cfg=cfg,
+        discovery_execution=execution,
+        activity_attempt=1,
+        activity_owner_token="listing-only-attempt-1",
+        adapter_registry=registry,
+    )
+
+    assert _ListingOnlyLinkedIn.fetch_description_requests == [False]
+    assert result["new"] == 1, json.dumps(result, sort_keys=True)
+    stored = conn.execute(
+        "SELECT job_id, description, full_description, location FROM jobs"
+    ).fetchone()
+    assert stored is not None
+    assert stored["description"] == ""
+    assert stored["full_description"] is None
+    assert stored["location"] == "Spain (Remote)"
+    assert conn.execute("SELECT COUNT(*) FROM job_enrichments").fetchone()[0] == 0
+    assert {row["job_id"] for row in get_jobs_by_stage(conn, "pending_detail", limit=0)} == {stored["job_id"]}
+
+
+def test_interrupted_legacy_linkedin_plan_keeps_its_frozen_detail_request(
+    discovery_db,
+) -> None:
+    conn, _db_path = discovery_db
+    execution = _execution("temporal-run-linkedin-legacy-plan")
+    cfg = _remote_eu_linkedin_config()
+    specs = jobspy._durable_search_specs(  # noqa: SLF001
+        cfg,
+        tiers=None,
+        locations=None,
+        sites=["linkedin"],
+        results_per_site=10,
+        hours_old=72,
+        linkedin_fetch_description=True,
+    )
+    SqliteDiscoverySearchUnitRepository(conn).plan_units(execution, specs)
+    registry = AdapterRegistry()
+    registry.register(Site.LINKEDIN, _ListingOnlyLinkedIn)
+    _ListingOnlyLinkedIn.fetch_description_requests = []
+
+    result = jobspy.run_discovery(
+        cfg=cfg,
+        discovery_execution=execution,
+        activity_attempt=1,
+        activity_owner_token="legacy-plan-attempt-1",
+        adapter_registry=registry,
+    )
+
+    assert _ListingOnlyLinkedIn.fetch_description_requests == [True]
+    assert result["new"] == 1
+    assert SqliteDiscoverySearchUnitRepository(conn).list_units(execution)[0].state == "completed"
 
 
 def test_partial_board_success_is_retained_with_typed_failure_evidence(


### PR DESCRIPTION
## Outcome

Make new LinkedIn discovery searches listing-only so JobCtrl can run its existing intake checks before paying for full posting detail.

## Changes

- disable eager LinkedIn description fetching in ordinary, manual, and durable JobCtrl search paths
- keep provider remote-only evidence when visible card text is incomplete
- preserve the frozen `linkedin_fetch_description=true` request for interrupted legacy executions so checkpoint fingerprints remain compatible
- document the listing-first ownership boundary

This changes request timing and avoids one detail request for each card that never needs detail. It does not claim a measured production speedup; no comparable live-provider run was performed.

## Validation

- deterministic listing-only, remote-evidence, checkpoint-compatibility, replay, and limit regressions: passed
- cumulative discovery integration QA: 118 passed
- complete locked worker suite: 3,729 passed, 2 skipped
- whole-worker Ruff lint, uv lock check, documentation build, and diff check: passed
- independent cumulative review and Tier 2 QA: PASS with zero findings

## Stack

Part 3 of stack #853. Base: #849.

## Safety

No live provider crawl, production data access, release, deployment, or application submission was performed.
