### PR TITLE
fix(discovery): resolve sparse listing collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,18 +175,20 @@ evidence, qualifications, and the complete capability matrix.
 - Discover jobs from configured searches and supported source registries,
   driven by your target roles, locations, and seniority — recording which
   source each job came from.
-- Stream broad-board results through JobStreaming and commit each accepted
-  posting before acknowledging its provider checkpoint. If the worker stops,
+- Stream broad-board results through JobStreaming and commit each admitted
+  lead before acknowledging its provider checkpoint. If the worker stops,
   the same Discover execution resumes unfinished query/location/board units;
-  accepted postings and the run-wide new-job limit survive replay, and
-  Pipelines reports how many units resumed. JobStreaming 0.0.4 also supplies
+  admitted leads and the run-wide new-job limit survive replay, and Pipelines
+  reports how many units resumed. JobStreaming 0.0.5 also supplies
   cursor-free provider page progress so the active crawl can show completed
   pages, raw listings, emitted jobs, and known continuation without guessing
   an unavailable provider total. JobCtrl can separately estimate source-family
   completion from recent whole-family durations when live queue and capacity
   observations bound the shared worker contention. LinkedIn search remains a
-  lightweight listing pass; full posting text is fetched by Detail Enrichment
-  only after a listing passes Discovery's acceptance checks.
+  lightweight listing pass. JobCtrl requests one posting's detail early only
+  when a sparse card may duplicate another stored job; other admitted
+  leads receive full posting text in Detail Enrichment. Admission means the
+  lead is safe to enrich, not that JobCtrl has judged it suitable or relevant.
 - Optionally reconcile a local Temporal Schedule for discovery; it is disabled
   by default and uses the configured cron only after you enable it.
 - Enrich postings with full descriptions, canonical posting URLs, and apply

--- a/docs/architecture/pipeline/envelope.md
+++ b/docs/architecture/pipeline/envelope.md
@@ -128,7 +128,7 @@ required-step list is never interpreted as proof of no work.
 ### Broad-Board Search Unit Envelope
 
 The `jobspy` source family name remains a compatibility key, but its provider is
-JobStreaming 0.0.4. At activity start, JobCtrl compiles or verifies an immutable
+JobStreaming 0.0.5. At activity start, JobCtrl compiles or verifies an immutable
 ordered plan of query/location/board units under the exact
 `DiscoveryExecutionRef`. Changing the live target-search configuration cannot
 rewrite a retrying execution's persisted plan.
@@ -139,16 +139,22 @@ increments the epoch; every accepted-job write and provider-checkpoint
 compare-and-swap verifies the current fence. This prevents a delayed old worker
 from advancing or canceling work after replacement.
 
-The event order is store, then acknowledge:
+The event order is admit, optionally resolve identity evidence, store, then
+acknowledge:
 
-1. project and filter the JobStreaming event;
-2. atomically persist accepted job/source/event facts and the unit receipt, or
+1. project the JobStreaming event and apply the existing title/location
+   admission policy;
+2. for an admitted, descriptionless LinkedIn card only, request targeted detail
+   when another stored job has the same normalized title and genuine
+   employer; a typed detail failure preserves the sparse lead and safely
+   under-merges it;
+3. atomically persist admitted job/source/event facts and the unit receipt, or
    a hashed filtered-result receipt when caller policy rejects the posting;
-3. acknowledge the exact event, which advances the provider checkpoint; and
-4. derive accepted/filtered progress and the global new-job limit from durable
+4. acknowledge the exact event, which advances the provider checkpoint; and
+5. derive admitted/filtered progress and the global new-job limit from durable
    receipts.
 
-Stopping before step 3 causes at-least-once replay, not lost work. Stable
+Stopping before step 4 causes at-least-once replay, not lost work. Stable
 provider keys and idempotent receipts make that replay harmless. A cursor reset
 is durable intent tied to the acknowledgement revision of its `ErrorEvent`; it
 cannot clear the checkpoint early. Request-fingerprint or cursor-schema

