### PR TITLE
test(enrichment): isolate activity harness lease

### DIFF
--- a/workers/automation/tests/test_activity_enrich.py
+++ b/workers/automation/tests/test_activity_enrich.py
@@ -37,10 +37,16 @@ class _EnrichHarness:
 async def test_enrich_activity_invokes_observed_enrich_core():
     queue = f"enrich-{uuid.uuid4()}"
 
-    with patch(
-        "jobctrl.pipeline.runner._run_stage_observed",
-        return_value=({"status": "ok"}, 0.2, "ok"),
-    ) as observed_mock:
+    with (
+        patch(
+            "jobctrl.pipeline.runner._run_stage_observed",
+            return_value=({"status": "ok"}, 0.2, "ok"),
+        ) as observed_mock,
+        patch(
+            "jobctrl.enrichment.activities._claim_activity_enrichment_lease",
+            return_value=None,
+        ),
+    ):
         async with time_skipping_env() as env:
             async with Worker(
                 env.client,


### PR DESCRIPTION
## Outcome

Keep the Temporal enrichment runner harness deterministic under randomized test order without weakening production lease coverage.

## Changes

- isolate the runner-wiring harness from shared-session enrichment lease persistence
- retain the real Temporal worker/activity boundary and all existing assertions on runner inputs and output projection
- leave lease acquisition and stale-owner fencing covered by their dedicated reliability tests

## Why

The hosted Python 3.12 lane twice reached the suite watchdog while this harness waited on SQLite `BEGIN IMMEDIATE`. The harness verifies activity-to-runner wiring, but its implicit use of the session database made it depend on unrelated writer state from randomized tests.

## Validation

- Python 3.12 activity test file: 4 passed
- repeated formerly hanging harness in one process: 3 consecutive passes
- cumulative Python 3.12 worker suite: 3,729 passed, 2 skipped
- focused cumulative discovery QA: 118 passed
- Ruff: passed
- lock check: passed
- `git diff --check`: passed
- independent review: PASS, 0 findings
- independent QA: PASS, 0 findings

## Stack

Depends on #851. The sparse-listing collision repair follows this PR.