--- a/docs/architecture/pipeline/operations.md
+++ b/docs/architecture/pipeline/operations.md
@@ -119,7 +119,7 @@ Broad-board progress uses `search units` as its source-level unit. Its
 `filteredJobs` comes from hashed filtered-result receipts, and `recoveredUnits`
 counts units reclaimed by a newer Temporal activity attempt.
 The TypeScript read model preserves that optional field and Pipelines renders
-it as `N resumed`. JobStreaming 0.0.4 `ProviderProgress` is a separate immutable
+it as `N resumed`. JobStreaming 0.0.5 `ProviderProgress` is a separate immutable
 value inside the source progress: provider, phase, unit, completed/total units,
 raw items seen, emitted jobs, and tri-state continuation. The worker stamps the
 exact Discover workflow/run identity onto the progress event, and Operations

--- a/docs/architecture/pipeline/stages.md
+++ b/docs/architecture/pipeline/stages.md
@@ -91,11 +91,15 @@ Key facts about the four activities:
   exact-query duplicates never starve later recall queries or sources.
 
   The broad-board family further decomposes the immutable search plan into one
-  query/location/board unit per JobStreaming stream. Each posting is durably
-  accepted before explicit provider acknowledgement. Provider search captures
-  listing metadata only; in particular, LinkedIn full-description requests are
-  deferred until the accepted job reaches Detail Enrichment, so rejected and
-  duplicate listings do not pay the detail-fetch cost. The unit checkpoint,
+  query/location/board unit per JobStreaming stream. Each admitted lead is
+  durably stored before explicit provider acknowledgement; admission permits
+  enrichment and is not a suitability or relevance verdict. Provider search
+  captures listing metadata only. A sparse LinkedIn card receives one targeted
+  detail request before persistence only when its normalized title and genuine
+  employer collide with another stored job and content evidence is
+  needed to protect the new-job budget. All other full-description work remains
+  in Detail Enrichment. A failed targeted request preserves the sparse lead and
+  safely under-merges it. The unit checkpoint,
   accepted-job receipts, result-limit count, typed board failure, and current
   Temporal activity-attempt fence live in SQLite. A hard worker loss leaves the
   unit `running` for the next activity attempt to reclaim; replay is idempotent.

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -503,7 +503,7 @@ draft leg.
 
 ### Broad-Board Provider Boundary
 
-JobStreaming 0.0.4 is the provider boundary for Indeed, LinkedIn, Glassdoor,
+JobStreaming 0.0.5 is the provider boundary for Indeed, LinkedIn, Glassdoor,
 and ZipRecruiter. The infrastructure gateway translates JobCtrl-owned immutable
 search specifications into provider requests and projects typed provider events
 back into the existing discovery ingestion shape. Provider types do not enter
@@ -512,12 +512,14 @@ the Discovery domain model.
 The responsibility split is deliberate:
 
 - JobCtrl owns the exact Discover execution, one immutable
-  query/location/board unit per provider stream, title/location acceptance,
+  query/location/board unit per provider stream, title/location admission,
   durable accepted counts, run-wide limits, lifecycle state, Temporal-attempt
-  fencing, checkpoint storage, and product-visible recovery.
+  fencing, checkpoint storage, selective detail decisions for content identity,
+  and product-visible recovery.
 - JobStreaming owns the board adapter and transport, cursor/resume state,
   stable job keys, typed error classification, cancellation-aware waits, and
-  explicit event acknowledgement.
+  explicit event acknowledgement. Its optional targeted-detail operation
+  fetches one already-known listing without changing search checkpoints.
 
 The consumer stores an accepted posting and its idempotent unit receipt before
 acknowledging the event. A newer activity attempt increments the unit lease

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2160,6 +2160,16 @@ release reduces LinkedIn continuation pacing, uses the observed ten-card page
 contract, stops after a partial final page, and avoids detail work for identities
 already present in the current or resumed provider checkpoint.
 
+Amended (2026-08-29): the provider pin advances to JobStreaming 0.0.5. Provider
+search remains listing-only by default. JobCtrl may request detail for one
+already-known LinkedIn card only after its existing title/location policy admits
+the lead and only when the sparse card could collide with another stored job on
+normalized title and genuine employer. JobStreaming owns that targeted
+transport without changing the search checkpoint; JobCtrl owns the decision,
+content-identity comparison, durable receipt, limit, and acknowledgement. A
+typed detail failure preserves the sparse lead and safely under-merges it rather
+than becoming a suitability filter or a title/employer-only merge.
+
 ## 2026-07-29: Stable Job Identity And Human-Approved Feedback Learning
 
 Status: accepted

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -50,7 +50,7 @@ corepack pnpm dev:setup
 
 `corepack pnpm dev:setup` installs the Node workspace dependencies and runs
 `uv --project workers/automation sync --extra dev`, which installs the Python
-worker, the pinned `jobstreaming==0.0.4` provider, its locked transitive
+worker, the pinned `jobstreaming==0.0.5` provider, its locked transitive
 dependencies, and the Python dev tools used by local checks. It does not install Temporal or
 Playwright browser binaries. Do not set `UV_EXCLUDE_NEWER` (or a global uv
 `exclude-newer` config): it makes uv treat `uv.lock` as needing re-resolution,

--- a/docs/user/discovery.md
+++ b/docs/user/discovery.md
@@ -5,7 +5,7 @@ import DiscoveryPipeline from "../.vitepress/theme/DiscoveryPipeline.vue";
 # Discovery & Sources
 
 Discovery turns your target search into source queries, checks returned jobs
-against that intent, and prepares accepted jobs for scoring and materials. This
+against that intent, and prepares admitted leads for scoring and materials. This
 page owns the target-search controls, source/runtime settings, scheduling, crawl
 policy, and supervised contact-research boundary. For the end-to-end loop, start
 with [Daily Workflow](normal-flows.md); for providers and the shared spend
@@ -55,11 +55,19 @@ starts, so a change affects the next run rather than work already in progress.
 <a id="runtime-setting-results-per-board"></a>
 **Results per board.** Set the maximum number of results requested from each
 selected board for one search unit. This is a provider request limit, not a
-promise that every board will return that many accepted jobs; title, location,
+promise that every board will return that many admitted leads; title, location,
 age, and deduplication checks still apply. The next Discover run snapshots the
-new value. LinkedIn search does not download every result's full description:
-accepted listings enter Detail Enrichment, which fetches the posting content
-needed for scoring.
+new value. Admission means a lead is eligible for persistence and enrichment;
+it is not a relevance score or a judgment that the job is suitable.
+
+LinkedIn search keeps cards listing-only instead of downloading every result's
+full description. When an admitted sparse card has the same normalized role and
+genuine employer as another stored job, JobCtrl requests that one
+posting's detail so content evidence can resolve the possible duplicate before
+the new-job budget advances. Other admitted cards enter Detail Enrichment for
+their posting content. If targeted detail is unavailable, JobCtrl preserves the
+sparse lead and safely keeps it separate rather than dropping it or merging on
+title and employer alone.
 
 <a id="runtime-setting-posting-lookback-hours"></a>
 **Posting lookback hours.** Limit broad-board discovery to postings no older
@@ -198,21 +206,22 @@ Temporal run ID, and the bounded repair reason code remain available under
 
 ### Resumable Broad-Board Searches
 
-Broad-board discovery uses JobStreaming 0.0.4. At the beginning of the source
+Broad-board discovery uses JobStreaming 0.0.5. At the beginning of the source
 activity, JobCtrl compiles an immutable unit for every query, target/provider
 location, and board under the exact Discover workflow/run identity. JobCtrl,
 not the provider, owns whether that unit is pending, running, completed, failed,
 skipped, or canceled.
 
-For each posting event, JobCtrl applies the title/location policy and commits
-the accepted job, source observation, event records, and an idempotent unit
+For each posting event, JobCtrl applies the title/location admission policy and
+commits the admitted lead, source observation, event records, and an idempotent unit
 receipt before acknowledging the JobStreaming event. The acknowledgement then
 advances the provider checkpoint. If the process stops in that gap, the event
 is delivered again and the durable receipt makes the replay harmless. Results
 rejected by the caller's title/location policy get a separate hashed receipt
 before acknowledgement. Accepted new/existing counts, filtered counts, and the
 run-wide new-job limit are therefore read from durable receipts, so a retry
-cannot lose progress or start the limit over.
+cannot lose progress or start the limit over. This intake admission remains
+separate from the later score and relevance decision.
 
 Temporal retries reclaim only unfinished units with a newer activity-attempt
 fence. Retryable board errors resume from their checkpoint; an expired board

--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -835,6 +835,61 @@ def _find_existing_content_duplicate(
     )
 
 
+def _needs_linkedin_detail_for_content_identity(
+    conn: sqlite3.Connection,
+    frame: Any,
+) -> bool:
+    """Return whether one admitted sparse listing needs collision evidence.
+
+    This is not another suitability filter. The listing has already passed the
+    existing title/location policy. Detail is requested only when a
+    descriptionless LinkedIn card could be the same opening as a stored Job at
+    another URL with the same normalized role and genuine employer. Without
+    description evidence, the content-identity boundary must safely under-merge
+    instead of collapsing jobs on title and employer alone.
+    """
+
+    if frame.empty or len(frame.index) != 1:
+        return False
+    row = frame.iloc[0]
+    if normalize_identity_text(row.get("site")) != "linkedin":
+        return False
+    if _nullable_str(row.get("description")) is not None:
+        return False
+    url = _nullable_str(row.get("job_url"))
+    title = _nullable_str(row.get("title"))
+    company = _nullable_str(row.get("company"))
+    if not url or not title or not is_genuine_employer_identity(company):
+        return False
+
+    conn.create_function(
+        "jh_normalize_identity",
+        1,
+        normalize_identity_text,
+        deterministic=True,
+    )
+    return (
+        conn.execute(
+            """
+            SELECT 1
+              FROM jobs j
+             WHERE j.tenant_id = ?
+               AND j.url != ?
+               AND jh_normalize_identity(COALESCE(j.title, '')) = ?
+               AND jh_normalize_identity(COALESCE(j.company, '')) = ?
+             LIMIT 1
+            """,
+            (
+                str(LOCAL_TENANT),
+                url,
+                normalize_identity_text(title),
+                normalize_identity_text(company),
+            ),
+        ).fetchone()
+        is not None
+    )
+
+
 def _find_stored_content_duplicate_survivor(conn: sqlite3.Connection, *, url: str) -> str | None:
     row = conn.execute(
         """
@@ -1686,6 +1741,7 @@ def _durable_full_crawl(
         CheckpointMismatchError,
         ErrorEvent,
         JobEvent,
+        JobStreamingError,
         ProgressEvent,
         SearchCompleteEvent,
         SiteCompleteEvent,
@@ -1858,6 +1914,36 @@ def _durable_full_crawl(
                                     event.job_key,
                                 )
                             else:
+                                if _needs_linkedin_detail_for_content_identity(
+                                    conn,
+                                    accepted_frame,
+                                ):
+                                    try:
+                                        detailed_job = gateway.fetch_detail_for_job_event(
+                                            event,
+                                            proxies=proxies,
+                                            user_agent=politeness_ua,
+                                            registry=adapter_registry,
+                                        )
+                                    except JobStreamingError as exc:
+                                        # Detail is evidence for a possible
+                                        # cross-source identity match, not a
+                                        # new admission gate. Keep the viable
+                                        # lead on typed provider failure and
+                                        # safely under-merge it below.
+                                        log.warning(
+                                            "JobStreaming targeted detail for %s failed "
+                                            "with %s; preserving the sparse lead",
+                                            event.site.value,
+                                            type(exc).__name__,
+                                        )
+                                    else:
+                                        if detailed_job is not None:
+                                            accepted_frame = gateway.frame_for_job_event(
+                                                event,
+                                                provider_spec,
+                                                job=detailed_job,
+                                            )
                                 store_jobspy_results(
                                     conn,
                                     accepted_frame,

--- a/workers/automation/src/jobctrl/infrastructure/discovery/jobstreaming_gateway.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/jobstreaming_gateway.py
@@ -23,6 +23,7 @@ from jobstreaming import (
     Scraper,
     ErrorEvent,
     JobEvent,
+    JobPost,
     ProgressEvent,
     SearchCompleteEvent,
     SearchRequest,
@@ -32,6 +33,7 @@ from jobstreaming import (
     WarningEvent,
     build_search_request,
     default_registry,
+    fetch_job_detail,
     stream_search,
 )
 from jobstreaming.batch import jobs_to_dataframe
@@ -239,6 +241,8 @@ class JobStreamingGateway:
         cls,
         event: JobEvent,
         spec: JobStreamingSearchSpec,
+        *,
+        job: JobPost | None = None,
     ) -> pd.DataFrame:
         """Project one provider event into the legacy storage frame.
 
@@ -249,13 +253,40 @@ class JobStreamingGateway:
 
         frame = _apply_provider_filter_evidence(
             jobs_to_dataframe(
-                [(event.site, event.job)],
+                [(event.site, job or event.job)],
                 cls.build_request(spec),
             ),
             spec,
         )
         frame["jobstreaming_job_key"] = event.job_key
         return frame
+
+    @staticmethod
+    def fetch_detail_for_job_event(
+        event: JobEvent,
+        *,
+        proxies: list[str] | str | None = None,
+        user_agent: str | None = None,
+        request_timeout: float = 30,
+        registry: AdapterRegistry | None = None,
+    ) -> JobPost | None:
+        """Fetch detail for one known provider event without starting a search.
+
+        JobCtrl owns the selective decision. JobStreaming owns the provider
+        transport and returns the same immutable posting with any available
+        detail attached. The original event key remains the durable
+        acknowledgement identity when the caller reprojects the result.
+        """
+
+        return fetch_job_detail(
+            event.site,
+            event.job,
+            proxies=proxies,
+            user_agent=user_agent,
+            description_format="markdown",
+            request_timeout=request_timeout,
+            registry=_normalize_tls_adapter_timeouts(registry),
+        )
 
     def collect(
         self,

--- a/workers/automation/tests/test_jobstreaming_gateway.py
+++ b/workers/automation/tests/test_jobstreaming_gateway.py
@@ -77,6 +77,14 @@ class _RemoteFilterLinkedIn(Scraper):
         return JobResponse()
 
 
+class _SelectiveDetailLinkedIn(_RemoteFilterLinkedIn):
+    detail_requests: list[tuple[str | None, float]] = []
+
+    def fetch_job_detail(self, job, request):
+        type(self).detail_requests.append((job.id, request.request_timeout))
+        return job.model_copy(update={"description": "Verified targeted detail"})
+
+
 class _TlsTimeoutInspectingAdapter(Scraper):
     seen_timeouts: list[object] = []
 
@@ -251,6 +259,36 @@ def test_linkedin_remote_filter_evidence_survives_batch_and_event_projection() -
         frame = gateway.frame_for_job_event(event, spec)
 
     assert frame.loc[0, "location"] == "Spain"
+    assert bool(frame.loc[0, "is_remote"]) is True
+
+
+def test_targeted_detail_reprojects_content_under_the_original_event_key() -> None:
+    registry = AdapterRegistry()
+    registry.register(Site.LINKEDIN, _SelectiveDetailLinkedIn)
+    _SelectiveDetailLinkedIn.detail_requests = []
+    gateway = JobStreamingGateway()
+    spec = JobStreamingSearchSpec(
+        sites=("linkedin",),
+        query="Engineering Manager",
+        location="European Union",
+        results_per_site=10,
+        remote_only=True,
+    )
+
+    with gateway.open_stream(spec, registry=registry, resume=False) as stream:
+        event = next(stream)
+        assert isinstance(event, JobEvent)
+        detailed = gateway.fetch_detail_for_job_event(
+            event,
+            request_timeout=7,
+            registry=registry,
+        )
+        assert detailed is not None
+        frame = gateway.frame_for_job_event(event, spec, job=detailed)
+
+    assert _SelectiveDetailLinkedIn.detail_requests == [("linkedin-remote-1", 7)]
+    assert frame.loc[0, "description"] == "Verified targeted detail"
+    assert frame.loc[0, "jobstreaming_job_key"] == event.job_key
     assert bool(frame.loc[0, "is_remote"]) is True
 
 

--- a/workers/automation/tests/test_jobstreaming_resumable_discovery.py
+++ b/workers/automation/tests/test_jobstreaming_resumable_discovery.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from datetime import timedelta
 from pathlib import Path
 
+import pandas as pd
 import pytest
 from temporalio import activity
 from .temporal_env import time_skipping_env
@@ -26,6 +27,7 @@ from jobstreaming import (
     Scraper,
     SearchCheckpoint,
     Site,
+    TransientNetworkError,
 )
 
 from jobctrl.database import close_connection, get_jobs_by_stage, init_db
@@ -204,6 +206,54 @@ class _ListingOnlyLinkedIn(Scraper):
         return JobResponse()
 
 
+class _ContentCollisionLinkedIn(Scraper):
+    capabilities = AdapterCapabilities(filters=frozenset({"location", "is_remote", "hours_old"}))
+    detail_requests: list[str | None] = []
+
+    def __init__(self, **_: object) -> None:
+        super().__init__(Site.LINKEDIN)
+
+    def scrape(self, request, context=None) -> JobResponse:
+        assert context is not None
+        listings = (
+            JobPost(
+                id="101",
+                title=request.search_term,
+                company_name="Acme",
+                job_url="https://www.linkedin.com/jobs/view/101",
+                location=Location(city="Remote"),
+                description="",
+                is_remote=True,
+            ),
+            JobPost(
+                id="202",
+                title=request.search_term,
+                company_name="Unique Example",
+                job_url="https://www.linkedin.com/jobs/view/202",
+                location=Location(city="Remote"),
+                description="",
+                is_remote=True,
+            ),
+        )
+        start = int(context.resume_state.get("start", 0))
+        for index, listing in enumerate(listings[start:], start=start):
+            if not context.emit_job(listing, {"start": index + 1}):
+                break
+        return JobResponse()
+
+    def fetch_job_detail(self, job, request):
+        assert request.site_type == (Site.LINKEDIN,)
+        type(self).detail_requests.append(job.id)
+        return job.model_copy(update={"description": _DESCRIPTION})
+
+
+class _FailingContentCollisionLinkedIn(_ContentCollisionLinkedIn):
+    def fetch_job_detail(self, job, request):
+        del request
+        type(self).detail_requests.append(job.id)
+        raise TransientNetworkError("targeted detail temporarily unavailable")
+
+
 class _CursorThenPosting(_SuccessfulIndeed):
     calls = 0
 
@@ -302,6 +352,28 @@ def _remote_eu_linkedin_config() -> dict:
         "local_accept_patterns": ["Barcelona, Spain"],
     }
     return cfg
+
+
+def _seed_cross_source_content_owner(conn) -> str:
+    owner_url = "https://boards.greenhouse.io/acme/jobs/director-engineering"
+    assert jobspy.store_jobspy_results(
+        conn,
+        pd.DataFrame(
+            [
+                {
+                    "job_url": owner_url,
+                    "title": "Director of Engineering",
+                    "company": "Acme",
+                    "description": _DESCRIPTION,
+                    "location": "Remote",
+                    "site": "greenhouse",
+                    "is_remote": True,
+                }
+            ]
+        ),
+        "Director of Engineering",
+    ) == (1, 0)
+    return owner_url
 
 
 def _registry(*, linkedin: bool = False, indeed_factory=_PagedIndeed):
@@ -899,6 +971,145 @@ def test_linkedin_listing_only_discovery_persists_job_for_detail_enrichment(
     assert stored["location"] == "Spain (Remote)"
     assert conn.execute("SELECT COUNT(*) FROM job_enrichments").fetchone()[0] == 0
     assert {row["job_id"] for row in get_jobs_by_stage(conn, "pending_detail", limit=0)} == {stored["job_id"]}
+
+
+def test_selective_detail_prevents_a_cross_source_collision_from_consuming_the_new_job_limit(
+    discovery_db,
+) -> None:
+    conn, _db_path = discovery_db
+    owner_url = _seed_cross_source_content_owner(conn)
+    execution = _execution("temporal-run-linkedin-content-collision")
+    registry = AdapterRegistry()
+    registry.register(Site.LINKEDIN, _ContentCollisionLinkedIn)
+    _ContentCollisionLinkedIn.detail_requests = []
+
+    result = jobspy.run_discovery(
+        cfg=_config(boards=("linkedin",)),
+        limit=1,
+        discovery_execution=execution,
+        activity_attempt=1,
+        activity_owner_token="content-collision-attempt-1",
+        adapter_registry=registry,
+    )
+
+    assert _ContentCollisionLinkedIn.detail_requests == ["101"]
+    assert result["new"] == 1
+    assert result["existing"] == 1
+    assert result["raw_total"] == 2
+    assert {row["url"] for row in conn.execute("SELECT url FROM jobs").fetchall()} == {
+        owner_url,
+        "https://www.linkedin.com/jobs/view/202",
+    }
+    link = conn.execute("SELECT surviving_job_id, reason FROM job_duplicate_links").fetchone()
+    assert link is not None
+    assert link["reason"] == "content_fingerprint_match"
+    assert (
+        conn.execute(
+            "SELECT job_id FROM jobs WHERE url = ?",
+            (owner_url,),
+        ).fetchone()["job_id"]
+        == link["surviving_job_id"]
+    )
+
+
+def test_selective_detail_replays_safely_when_provider_acknowledgement_is_lost(
+    discovery_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn, _db_path = discovery_db
+    owner_url = _seed_cross_source_content_owner(conn)
+    execution = _execution("temporal-run-linkedin-content-collision-replay")
+    registry = AdapterRegistry()
+    registry.register(Site.LINKEDIN, _ContentCollisionLinkedIn)
+    _ContentCollisionLinkedIn.detail_requests = []
+    original_save = SqliteDiscoverySearchUnitCheckpointStore.save
+    interrupted = False
+
+    def interrupt_first_job_ack(self, checkpoint) -> None:
+        nonlocal interrupted
+        if checkpoint.revision == 1 and not interrupted:
+            interrupted = True
+            raise RuntimeError("simulated worker loss after selective detail")
+        original_save(self, checkpoint)
+
+    monkeypatch.setattr(
+        SqliteDiscoverySearchUnitCheckpointStore,
+        "save",
+        interrupt_first_job_ack,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="simulated worker loss after selective detail",
+    ):
+        jobspy.run_discovery(
+            cfg=_config(boards=("linkedin",)),
+            limit=1,
+            discovery_execution=execution,
+            activity_attempt=1,
+            activity_owner_token="content-collision-replay-attempt-1",
+            adapter_registry=registry,
+        )
+
+    repository = SqliteDiscoverySearchUnitRepository(conn)
+    assert repository.execution_counts(execution) == {
+        "accepted": 1,
+        "new": 0,
+        "existing": 1,
+    }
+    assert repository.list_units(execution)[0].checkpoint_revision == 0
+
+    result = jobspy.run_discovery(
+        cfg=_config(boards=("linkedin",)),
+        limit=1,
+        discovery_execution=execution,
+        activity_attempt=2,
+        activity_owner_token="content-collision-replay-attempt-2",
+        adapter_registry=registry,
+    )
+
+    assert _ContentCollisionLinkedIn.detail_requests == ["101", "101"]
+    assert result["new"] == 1
+    assert result["existing"] == 1
+    assert result["raw_total"] == 2
+    assert {row["url"] for row in conn.execute("SELECT url FROM jobs").fetchall()} == {
+        owner_url,
+        "https://www.linkedin.com/jobs/view/202",
+    }
+    assert conn.execute("SELECT COUNT(*) FROM job_duplicate_links").fetchone()[0] == 1
+    assert repository.list_units(execution)[0].recovery_count == 1
+
+
+def test_selective_detail_failure_preserves_the_sparse_lead(
+    discovery_db,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    conn, _db_path = discovery_db
+    owner_url = _seed_cross_source_content_owner(conn)
+    execution = _execution("temporal-run-linkedin-content-collision-detail-failure")
+    registry = AdapterRegistry()
+    registry.register(Site.LINKEDIN, _FailingContentCollisionLinkedIn)
+    _FailingContentCollisionLinkedIn.detail_requests = []
+
+    with caplog.at_level("WARNING"):
+        result = jobspy.run_discovery(
+            cfg=_config(boards=("linkedin",)),
+            limit=1,
+            discovery_execution=execution,
+            activity_attempt=1,
+            activity_owner_token="content-collision-detail-failure-attempt-1",
+            adapter_registry=registry,
+        )
+
+    assert _FailingContentCollisionLinkedIn.detail_requests == ["101"]
+    assert result["new"] == 1
+    assert result["existing"] == 0
+    assert {row["url"] for row in conn.execute("SELECT url FROM jobs").fetchall()} == {
+        owner_url,
+        "https://www.linkedin.com/jobs/view/101",
+    }
+    assert conn.execute("SELECT COUNT(*) FROM job_duplicate_links").fetchone()[0] == 0
+    assert "preserving the sparse lead" in caplog.text
 
 
 def test_interrupted_legacy_linkedin_plan_keeps_its_frozen_detail_request(


### PR DESCRIPTION
## Outcome

Prevent a sparse LinkedIn card that is actually an existing job from consuming the run-wide new-job budget and starving a later unique lead.

## Changes

- request targeted detail only after existing title/location admission and only for one descriptionless LinkedIn card that could collide with another stored job on normalized title and a genuine employer
- reproject returned detail under the original provider event key, then use the existing content-identity rules
- preserve the sparse lead and safely under-merge when targeted detail returns `None` or a typed provider failure
- retain store-before-ack ordering, durable receipt counts, replay safety, remote-only evidence, and frozen legacy checkpoints
- describe the behavior as lead admission, explicitly separate from relevance/suitability, and document the JobCtrl/JobStreaming responsibility split

Title and employer are only the trigger for obtaining evidence; they never establish a duplicate by themselves.

## Validation

- exact reviewer regression: existing described ATS job, colliding sparse LinkedIn card first, unique sparse LinkedIn card second, `limit=1` -> colliding card counted existing; unique card persisted as the one new lead
- lost-ack replay, targeted-detail `None`, typed failure, pre-detail title/location rejection, remote evidence, missing-description admission, and `pending_detail` regressions: passed
- cumulative discovery integration QA: 118 passed
- focused cumulative discovery suite: 97 passed
- complete locked worker suite: 3,729 passed, 2 skipped
- whole-worker Ruff lint, uv lock check, documentation build with 9,653 references, and diff check: passed
- independent cumulative review: PASS, Blocker=0 High=0 Medium=0 Low=0
- independent Tier 2 QA: PASS, Blocker=0 High=0 Medium=0 Low=0

## Residual risk

No comparable live-provider crawl was run. Deterministic JobCtrl behavior and the published JobStreaming contract are proven; current LinkedIn markup, throttling, redirects, real-world collision distribution, and production latency remain external measurements.

## Stack

Final slice. Based on current `main` after #848, #849, #854, #850, and #851 were merged in dependency order.

## Safety

No live provider crawl, production data access, JobCtrl release, deployment, or application submission was performed.