### PR TITLE
refactor(web): reconcile saved review drafts in one cache

### DIFF
--- a/apps/api/test/e2e-server.ts
+++ b/apps/api/test/e2e-server.ts
@@ -1,0 +1,85 @@
+// Test-only process entry point. Assert ownership before importing/building the
+// API: buildApp normalizes its database immediately, before listen hooks run.
+import { createRequire } from "node:module";
+import { BrowserCapabilityIds } from "@jobctrl/contracts";
+import type { CredentialStore } from "../src/credentials.js";
+import type { JsonRpcDispatcher } from "../src/json-rpc-adapter.js";
+
+const { assertIsolatedE2eWorkspace } = createRequire(import.meta.url)(
+  "../../web/e2e/fixtures/isolated-workspace.cjs",
+) as { assertIsolatedE2eWorkspace(): Promise<string> };
+await assertIsolatedE2eWorkspace();
+const { resolveApiConfig } = await import("../src/config.js");
+const { buildApp } = await import("../src/server.js");
+const { e2eStubActionDispatcher, e2eStubProfileImporter } =
+  await import("../src/e2e-dispatch.js");
+const config = resolveApiConfig();
+const unavailable = async () => {
+  throw new Error("Operation is outside the isolated E2E fixture");
+};
+const providerDispatcher: JsonRpcDispatcher = {
+  call: async (method) =>
+    method === "browser_capabilities_list"
+      ? {
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            capabilities: BrowserCapabilityIds.map((id) => ({
+              id,
+              status: "disabled",
+              detail: "Synthetic E2E capability",
+              mutable: false,
+              enabled: false,
+              profileCopyReady: false,
+            })),
+            detectedBrowsers: [],
+          },
+        }
+      : {
+          jsonrpc: "2.0",
+          id: 1,
+          error: {
+            code: -32601,
+            message: "Method is outside the isolated E2E fixture",
+          },
+        },
+  close: async () => {},
+};
+const credentialStore: CredentialStore = {
+  list: async () => ({
+    ok: true,
+    store: {
+      kind: "config_and_macos_keychain",
+      available: false,
+      unavailableReason: "unsupported_platform",
+      requiresWorkerRestart: true,
+    },
+    credentials: [],
+  }),
+  set: unavailable,
+  delete: unavailable,
+  applyBatch: unavailable,
+};
+const app = buildApp({
+  ...config,
+  providerDispatcher,
+  credentialStore,
+  pythonRuntime: {
+    id: "isolated-e2e-deny-subprocess",
+    resolve: () => {
+      throw new Error("Subprocess is outside the isolated E2E fixture");
+    },
+  },
+  actionDispatcher: e2eStubActionDispatcher,
+  profileImporter: e2eStubProfileImporter,
+  artifactOpener: unavailable,
+  jobUrlValidator: unavailable,
+  placeValidator: unavailable,
+  requireHealthyWorkerForActions: true,
+});
+await assertIsolatedE2eWorkspace();
+await app.listen({ host: config.host, port: config.port });
+for (const signal of ["SIGTERM", "SIGINT"] as const)
+  process.once(signal, () => {
+    void app.close();
+  });

--- a/apps/web/e2e/fixtures/e2e-state.ts
+++ b/apps/web/e2e/fixtures/e2e-state.ts
@@ -1,9 +1,10 @@
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import Database from "better-sqlite3";
 
 interface E2eState {
-  workspace?: { dbPath?: string };
+  workspace?: { appDir?: string; dbPath?: string };
 }
 
 /** Canonical ID emitted for QA_PLATFORM_JOB_URL by the exact-v7 QA seed. */
@@ -16,6 +17,10 @@ export function e2eStateFilePath(): string {
       "JOBCTRL_E2E_STATE_FILE is not set; playwright.config.ts should isolate the run before setup.",
     );
   }
+  if (process.env["JOBCTRL_E2E_ISOLATED"] === "1") {
+    const { assertInside } = createRequire(import.meta.url)("./isolated-workspace.cjs") as { assertInside(root: string, candidate: string): void };
+    assertInside(fs.realpathSync(process.env["JOBCTRL_E2E_APP_DIR"]!), configured);
+  }
   return path.resolve(configured);
 }
 
@@ -27,6 +32,10 @@ export function loadE2eDbPath(): string {
     throw new Error(
       "E2E state file is missing workspace.dbPath; global-setup did not run.",
     );
+  }
+  if (process.env["JOBCTRL_E2E_ISOLATED"] === "1") {
+    const { assertExpectedWorkspace } = createRequire(import.meta.url)("./isolated-workspace.cjs") as { assertExpectedWorkspace(workspace: E2eState["workspace"]): void };
+    assertExpectedWorkspace(state.workspace);
   }
   return state.workspace.dbPath;
 }

--- a/apps/web/e2e/fixtures/global-setup.ts
+++ b/apps/web/e2e/fixtures/global-setup.ts
@@ -35,6 +35,10 @@ function findRepoRoot(start: string): string {
 }
 
 export default async function globalSetup(): Promise<void> {
+  if (process.env["JOBCTRL_E2E_ISOLATED"] === "1") {
+    const { assertIsolatedE2eWorkspace } = createRequire(import.meta.url)("./isolated-workspace.cjs") as { assertIsolatedE2eWorkspace(): Promise<string> };
+    await assertIsolatedE2eWorkspace();
+  }
   const repoRoot = findRepoRoot(process.cwd());
   const stateFile = e2eStateFilePath();
   const targetDir = process.env["JOBCTRL_E2E_APP_DIR"];
@@ -52,6 +56,11 @@ export default async function globalSetup(): Promise<void> {
     fs.mkdirSync(targetDir, { recursive: true });
   }
 
+  if (process.env["JOBCTRL_E2E_ISOLATED"] === "1") {
+    fs.mkdirSync(process.env["TMPDIR"]!, { recursive: true });
+    fs.mkdirSync(process.env["JOBCTRL_E2E_SERVICE_HOME"]!, { recursive: true });
+  }
+
   const stdout = execFileSync(
     "corepack",
     [
@@ -66,6 +75,10 @@ export default async function globalSetup(): Promise<void> {
     { cwd: repoRoot, stdio: ["ignore", "pipe", "inherit"], encoding: "utf-8" },
   );
   const report = JSON.parse(stdout.trim()) as SeedReport;
+  if (process.env["JOBCTRL_E2E_ISOLATED"] === "1") {
+    const { assertExpectedWorkspace } = createRequire(import.meta.url)("./isolated-workspace.cjs") as { assertExpectedWorkspace(workspace: SeedReport): void };
+    assertExpectedWorkspace(report);
+  }
 
   fs.mkdirSync(path.dirname(stateFile), { recursive: true });
   fs.writeFileSync(stateFile, JSON.stringify({ workspace: report, stateFile }, null, 2));

--- a/apps/web/e2e/fixtures/global-teardown.ts
+++ b/apps/web/e2e/fixtures/global-teardown.ts
@@ -28,10 +28,14 @@ function findRepoRoot(start: string): string | null {
 }
 
 interface State {
-  workspace?: { appDir?: string };
+  workspace?: { appDir?: string; dbPath?: string };
 }
 
 export default async function globalTeardown(): Promise<void> {
+  if (process.env["JOBCTRL_E2E_ISOLATED"] === "1") {
+    const { assertIsolatedE2eWorkspace } = createRequire(import.meta.url)("./isolated-workspace.cjs") as { assertIsolatedE2eWorkspace(): Promise<string> };
+    await assertIsolatedE2eWorkspace();
+  }
   const repoRoot = findRepoRoot(process.cwd());
   if (!repoRoot) {
     return;
@@ -49,6 +53,10 @@ export default async function globalTeardown(): Promise<void> {
       return;
     }
     throw error;
+  }
+  if (process.env["JOBCTRL_E2E_ISOLATED"] === "1") {
+    const { assertExpectedWorkspace } = createRequire(import.meta.url)("./isolated-workspace.cjs") as { assertExpectedWorkspace(workspace: State["workspace"]): void };
+    assertExpectedWorkspace(state.workspace);
   }
   const dir = state.workspace?.appDir;
   if (dir && fs.existsSync(dir)) {

--- a/apps/web/e2e/fixtures/isolated-workspace.cjs
+++ b/apps/web/e2e/fixtures/isolated-workspace.cjs
@@ -1,0 +1,75 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  assertOwnedDocsScreenshotDirectory,
+} = require("./docs-screenshot-workspace.cjs");
+
+function assertInside(root, candidate) {
+  if (!candidate || !path.isAbsolute(candidate))
+    throw new Error("Isolated E2E paths must be absolute");
+  const relative = path.relative(root, candidate);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative))
+    throw new Error("Isolated E2E path escaped its owned workspace");
+  if (path.normalize(candidate) !== candidate)
+    throw new Error("Isolated E2E path must be normalized");
+  let component = root;
+  for (const segment of relative.split(path.sep)) {
+    component = path.join(component, segment);
+    try {
+      if (fs.lstatSync(component).isSymbolicLink())
+        throw new Error("Isolated E2E path follows a symlink");
+    } catch (error) {
+      if (error.code === "ENOENT") break;
+      throw error;
+    }
+  }
+  return candidate;
+}
+
+async function assertIsolatedE2eWorkspace(env = process.env) {
+  if (env.JOBCTRL_E2E_ISOLATED !== "1" || env.JOBCTRL_DOCS_SCREENSHOTS !== "1")
+    throw new Error("Isolated E2E requires the owned screenshot fixture mode");
+  const appDir = await assertOwnedDocsScreenshotDirectory(
+    env.JOBCTRL_E2E_APP_DIR,
+  );
+  if (fs.realpathSync(env.JOBCTRL_DIR) !== appDir)
+    throw new Error("Isolated E2E app directory mismatch");
+  for (const name of [
+    "JOBCTRL_DB_PATH",
+    "JOBCTRL_CONFIG_PATH",
+    "JOBCTRL_E2E_DB_PATH",
+    "JOBCTRL_E2E_CONFIG_PATH",
+    "JOBCTRL_E2E_STATE_FILE",
+    "JOBCTRL_E2E_SERVICE_HOME",
+    "TMPDIR",
+  ]) {
+    assertInside(appDir, env[name]);
+  }
+  if (
+    env.JOBCTRL_DB_PATH !== env.JOBCTRL_E2E_DB_PATH ||
+    env.JOBCTRL_CONFIG_PATH !== env.JOBCTRL_E2E_CONFIG_PATH
+  )
+    throw new Error("Isolated E2E database/configuration mismatch");
+  return appDir;
+}
+
+function assertExpectedWorkspace(workspace, env = process.env) {
+  const root = fs.realpathSync(env.JOBCTRL_E2E_APP_DIR);
+  if (
+    workspace?.appDir !== root ||
+    workspace?.dbPath !== env.JOBCTRL_E2E_DB_PATH
+  )
+    throw new Error("Isolated E2E state belongs to a different run");
+  assertInside(root, workspace.dbPath);
+  if (
+    workspace.configPath !== undefined &&
+    workspace.configPath !== env.JOBCTRL_E2E_CONFIG_PATH
+  )
+    throw new Error("Isolated E2E state configuration mismatch");
+}
+
+module.exports = {
+  assertInside,
+  assertIsolatedE2eWorkspace,
+  assertExpectedWorkspace,
+};

--- a/apps/web/e2e/playwright.config.ts
+++ b/apps/web/e2e/playwright.config.ts
@@ -35,8 +35,9 @@ process.env["JOBCTRL_E2E_STATE_FILE"] = E2E_STATE_FILE;
 // Documentation screenshots are committed artifacts, so their run must own
 // both servers and the disposable workspace wired into them. A listening port
 // is not sufficient evidence that an existing process uses E2E_DIR.
+const ISOLATED_E2E = process.env["JOBCTRL_E2E_ISOLATED"] === "1";
 const REUSE_EXISTING_SERVERS =
-  !process.env["CI"] && process.env["JOBCTRL_DOCS_SCREENSHOTS"] !== "1";
+  !ISOLATED_E2E && !process.env["CI"] && process.env["JOBCTRL_DOCS_SCREENSHOTS"] !== "1";
 const DOCS_SERVICE_ENVIRONMENT =
   process.env["JOBCTRL_DOCS_SCREENSHOTS"] === "1"
     ? {
@@ -87,7 +88,9 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command: "corepack pnpm --filter @jobctrl/api dev",
+      command: ISOLATED_E2E
+        ? "corepack pnpm --filter @jobctrl/api exec tsx test/e2e-server.ts"
+        : "corepack pnpm --filter @jobctrl/api dev",
       port: Number(API_PORT),
       cwd: repoRoot,
       env: {

--- a/apps/web/e2e/tests/artifact-comparison.spec.ts
+++ b/apps/web/e2e/tests/artifact-comparison.spec.ts
@@ -110,11 +110,25 @@ function artifactDetail(artifactId: string) {
   return makeArtifactDetail({ ...acceptedArtifact, artifactId });
 }
 
-async function installArtifactComparisonRoutes(page: Page) {
+async function installArtifactComparisonRoutes(page: Page, advanceDraftAfterRender = true) {
+  let renderCompleted = false;
+  const nextDraft = {
+    ...draft, draftId: "draft-after-promotion", baseGeneration: 3,
+    baseResumeTextArtifactId: draftArtifact.artifactId, baseResumePdfArtifactId: "resume-review-pdf",
+    state: "active", currentRevisionId: null, latestRevisionNumber: 0,
+    latestRevision: null, commentThreads: [],
+  };
+  const currentDraft = () => renderCompleted && advanceDraftAfterRender ? nextDraft : draft;
   await page.route("**/v1/apply/review-queue", async (route) => {
     await route.fulfill({
       contentType: "application/json",
-      body: JSON.stringify(sampleApplyReviewQueue),
+      body: JSON.stringify(renderCompleted && advanceDraftAfterRender ? {
+        ...sampleApplyReviewQueue,
+        items: sampleApplyReviewQueue.items.map((item) => item.jobKey === jobKey ? {
+          ...item, materialsPreview: { ...item.materialsPreview,
+            resumeTextArtifactId: draftArtifact.artifactId, resumePdfArtifactId: "resume-review-pdf" },
+        } : item),
+      } : sampleApplyReviewQueue),
     });
   });
   await page.route("**/v1/resume-templates", async (route) => {
@@ -126,7 +140,7 @@ async function installArtifactComparisonRoutes(page: Page) {
   await page.route("**/v1/jobs/*/resume-review/draft", async (route) => {
     await route.fulfill({
       contentType: "application/json",
-      body: JSON.stringify({ ok: true, draft }),
+      body: JSON.stringify({ ok: true, draft: currentDraft() }),
     });
   });
   await page.route(
@@ -136,20 +150,21 @@ async function installArtifactComparisonRoutes(page: Page) {
         contentType: "application/json",
         body: JSON.stringify({
           ok: true,
-          draft,
-          commentThreads: draft.commentThreads,
-          seededCount: draft.commentThreads.length,
+          draft: currentDraft(),
+          commentThreads: currentDraft().commentThreads,
+          seededCount: currentDraft().commentThreads.length,
           updatedCount: 0,
         }),
       });
     },
   );
   await page.route("**/v1/resume-review/drafts/*/render", async (route) => {
+    renderCompleted = true;
     await route.fulfill({
       contentType: "application/json",
       body: JSON.stringify({
         ok: true,
-        draft: { ...draft, state: "rendered" },
+        draft: { ...draft, state: advanceDraftAfterRender ? "promoted" : "rendered" },
         validation: { passed: true, errors: [], warnings: [] },
         artifacts: {
           resumeText: {
@@ -180,7 +195,11 @@ async function installArtifactComparisonRoutes(page: Page) {
   await page.route("**/v1/artifacts/*/preview.html*", async (route) => {
     await route.fulfill({
       contentType: "text/html",
-      body: "<main><h1>Principal Platform Engineer</h1><p>Owned platform reliability work for incident response.</p></main>",
+      body: `<main><section class="resume-page" data-resume-page="1">
+        <h1 data-resume-line-number="1" data-resume-layout-target="personal:full_name">Principal Platform Engineer</h1>
+        <h2 data-resume-line-number="2" data-resume-layout-target="section:experience">Experience</h2>
+        <p data-resume-line-number="3" data-resume-layout-target="experience:line:3">Owned platform reliability work for incident response.</p>
+      </section></main>`,
     });
   });
   await page.route("**/v1/artifacts/*", async (route) => {
@@ -218,6 +237,11 @@ test("apply review compares accepted artifact with rendered draft artifact", asy
   await expect(comparison).toContainText("declared lost");
   await expect(comparison).toContainText("gcp");
   await expect(comparison).toContainText("claim risk");
+  await expect(comparison).toContainText("Accepted resume");
+  await expect(comparison).toContainText("Rendered draft resume");
+  await expect(page.getByText("draft ready", { exact: true })).toBeVisible();
+  await expect(renderButton).toBeDisabled();
+  await expect(page.getByText("replacement rendered", { exact: true })).toHaveCount(0);
   await expect(
     page.getByRole("region", { name: "Tailored resume preview" }),
   ).toBeVisible();
@@ -299,17 +323,23 @@ test("late saved snapshot preserves newer typing and keeps rendering gated", asy
 });
 
 test("a delayed seed snapshot cannot replace a rendered saved revision", async ({ page }) => {
-  await installArtifactComparisonRoutes(page);
+  await installArtifactComparisonRoutes(page, false);
   let finishSeed!: () => void;
+  const lateThread = { ...draft.commentThreads[0]!, threadId: "late-seed-witness",
+    semanticId: null, lineAnchor: null, sourcePinId: null, anchorResolved: false,
+    commentBody: "Late seed response published" };
+  const seededDraft = { ...draft, commentThreads: [...draft.commentThreads, lateThread] };
   await page.route("**/v1/resume-review/drafts/*/comment-threads", async (route) => {
     await new Promise<void>((resolve) => { finishSeed = resolve; });
-    await route.fulfill({ json: { ok: true, draft, commentThreads: draft.commentThreads, seededCount: 1, updatedCount: 0 } });
+    await route.fulfill({ json: { ok: true, draft: seededDraft, commentThreads: seededDraft.commentThreads, seededCount: 1, updatedCount: 0 } });
   });
   await page.goto("/apply-review");
   await expect.poll(() => Boolean(finishSeed)).toBe(true);
   await page.getByRole("button", { name: "Render replacement" }).click();
   await expect(page.getByText("replacement rendered", { exact: true })).toBeVisible();
   finishSeed();
+  // This new thread is observable only after the late mutation publishes into the cache.
+  await expect(page.getByText("Late seed response published", { exact: true })).toBeVisible();
   await expect(page.getByText("replacement rendered", { exact: true })).toBeVisible();
   await expect(page.getByRole("region", { name: "Artifact comparison" })).toContainText("+covered");
 });

--- a/apps/web/e2e/tests/artifact-comparison.spec.ts
+++ b/apps/web/e2e/tests/artifact-comparison.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
+import { checkA11y, injectAxe } from "axe-playwright";
 
 import {
   makeArtifactDetail,
@@ -10,6 +11,11 @@ import {
   sampleDraftResumeArtifact,
   sampleResumeTemplateListResponse,
 } from "../../src/test/fixtures/projections.js";
+
+test.beforeEach(async ({ context, baseURL }) => {
+  const allowed = new Set([new URL(baseURL!).origin, `http://127.0.0.1:${process.env["JOBCTRL_E2E_API_PORT"] ?? "8767"}`]);
+  await context.route("**/*", (route) => allowed.has(new URL(route.request().url()).origin) ? route.continue() : route.abort("blockedbyclient"));
+});
 
 const jobKey = sampleApplyReviewQueue.items[0]!.jobKey;
 const acceptedArtifact = {
@@ -215,6 +221,8 @@ test("apply review compares accepted artifact with rendered draft artifact", asy
   await expect(
     page.getByRole("region", { name: "Tailored resume preview" }),
   ).toBeVisible();
+  await injectAxe(page);
+  await checkA11y(page, ".apply-review-resume-review", { includedImpacts: ["critical", "serious"] });
 });
 
 test("artifact full-page detail compares same-job generated artifacts", async ({
@@ -248,4 +256,60 @@ test("artifact full-page detail compares same-job generated artifacts", async ({
   await expect(comparison).toContainText("+declared");
   await expect(comparison).toContainText("declared lost");
   await expect(comparison).toContainText("gcp");
+});
+
+test("late saved snapshot preserves newer typing and keeps rendering gated", async ({ page }) => {
+  await installArtifactComparisonRoutes(page);
+  let acknowledge!: () => void;
+  let savedText = "";
+  let savedDraft = draft;
+  await page.route("**/v1/resume-review/drafts/*/revisions", async (route) => {
+    const body = route.request().postDataJSON();
+    savedText = body.editedText;
+    await new Promise<void>((resolve) => { acknowledge = resolve; });
+    savedDraft = {
+      ...draft,
+      currentRevisionId: "revision-2",
+      latestRevisionNumber: 2,
+      latestRevision: { ...draft.latestRevision, revisionId: "revision-2", revisionNumber: 2,
+        editedText: body.editedText, plateDocument: body.plateDocument },
+    };
+    await route.fulfill({ json: { ok: true, draft: savedDraft, revision: savedDraft.latestRevision } });
+  });
+  await page.goto("/apply-review");
+  const editor = page.getByRole("textbox", { name: "Tailored resume preview editor" });
+  await expect(editor).toBeVisible();
+  await editor.click();
+  await editor.press("ControlOrMeta+End");
+  await editor.pressSequentially(" snapshotA");
+  await expect(page.getByRole("button", { name: "Save draft" })).toBeEnabled();
+  await page.getByRole("button", { name: "Save draft" }).click();
+  await expect.poll(() => Boolean(acknowledge)).toBe(true);
+  await editor.click();
+  await editor.press("ControlOrMeta+End");
+  await editor.pressSequentially(" laterB");
+  acknowledge();
+  await expect(page.getByText("unsaved changes", { exact: true })).toBeVisible();
+  await expect(editor).toContainText("laterB");
+  await expect(editor).toBeFocused();
+  expect(savedText).toContain("snapshotA");
+  expect(savedText).not.toContain("laterB");
+  await expect(page.getByRole("button", { name: "Save draft" })).toBeEnabled();
+  await expect(page.getByRole("button", { name: "Render replacement" })).toBeDisabled();
+});
+
+test("a delayed seed snapshot cannot replace a rendered saved revision", async ({ page }) => {
+  await installArtifactComparisonRoutes(page);
+  let finishSeed!: () => void;
+  await page.route("**/v1/resume-review/drafts/*/comment-threads", async (route) => {
+    await new Promise<void>((resolve) => { finishSeed = resolve; });
+    await route.fulfill({ json: { ok: true, draft, commentThreads: draft.commentThreads, seededCount: 1, updatedCount: 0 } });
+  });
+  await page.goto("/apply-review");
+  await expect.poll(() => Boolean(finishSeed)).toBe(true);
+  await page.getByRole("button", { name: "Render replacement" }).click();
+  await expect(page.getByText("replacement rendered", { exact: true })).toBeVisible();
+  finishSeed();
+  await expect(page.getByText("replacement rendered", { exact: true })).toBeVisible();
+  await expect(page.getByRole("region", { name: "Artifact comparison" })).toContainText("+covered");
 });

--- a/apps/web/e2e/tests/artifact-comparison.spec.ts
+++ b/apps/web/e2e/tests/artifact-comparison.spec.ts
@@ -282,6 +282,40 @@ test("artifact full-page detail compares same-job generated artifacts", async ({
   await expect(comparison).toContainText("gcp");
 });
 
+test("initial revision-zero draft arrival preserves text typed while loading", async ({ page }) => {
+  await installArtifactComparisonRoutes(page);
+  const initialDraft = {
+    ...draft, currentRevisionId: null, latestRevisionNumber: 0,
+    latestRevision: null, commentThreads: [],
+  };
+  let finishCreating!: () => void;
+  await page.route("**/v1/jobs/*/resume-review/draft", async (route) => {
+    await new Promise<void>((resolve) => { finishCreating = resolve; });
+    await route.fulfill({ json: { ok: true, draft: initialDraft } });
+  });
+  await page.route("**/v1/resume-review/drafts/*/comment-threads", async (route) => {
+    await route.fulfill({ json: {
+      ok: true, draft: initialDraft, commentThreads: [], seededCount: 0, updatedCount: 0,
+    } });
+  });
+  await page.goto("/apply-review");
+  const editor = page.getByRole("textbox", { name: "Tailored resume preview editor" });
+  await expect(editor).toBeVisible();
+  await expect(page.getByText("loading draft", { exact: true })).toBeVisible();
+  await editor.click();
+  await editor.press("ControlOrMeta+End");
+  await editor.pressSequentially(" typedWhileLoading");
+  await expect(page.getByLabel("Editable resume page")).toHaveAttribute("data-draft-dirty", "true");
+  await expect.poll(() => Boolean(finishCreating)).toBe(true);
+  finishCreating();
+  await expect(page.getByText("loading draft", { exact: true })).not.toBeVisible();
+  await expect(editor).toContainText("typedWhileLoading");
+  await expect(page.getByText("unsaved changes", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("Editable resume page")).toHaveAttribute("data-draft-dirty", "true");
+  await expect(page.getByRole("button", { name: "Save draft" })).toBeEnabled();
+  await expect(page.getByRole("button", { name: "Render replacement" })).toBeDisabled();
+});
+
 test("late saved snapshot preserves newer typing and keeps rendering gated", async ({ page }) => {
   await installArtifactComparisonRoutes(page);
   let acknowledge!: () => void;

--- a/apps/web/e2e/tests/artifact-comparison.spec.ts
+++ b/apps/web/e2e/tests/artifact-comparison.spec.ts
@@ -406,6 +406,51 @@ test("late saved snapshot preserves newer typing and keeps rendering gated", asy
   await expect(page.getByRole("button", { name: "Render replacement" })).toBeDisabled();
 });
 
+test("late save acknowledgement preserves an undo to the prior baseline", async ({ page }) => {
+  await installArtifactComparisonRoutes(page);
+  let acknowledge!: () => void;
+  let savedText = "";
+  let saveCount = 0;
+  await page.route("**/v1/resume-review/drafts/*/revisions", async (route) => {
+    const body = route.request().postDataJSON();
+    savedText = body.editedText;
+    saveCount += 1;
+    if (saveCount === 2) await new Promise<void>((resolve) => { acknowledge = resolve; });
+    const savedDraft = {
+      ...draft, currentRevisionId: `revision-${saveCount + 1}`, latestRevisionNumber: saveCount + 1,
+      latestRevision: { ...draft.latestRevision, revisionId: `revision-${saveCount + 1}`, revisionNumber: saveCount + 1,
+        editedText: body.editedText, plateDocument: body.plateDocument },
+    };
+    await route.fulfill({ json: { ok: true, draft: savedDraft, revision: savedDraft.latestRevision } });
+  });
+  await page.goto("/apply-review");
+  const editor = page.getByRole("textbox", { name: "Tailored resume preview editor" });
+  await expect(editor).toBeVisible();
+  await editor.click();
+  await editor.press("ControlOrMeta+End");
+  // First persist a browser-edited document, including Slate normalization.
+  await editor.pressSequentially(" baseline");
+  await expect.poll(() => saveCount).toBe(1);
+  await expect(page.getByLabel("Editable resume page")).toHaveAttribute("data-draft-dirty", "false");
+  const originalEditor = await editor.elementHandle();
+  const baselineText = await editor.innerText();
+  await editor.pressSequentially("X");
+  await expect(editor).toContainText("X");
+  // Exercise the production autosave timer, holding its response during the undo.
+  await expect.poll(() => Boolean(acknowledge)).toBe(true);
+  await editor.press("Backspace");
+  await expect(editor).toHaveText(baselineText, { useInnerText: true });
+  await expect(page.getByLabel("Editable resume page")).toHaveAttribute("data-draft-dirty", "false");
+  acknowledge();
+  await expect(page.getByRole("button", { name: "Save draft" })).toBeEnabled();
+  await expect(editor).toHaveText(baselineText, { useInnerText: true });
+  expect(await editor.evaluate((element, original) => element === original, originalEditor)).toBe(true);
+  await expect(editor).toBeFocused();
+  await expect(page.getByLabel("Editable resume page")).toHaveAttribute("data-draft-dirty", "true");
+  await expect(page.getByRole("button", { name: "Render replacement" })).toBeDisabled();
+  expect(savedText).toContain("X");
+});
+
 test("a delayed seed snapshot cannot replace a rendered saved revision", async ({ page }) => {
   await installArtifactComparisonRoutes(page, false);
   let finishSeed!: () => void;

--- a/apps/web/e2e/tests/artifact-comparison.spec.ts
+++ b/apps/web/e2e/tests/artifact-comparison.spec.ts
@@ -282,6 +282,56 @@ test("artifact full-page detail compares same-job generated artifacts", async ({
   await expect(comparison).toContainText("gcp");
 });
 
+test("switching identical cached drafts does not carry unsaved text to another job", async ({ page }) => {
+  await installArtifactComparisonRoutes(page);
+  const first = sampleApplyReviewQueue.items[0]!;
+  const other = sampleApplyReviewQueue.items[1]!;
+  const second = { ...first, jobKey: other.jobKey, title: other.title,
+    materialsPreview: { ...first.materialsPreview,
+      resumeTextArtifactId: "other-job-text", resumePdfArtifactId: "other-job-pdf" },
+  };
+  const plateDocument = [{ type: "resume_block", tagName: "main", className: "resume-page", pageNumber: 1,
+    children: [{ type: "resume_block", tagName: "p", lineNumber: 3, pageNumber: 1,
+      semanticId: "experience:line:3", children: [{ text: "Shared saved resume content." }] }],
+  }];
+  const draftA = { ...draft, latestRevision: { ...draft.latestRevision, plateDocument }, commentThreads: [] };
+  const draftB = { ...draftA, draftId: "other-job-draft", jobKey: second.jobKey,
+    baseResumeTextArtifactId: "other-job-text", baseResumePdfArtifactId: "other-job-pdf",
+    latestRevision: { ...draftA.latestRevision, draftId: "other-job-draft", jobKey: second.jobKey },
+  };
+  const loadedJobs = new Set<string>();
+  await page.route("**/v1/apply/review-queue", route => route.fulfill({
+    json: { ...sampleApplyReviewQueue, items: [first, second] },
+  }));
+  await page.route("**/v1/jobs/*/resume-review/draft", async (route) => {
+    const requestedJob = decodeURIComponent(new URL(route.request().url()).pathname.split("/")[3]!);
+    await route.fulfill({ json: { ok: true, draft: requestedJob === first.jobKey ? draftA : draftB } });
+    loadedJobs.add(requestedJob);
+  });
+  await page.route("**/v1/resume-review/drafts/*/comment-threads", route => route.fulfill({ json: {
+    ok: true, draft: route.request().url().includes(draftB.draftId) ? draftB : draftA,
+    commentThreads: [], seededCount: 0, updatedCount: 0,
+  } }));
+  await page.goto("/apply-review");
+  const editor = page.getByRole("textbox", { name: "Tailored resume preview editor" });
+  const queue = page.getByLabel("Application review queue");
+  await expect(editor).toContainText("Shared saved resume content.");
+  await expect.poll(() => loadedJobs.has(first.jobKey)).toBe(true);
+  await queue.getByRole("button", { name: new RegExp(second.title) }).click();
+  await expect.poll(() => loadedJobs.has(second.jobKey)).toBe(true);
+  await expect(page.getByLabel("Editable resume page")).toHaveAttribute("data-draft-dirty", "false");
+  await queue.getByRole("button", { name: new RegExp(first.title) }).click();
+  await editor.click();
+  await editor.press("ControlOrMeta+End");
+  await editor.pressSequentially(" belongsOnlyToFirstJob");
+  await expect(page.getByLabel("Editable resume page")).toHaveAttribute("data-draft-dirty", "true");
+  await queue.getByRole("button", { name: new RegExp(second.title) }).click();
+  await expect(editor).toContainText("Shared saved resume content.");
+  await expect(editor).not.toContainText("belongsOnlyToFirstJob");
+  await expect(page.getByLabel("Editable resume page")).toHaveAttribute("data-draft-dirty", "false");
+  await expect(page.getByRole("button", { name: "Save draft" })).toBeDisabled();
+});
+
 test("initial revision-zero draft arrival preserves text typed while loading", async ({ page }) => {
   await installArtifactComparisonRoutes(page);
   const initialDraft = {

--- a/apps/web/src/contexts/apply/hooks/reconcileResumeReviewDraft.test.ts
+++ b/apps/web/src/contexts/apply/hooks/reconcileResumeReviewDraft.test.ts
@@ -1,0 +1,234 @@
+import type {
+  ResumeCommentThread,
+  ResumeReviewDraft,
+  TailoringFeedbackSignal,
+} from "@jobctrl/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  reconcileResumeReviewDraft,
+  reconcileResumeReviewReply,
+} from "./reconcileResumeReviewDraft.js";
+
+const time = "2026-09-06T10:00:00.000Z";
+const thread: ResumeCommentThread = {
+  threadId: "thread-1",
+  draftId: "draft-1",
+  jobKey: "job-1",
+  baseArtifactId: null,
+  semanticId: null,
+  lineAnchor: null,
+  sourcePinId: null,
+  riskLabel: "claim risk",
+  commentBody: "Check evidence",
+  state: "open",
+  anchorResolved: true,
+  createdAt: time,
+  updatedAt: time,
+  replies: [],
+};
+const draft: ResumeReviewDraft = {
+  draftId: "draft-1",
+  jobKey: "job-1",
+  baseGeneration: 1,
+  baseResumeTextArtifactId: "accepted-1",
+  baseResumePdfArtifactId: null,
+  rendererFormat: "html_css",
+  state: "active",
+  currentRevisionId: "revision-1",
+  latestRevisionNumber: 1,
+  createdAt: time,
+  updatedAt: time,
+  latestRevision: {
+    revisionId: "revision-1",
+    draftId: "draft-1",
+    jobKey: "job-1",
+    revisionNumber: 1,
+    editedText: "Saved evidence",
+    plateDocument: [
+      { type: "p", children: [{ text: "Saved evidence", bold: true }] },
+    ],
+    editDeltas: [],
+    createdAt: time,
+  },
+  commentThreads: [thread],
+  feedbackSignals: [],
+};
+const signal: TailoringFeedbackSignal = {
+  signalId: "signal-1",
+  jobKey: "job-1",
+  draftId: "draft-1",
+  draftRevisionId: "revision-1",
+  sourceKind: "comment_reply",
+  sourceId: "reply-1",
+  kind: "factual_correction",
+  status: "candidate",
+  summary: "Corrected",
+  section: null,
+  semanticId: null,
+  createdAt: time,
+  reviewedAt: null,
+};
+
+describe("saved resume draft reconciliation", () => {
+  it("keeps the highest revision and its rendered state through reversed full responses", () => {
+    const rendered = {
+      ...draft,
+      latestRevisionNumber: 2,
+      state: "rendered" as const,
+    };
+    for (const older of [
+      draft,
+      { ...draft, latestRevisionNumber: 0, latestRevision: null },
+      {
+        ...rendered,
+        state: "active" as const,
+        updatedAt: "2026-09-25T10:00:00.000Z",
+      },
+    ]) {
+      const result = reconcileResumeReviewDraft(rendered, older);
+      expect(result.latestRevisionNumber).toBe(2);
+      expect(result.state).toBe("rendered");
+      expect(result.latestRevision).toBe(rendered.latestRevision);
+    }
+    expect(
+      reconcileResumeReviewDraft(rendered, {
+        ...draft,
+        latestRevisionNumber: 3,
+      }).latestRevisionNumber,
+    ).toBe(3);
+  });
+
+  it("orders distinct drafts by base generation then server creation time, never revision or opaque id", () => {
+    const old = { ...draft, latestRevisionNumber: 9 };
+    const replacement = { ...draft, draftId: "aaa-new", baseGeneration: 2 };
+    expect(reconcileResumeReviewDraft(old, replacement).draftId).toBe(
+      "aaa-new",
+    );
+    expect(reconcileResumeReviewDraft(replacement, old).draftId).toBe(
+      "aaa-new",
+    );
+    const sameGeneration = {
+      ...draft,
+      draftId: "aaa-later",
+      createdAt: "2026-09-06T11:00:00.000Z",
+    };
+    expect(reconcileResumeReviewDraft(old, sameGeneration).draftId).toBe(
+      "aaa-later",
+    );
+    expect(reconcileResumeReviewDraft(sameGeneration, old).draftId).toBe(
+      "aaa-later",
+    );
+    expect(
+      reconcileResumeReviewDraft(draft, { ...draft, draftId: "zzz-tied" })
+        .draftId,
+    ).toBe("draft-1");
+  });
+
+  it("preserves independent replies, thread state and feedback after a stale full snapshot", () => {
+    const reply = {
+      replyId: "reply-1",
+      threadId: thread.threadId,
+      draftRevisionId: null,
+      author: "user",
+      decision: "clarified" as const,
+      body: "Corrected",
+      createdAt: "2026-09-06T10:01:00.000Z",
+    };
+    const replied = reconcileResumeReviewReply(draft, {
+      ok: true,
+      reply,
+      feedbackSignal: signal,
+      thread: {
+        ...thread,
+        state: "user_replied",
+        updatedAt: reply.createdAt,
+        replies: [reply],
+      },
+    });
+    const stale = reconcileResumeReviewDraft(replied, draft);
+    expect(stale.commentThreads[0]?.replies).toEqual([reply]);
+    expect(stale.commentThreads[0]?.state).toBe("user_replied");
+    expect(stale.feedbackSignals).toEqual([signal]);
+    const reviewedSignal = {
+      ...signal,
+      status: "accepted" as const,
+      reviewedAt: "2026-09-06T11:00:00.000Z",
+    };
+    const reviewed = reconcileResumeReviewDraft(stale, {
+      ...draft,
+      feedbackSignals: [reviewedSignal],
+    });
+    expect(
+      reconcileResumeReviewDraft(reviewed, replied).feedbackSignals,
+    ).toEqual([reviewedSignal]);
+    const second = {
+      ...reply,
+      replyId: "reply-2",
+      createdAt: "2026-09-06T10:02:00.000Z",
+    };
+    const independent = reconcileResumeReviewDraft(stale, {
+      ...draft,
+      commentThreads: [
+        {
+          ...thread,
+          updatedAt: second.createdAt,
+          state: "user_replied",
+          replies: [second],
+        },
+      ],
+    });
+    expect(
+      independent.commentThreads[0]?.replies.map((item) => item.replyId),
+    ).toEqual(["reply-1", "reply-2"]);
+  });
+
+  it("retains a late old-draft reply as job feedback without reviving its thread", () => {
+    const replacement = {
+      ...draft,
+      draftId: "draft-2",
+      baseGeneration: 2,
+      commentThreads: [],
+    };
+    const reply = {
+      replyId: "reply-1",
+      threadId: thread.threadId,
+      draftRevisionId: null,
+      author: "user",
+      decision: "clarified" as const,
+      body: "Correction",
+      createdAt: time,
+    };
+    const result = reconcileResumeReviewReply(replacement, {
+      ok: true,
+      reply,
+      feedbackSignal: signal,
+      thread: { ...thread, state: "user_replied", replies: [reply] },
+    });
+    expect(result.draftId).toBe("draft-2");
+    expect(result.commentThreads).toEqual([]);
+    expect(result.feedbackSignals).toEqual([signal]);
+  });
+
+  it("never mixes thread identities across replacement drafts or jobs", () => {
+    const replacement = {
+      ...draft,
+      draftId: "draft-2",
+      baseGeneration: 2,
+      commentThreads: [],
+    };
+    expect(
+      reconcileResumeReviewDraft(draft, replacement).commentThreads,
+    ).toEqual([]);
+    expect(
+      reconcileResumeReviewDraft(replacement, draft).commentThreads,
+    ).toEqual([]);
+    expect(
+      reconcileResumeReviewDraft(draft, {
+        ...draft,
+        jobKey: "other",
+        commentThreads: [],
+      }).commentThreads,
+    ).toEqual([]);
+  });
+});

--- a/apps/web/src/contexts/apply/hooks/reconcileResumeReviewDraft.ts
+++ b/apps/web/src/contexts/apply/hooks/reconcileResumeReviewDraft.ts
@@ -1,0 +1,122 @@
+import type {
+  ResumeCommentReplyResponse,
+  ResumeCommentThread,
+  ResumeReviewDraft,
+  TailoringFeedbackSignal,
+} from "@jobctrl/contracts";
+
+function timestamp(value: string | null): number {
+  const parsed = value ? Date.parse(value) : NaN;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function stateRank(draft: ResumeReviewDraft): number {
+  return draft.state === "promoted" ? 3 : draft.state === "rendered" ? 2 : 1;
+}
+
+function mergeThread(
+  current: ResumeCommentThread,
+  incoming: ResumeCommentThread,
+  newerRevision: boolean,
+): ResumeCommentThread {
+  const incomingIsNewer =
+    timestamp(incoming.updatedAt) > timestamp(current.updatedAt) ||
+    (timestamp(incoming.updatedAt) === timestamp(current.updatedAt) &&
+      (newerRevision ||
+        incoming.replies.some(
+          (reply) =>
+            !current.replies.some((saved) => saved.replyId === reply.replyId),
+        )));
+  const selected = incomingIsNewer ? incoming : current;
+  const replies = new Map(
+    current.replies.map((reply) => [reply.replyId, reply]),
+  );
+  for (const reply of incoming.replies) replies.set(reply.replyId, reply);
+  return {
+    ...selected,
+    replies: [...replies.values()].sort(
+      (left, right) => timestamp(left.createdAt) - timestamp(right.createdAt),
+    ),
+  };
+}
+
+function mergeSignals(
+  current: readonly TailoringFeedbackSignal[],
+  incoming: readonly TailoringFeedbackSignal[],
+): TailoringFeedbackSignal[] {
+  const signals = new Map(current.map((signal) => [signal.signalId, signal]));
+  for (const signal of incoming) {
+    const previous = signals.get(signal.signalId);
+    if (
+      !previous ||
+      timestamp(signal.reviewedAt ?? signal.createdAt) >
+        timestamp(previous.reviewedAt ?? previous.createdAt) ||
+      (signal.reviewedAt !== null && previous.reviewedAt === null)
+    ) {
+      signals.set(signal.signalId, signal);
+    }
+  }
+  return [...signals.values()];
+}
+
+/** Document revisions and comment activity advance independently. */
+export function reconcileResumeReviewDraft(
+  current: ResumeReviewDraft | undefined,
+  incoming: ResumeReviewDraft,
+): ResumeReviewDraft {
+  if (!current || current.jobKey !== incoming.jobKey) return incoming;
+  const feedbackSignals = mergeSignals(
+    current.feedbackSignals,
+    incoming.feedbackSignals,
+  );
+  if (current.draftId !== incoming.draftId) {
+    // Revision counters restart for each draft. Draft creation time is server
+    // metadata; opaque IDs themselves never establish chronological order.
+    const difference =
+      incoming.baseGeneration - current.baseGeneration ||
+      timestamp(incoming.createdAt) - timestamp(current.createdAt);
+    return { ...(difference > 0 ? incoming : current), feedbackSignals };
+  }
+  const difference =
+    incoming.latestRevisionNumber - current.latestRevisionNumber ||
+    stateRank(incoming) - stateRank(current) ||
+    timestamp(incoming.updatedAt) - timestamp(current.updatedAt);
+  const selected = difference > 0 ? incoming : current;
+  const threads = new Map(
+    current.commentThreads.map((thread) => [thread.threadId, thread]),
+  );
+  for (const thread of incoming.commentThreads) {
+    const previous = threads.get(thread.threadId);
+    threads.set(
+      thread.threadId,
+      previous ? mergeThread(previous, thread, difference > 0) : thread,
+    );
+  }
+  return {
+    ...selected,
+    commentThreads: [...threads.values()],
+    feedbackSignals,
+  };
+}
+
+export function reconcileResumeReviewReply(
+  current: ResumeReviewDraft,
+  response: ResumeCommentReplyResponse,
+): ResumeReviewDraft {
+  if (response.thread.jobKey !== current.jobKey) return current;
+  // Feedback is job-scoped even when its originating draft was replaced while
+  // the reply request was in flight. Only threads belong to one draft.
+  if (response.thread.draftId !== current.draftId) {
+    return {
+      ...current,
+      feedbackSignals: mergeSignals(current.feedbackSignals, [
+        response.feedbackSignal,
+      ]),
+    };
+  }
+  return reconcileResumeReviewDraft(current, {
+    ...current,
+    commentThreads: [response.thread],
+    feedbackSignals: [response.feedbackSignal],
+  });
+}

--- a/apps/web/src/contexts/apply/hooks/useApplyReviewMutations.test.ts
+++ b/apps/web/src/contexts/apply/hooks/useApplyReviewMutations.test.ts
@@ -1,4 +1,6 @@
-import { LOCAL_TENANT } from "@jobctrl/domain-types";
+import type { ResumeReviewDraft, ResumeReviewDraftResponse } from "@jobctrl/contracts";
+import { buildTestPorts, FakeSessionPort } from "../../../test/testPorts.js";
+import { LOCAL_TENANT, type TenantId } from "@jobctrl/domain-types";
 import { http, HttpResponse } from "msw";
 import { act } from "react";
 import { waitFor } from "@testing-library/react";
@@ -19,6 +21,49 @@ import {
 } from "./useApplyReviewMutations.js";
 
 describe("apply review mutations", () => {
+  it("publishes delayed responses to their original tenant/job without losing the newer saved revision", async () => {
+    const jobId = "job-race";
+    const draft: ResumeReviewDraft = {
+      draftId: "draft-race", jobKey: jobId, baseGeneration: 1,
+      baseResumeTextArtifactId: null, baseResumePdfArtifactId: null, rendererFormat: "html_css",
+      state: "active", currentRevisionId: null, latestRevisionNumber: 0,
+      createdAt: "2026-09-06T10:00:00.000Z", updatedAt: "2026-09-06T10:00:00.000Z",
+      latestRevision: null, commentThreads: [], feedbackSignals: [],
+    };
+    let finishCreate!: () => void;
+    let finishSeed!: () => void;
+    const ports = buildTestPorts({ api: {
+      createResumeReviewDraft: vi.fn(async () => {
+        await new Promise<void>((resolve) => { finishCreate = resolve; });
+        return { ok: true as const, draft };
+      }),
+      seedResumeReviewCommentThreads: vi.fn(async () => {
+        await new Promise<void>((resolve) => { finishSeed = resolve; });
+        return { ok: true as const, draft, commentThreads: [], seededCount: 0, updatedCount: 0 };
+      }),
+    } });
+    const { result, queryClient, rerender } = renderHookWithProviders(() => ({
+      create: useCreateResumeReviewDraftMutation(), seed: useSeedResumeReviewCommentThreadsMutation(),
+    }), { ports });
+    await act(async () => {
+      result.current.create.mutate({ jobId });
+      result.current.seed.mutate({ jobId, draftId: draft.draftId, body: { threads: [] } });
+    });
+    await waitFor(() => expect(finishSeed).toBeDefined());
+    const switchedTenant = "tenant-switched" as TenantId;
+    Object.assign(ports, { session: new FakeSessionPort({ tenantId: switchedTenant, userId: null }) });
+    rerender();
+    const rendered = { ...draft, latestRevisionNumber: 2, state: "rendered" as const };
+    queryClient.setQueryData(applyReviewKeys.draft(LOCAL_TENANT, jobId), { ok: true, draft: rendered });
+    const otherJob = { ok: true, draft: { ...draft, jobKey: "other-job" } };
+    queryClient.setQueryData(applyReviewKeys.draft(LOCAL_TENANT, "other-job"), otherJob);
+    await act(async () => { finishSeed(); finishCreate(); });
+    await waitFor(() => expect(result.current.create.isSuccess && result.current.seed.isSuccess).toBe(true));
+    expect(queryClient.getQueryData<ResumeReviewDraftResponse>(applyReviewKeys.draft(LOCAL_TENANT, jobId))?.draft).toEqual(rendered);
+    expect(queryClient.getQueryData(applyReviewKeys.draft(LOCAL_TENANT, "other-job"))).toEqual(otherJob);
+    expect(queryClient.getQueryData(applyReviewKeys.draft(switchedTenant, jobId))).toBeUndefined();
+  });
+
   it("records review decisions and invalidates review surfaces", async () => {
     const { result, queryClient } = renderHookWithProviders(() => useApplyReviewDecisionMutation());
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");

--- a/apps/web/src/contexts/apply/hooks/useApplyReviewMutations.ts
+++ b/apps/web/src/contexts/apply/hooks/useApplyReviewMutations.ts
@@ -245,7 +245,8 @@ export function useSeedResumeReviewCommentThreadsMutation(): UseMutationResult<
 export function useRenderResumeReviewDraftMutation(): UseMutationResult<
   ResumeReviewDraftRenderResponse,
   Error,
-  RenderResumeReviewDraftVariables
+  RenderResumeReviewDraftVariables,
+  { readonly tenantId: TenantId }
 > {
   const tenantId = useTenantId();
   const { api } = usePorts();

--- a/apps/web/src/contexts/apply/hooks/useApplyReviewMutations.ts
+++ b/apps/web/src/contexts/apply/hooks/useApplyReviewMutations.ts
@@ -12,6 +12,7 @@ import type {
   ResumeReviewCommentThreadSeedRequest,
   ResumeReviewCommentThreadSeedResponse,
   ResumeReviewDraftCreateRequest,
+  ResumeReviewDraft,
   ResumeReviewDraftRenderRequest,
   ResumeReviewDraftRenderResponse,
   ResumeReviewDraftResponse,
@@ -34,6 +35,7 @@ import { dashboardKeys } from "../../operations/dashboardKeys.js";
 import { jobsKeys } from "../../operations/jobsKeys.js";
 import { outcomesKeys } from "../../operations/outcomesKeys.js";
 import type { JobId } from "../../operations/types.js";
+import { reconcileResumeReviewDraft, reconcileResumeReviewReply } from "./reconcileResumeReviewDraft.js";
 
 export interface ApplyReviewDecisionVariables {
   readonly jobId: JobId;
@@ -166,6 +168,14 @@ export function useOutcomeSuggestionDecisionMutation(): UseMutationResult<
   });
 }
 
+function publishDraft(queryClient: QueryClient, tenantId: TenantId, jobId: JobId, draft: ResumeReviewDraft): void {
+  if (draft.jobKey !== jobId) return;
+  queryClient.setQueryData<ResumeReviewDraftResponse>(applyReviewKeys.draft(tenantId, jobId), (current) => ({
+    ok: true,
+    draft: reconcileResumeReviewDraft(current?.draft, draft),
+  }));
+}
+
 export function useCreateResumeReviewDraftMutation(): UseMutationResult<
   ResumeReviewDraftResponse,
   Error,
@@ -175,11 +185,14 @@ export function useCreateResumeReviewDraftMutation(): UseMutationResult<
   const { api } = usePorts();
   const queryClient = useQueryClient();
   return useMutation({
+    onMutate: () => ({ tenantId }),
     mutationFn: ({ jobId, body }) => api.createResumeReviewDraft(jobId, body ?? {}),
-    onSuccess: (data, variables) => {
-      queryClient.setQueryData(applyReviewKeys.draft(tenantId, variables.jobId), data);
+    onSuccess: (data, variables, context) => {
+      const tenantId = context!.tenantId;
+      publishDraft(queryClient, tenantId, variables.jobId, data.draft);
     },
-    onSettled: (_data, _error, variables) => {
+    onSettled: (_data, _error, variables, context) => {
+      const tenantId = context!.tenantId;
       invalidateApplyReviewSurfaces(queryClient, tenantId, variables.jobId);
     },
   });
@@ -194,14 +207,14 @@ export function useSaveResumeReviewDraftRevisionMutation(): UseMutationResult<
   const { api } = usePorts();
   const queryClient = useQueryClient();
   return useMutation({
+    onMutate: () => ({ tenantId }),
     mutationFn: ({ draftId, body }) => api.saveResumeReviewDraftRevision(draftId, body),
-    onSuccess: (data, variables) => {
-      queryClient.setQueryData(applyReviewKeys.draft(tenantId, variables.jobId), {
-        ok: true,
-        draft: data.draft,
-      });
+    onSuccess: (data, variables, context) => {
+      const tenantId = context!.tenantId;
+      publishDraft(queryClient, tenantId, variables.jobId, data.draft);
     },
-    onSettled: (_data, _error, variables) => {
+    onSettled: (_data, _error, variables, context) => {
+      const tenantId = context!.tenantId;
       invalidateApplyReviewSurfaces(queryClient, tenantId, variables.jobId);
     },
   });
@@ -216,14 +229,14 @@ export function useSeedResumeReviewCommentThreadsMutation(): UseMutationResult<
   const { api } = usePorts();
   const queryClient = useQueryClient();
   return useMutation({
+    onMutate: () => ({ tenantId }),
     mutationFn: ({ draftId, body }) => api.seedResumeReviewCommentThreads(draftId, body),
-    onSuccess: (data, variables) => {
-      queryClient.setQueryData(applyReviewKeys.draft(tenantId, variables.jobId), {
-        ok: true,
-        draft: data.draft,
-      });
+    onSuccess: (data, variables, context) => {
+      const tenantId = context!.tenantId;
+      publishDraft(queryClient, tenantId, variables.jobId, data.draft);
     },
-    onSettled: (_data, _error, variables) => {
+    onSettled: (_data, _error, variables, context) => {
+      const tenantId = context!.tenantId;
       invalidateApplyReviewSurfaces(queryClient, tenantId, variables.jobId);
     },
   });
@@ -238,12 +251,11 @@ export function useRenderResumeReviewDraftMutation(): UseMutationResult<
   const { api } = usePorts();
   const queryClient = useQueryClient();
   return useMutation({
+    onMutate: () => ({ tenantId }),
     mutationFn: ({ draftId, body }) => api.renderResumeReviewDraft(draftId, body ?? {}),
-    onSuccess: (data, variables) => {
-      queryClient.setQueryData(applyReviewKeys.draft(tenantId, variables.jobId), {
-        ok: true,
-        draft: data.draft,
-      });
+    onSuccess: (data, variables, context) => {
+      const tenantId = context!.tenantId;
+      publishDraft(queryClient, tenantId, variables.jobId, data.draft);
       void queryClient.invalidateQueries({ queryKey: artifactsKeys.lists(tenantId) });
       if (data.ok) {
         void queryClient.invalidateQueries({
@@ -254,7 +266,8 @@ export function useRenderResumeReviewDraftMutation(): UseMutationResult<
         });
       }
     },
-    onSettled: (_data, _error, variables) => {
+    onSettled: (_data, _error, variables, context) => {
+      const tenantId = context!.tenantId;
       invalidateApplyReviewSurfaces(queryClient, tenantId, variables.jobId);
     },
   });
@@ -269,8 +282,16 @@ export function useReplyToResumeReviewCommentMutation(): UseMutationResult<
   const { api } = usePorts();
   const queryClient = useQueryClient();
   return useMutation({
+    onMutate: () => ({ tenantId }),
     mutationFn: ({ threadId, body }) => api.replyToResumeReviewComment(threadId, body),
-    onSettled: (_data, _error, variables) => {
+    onSuccess: (data, variables, context) => {
+      queryClient.setQueryData<ResumeReviewDraftResponse>(
+        applyReviewKeys.draft(context!.tenantId, variables.jobId),
+        (current) => current ? { ...current, draft: reconcileResumeReviewReply(current.draft, data) } : current,
+      );
+    },
+    onSettled: (_data, _error, variables, context) => {
+      const tenantId = context!.tenantId;
       invalidateApplyReviewSurfaces(queryClient, tenantId, variables.jobId);
     },
   });

--- a/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
+++ b/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
@@ -3248,10 +3248,24 @@ export function ResumePlateEditor({
   }, [draft?.latestRevision?.plateDocument, htmlState]);
   const [currentPlateValue, setCurrentPlateValue] = useState<Value | null>(initialPlateValue);
 
+  const reviewDocumentIdentity = draft ? `${draft.draftId}:${draft.baseGeneration}` : artifactId;
+  const savedDocument = useRef({ identity: reviewDocumentIdentity, signature: resumePlateValueSignature(initialPlateValue) });
   useEffect(() => {
-    setCurrentPlateValue(initialPlateValue);
-    setDraftSourceVersion((currentVersion) => currentVersion + 1);
-  }, [initialPlateValue]);
+    const signature = resumePlateValueSignature(initialPlateValue);
+    const previous = savedDocument.current;
+    if (previous.identity === reviewDocumentIdentity && previous.signature === signature) return;
+    savedDocument.current = { identity: reviewDocumentIdentity, signature };
+    // A saved response acknowledges its snapshot, not edits typed after it.
+    // Comment-only publications and identical acknowledgements never remount
+    // Plate, preserving formatting, focus and selection in the live document.
+    const currentSignature = resumePlateValueSignature(currentPlateValue);
+    if (previous.identity !== reviewDocumentIdentity || currentSignature === previous.signature) {
+      if (currentSignature !== signature) {
+        setCurrentPlateValue(initialPlateValue);
+        setDraftSourceVersion((currentVersion) => currentVersion + 1);
+      }
+    }
+  }, [currentPlateValue, initialPlateValue, reviewDocumentIdentity]);
 
   const currentDraftText = useMemo(
     () => (currentPlateValue ? resumeTextFromPlateValue(currentPlateValue) : ""),

--- a/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
+++ b/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
@@ -3250,6 +3250,7 @@ export function ResumePlateEditor({
 
   const reviewDocumentIdentity = draft ? `${draft.draftId}:${draft.baseGeneration}` : artifactId;
   const savedDocument = useRef({ identity: reviewDocumentIdentity, signature: resumePlateValueSignature(initialPlateValue) });
+  const submittedDocument = useRef<{ identity: string; signature: string } | null>(null);
   useEffect(() => {
     const signature = resumePlateValueSignature(initialPlateValue);
     const previous = savedDocument.current;
@@ -3262,7 +3263,9 @@ export function ResumePlateEditor({
     // Comment-only publications and identical acknowledgements never remount
     // Plate, preserving formatting, focus and selection in the live document.
     const currentSignature = resumePlateValueSignature(currentPlateValue);
-    if (previous.identity !== reviewDocumentIdentity || currentSignature === previous.signature) {
+    const acknowledgesSubmission = submittedDocument.current?.identity === reviewDocumentIdentity
+      && submittedDocument.current.signature === signature;
+    if (previous.identity !== reviewDocumentIdentity || (!acknowledgesSubmission && currentSignature === previous.signature)) {
       if (currentSignature !== signature) {
         setCurrentPlateValue(initialPlateValue);
         setDraftSourceVersion((currentVersion) => currentVersion + 1);
@@ -3282,6 +3285,14 @@ export function ResumePlateEditor({
     () => resumePlateValueSignature(currentPlateValue),
     [currentPlateValue],
   );
+  const handleSaveDraft = useCallback((source: "autosave" | "manual") => {
+    if (!currentPlateValue || !onSaveDraft) return;
+    submittedDocument.current = {
+      identity: reviewDocumentIdentity,
+      signature: resumePlateValueSignature(normalizeResumePlateValue(currentPlateValue)),
+    };
+    onSaveDraft({ editedText: currentDraftText, plateDocument: currentPlateValue, source });
+  }, [currentDraftText, currentPlateValue, onSaveDraft, reviewDocumentIdentity]);
   const documentKey = `${artifactId}:${draft?.draftId ?? "no-draft"}:${htmlUrl ?? "no-html"}:${draftSourceVersion}:${editorVersion}`;
   const canFormat = formattingApiReady && Boolean(currentPlateValue);
   const draftDirty = Boolean(currentPlateValue && currentDraftSignature !== initialDraftSignature);
@@ -3427,11 +3438,7 @@ export function ResumePlateEditor({
     const handle = window.setTimeout(() => {
       if (!currentPlateValue || lastAutosaveSignature.current === currentDraftSignature) return;
       lastAutosaveSignature.current = currentDraftSignature;
-      onSaveDraft({
-        editedText: currentDraftText,
-        plateDocument: currentPlateValue,
-        source: "autosave",
-      });
+      handleSaveDraft("autosave");
     }, autosaveDelayMs);
     return () => window.clearTimeout(handle);
   }, [
@@ -3442,6 +3449,7 @@ export function ResumePlateEditor({
     draft,
     draftDirty,
     draftLoading,
+    handleSaveDraft,
     onSaveDraft,
     savePending,
   ]);
@@ -3503,14 +3511,7 @@ export function ResumePlateEditor({
           disabled={saveDisabled}
           size="sm"
           type="button"
-          onClick={() => {
-            if (!currentPlateValue) return;
-            onSaveDraft?.({
-              editedText: currentDraftText,
-              plateDocument: currentPlateValue,
-              source: "manual",
-            });
-          }}
+          onClick={() => handleSaveDraft("manual")}
         >
           Save draft
         </Button>

--- a/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
+++ b/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
@@ -3255,8 +3255,9 @@ export function ResumePlateEditor({
     const previous = savedDocument.current;
     if (previous.identity === reviewDocumentIdentity && previous.signature === signature) return;
     savedDocument.current = { identity: reviewDocumentIdentity, signature };
-    // The first draft can acquire an identity without changing its saved document.
-    if (previous.signature === signature) return;
+    // Only the initial revision-zero arrival continues the current artifact's
+    // editing session; identical saved documents in another draft still reset it.
+    if (previous.identity === artifactId && draft?.latestRevisionNumber === 0 && previous.signature === signature) return;
     // A saved response acknowledges its snapshot, not edits typed after it.
     // Comment-only publications and identical acknowledgements never remount
     // Plate, preserving formatting, focus and selection in the live document.
@@ -3267,7 +3268,7 @@ export function ResumePlateEditor({
         setDraftSourceVersion((currentVersion) => currentVersion + 1);
       }
     }
-  }, [currentPlateValue, initialPlateValue, reviewDocumentIdentity]);
+  }, [artifactId, currentPlateValue, draft?.latestRevisionNumber, initialPlateValue, reviewDocumentIdentity]);
 
   const currentDraftText = useMemo(
     () => (currentPlateValue ? resumeTextFromPlateValue(currentPlateValue) : ""),

--- a/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
+++ b/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
@@ -3255,6 +3255,8 @@ export function ResumePlateEditor({
     const previous = savedDocument.current;
     if (previous.identity === reviewDocumentIdentity && previous.signature === signature) return;
     savedDocument.current = { identity: reviewDocumentIdentity, signature };
+    // The first draft can acquire an identity without changing its saved document.
+    if (previous.signature === signature) return;
     // A saved response acknowledges its snapshot, not edits typed after it.
     // Comment-only publications and identical acknowledgements never remount
     // Plate, preserving formatting, focus and selection in the live document.

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -1998,6 +1998,48 @@ describe("<ApplyReviewView>", () => {
     );
   });
 
+  it("preserves later formatting and focus when a saved snapshot and stale seed response arrive", async () => {
+    const draft = makeResumeReviewDraft();
+    let acknowledge: (() => void) | undefined;
+    const saveResumeReviewDraftRevision = vi.fn(async (_draftId, body) => {
+      await new Promise<void>((resolve) => { acknowledge = resolve; });
+      const saved = makeResumeReviewDraft(draft.jobKey, {
+        ...body, revisionId: "saved-2", revisionNumber: 2,
+      });
+      return { ok: true as const, draft: saved, revision: saved.latestRevision! };
+    });
+    let seed: (() => void) | undefined;
+    renderWithProviders(<ApplyReviewView />, {
+      ports: buildTestPorts({ api: {
+        applyReviewQueue: vi.fn(async () => sampleApplyReviewQueue),
+        createResumeReviewDraft: vi.fn(async () => ({ ok: true as const, draft })),
+        saveResumeReviewDraftRevision,
+        seedResumeReviewCommentThreads: vi.fn(async () => {
+          await new Promise<void>((resolve) => { seed = resolve; });
+          return { ok: true as const, draft, commentThreads: [], seededCount: 0, updatedCount: 0 };
+        }),
+      } }),
+    });
+    const editor = await screen.findByRole("textbox", { name: "Tailored resume preview editor" });
+    await chooseSelectOption("Font", "Garamond");
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save draft" })).toBeEnabled());
+    await userEvent.click(screen.getByRole("button", { name: "Save draft" }));
+    await waitFor(() => expect(acknowledge).toBeDefined());
+    await chooseSelectOption("Font", "Helvetica");
+    await userEvent.click(editor);
+    expect(editor).toHaveFocus();
+    acknowledge!();
+    await waitFor(() => expect(screen.getByText("unsaved changes")).toBeInTheDocument());
+    seed?.();
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save draft" })).toBeEnabled());
+    expect(screen.getByRole("textbox", { name: "Tailored resume preview editor" })).toBe(editor);
+    expect(editor).toHaveFocus();
+    const shadow = await findResumeShadowRoot();
+    expect(shadowElementWithText(shadow, "Principal Platform Engineer").style.fontFamily).toContain("Helvetica");
+    expect(JSON.stringify(saveResumeReviewDraftRevision.mock.calls[0]![1].plateDocument)).toContain("garamond");
+    expect(JSON.stringify(saveResumeReviewDraftRevision.mock.calls[0]![1].plateDocument)).not.toContain("helvetica");
+  });
+
   it("keeps the cached resume review draft visible while create/load is pending", async () => {
     const jobKey = sampleApplyReviewQueue.items[0]!.jobKey;
     const draft = makeResumeReviewDraft(jobKey, {

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -2174,7 +2174,7 @@ describe("<ApplyReviewView>", () => {
     expect(screen.queryByText("Saved draft will render automatically before approval.")).not.toBeInTheDocument();
   });
 
-  it("compares the accepted artifact with the rendered draft artifact", async () => {
+  it.each([false, true])("keeps the completed-render comparison when a new active draft is loaded: %s", async (loadNewActiveDraft) => {
     const jobKey = sampleApplyReviewQueue.items[0]!.jobKey;
     const acceptedArtifact = {
       ...sampleAcceptedResumeArtifact,
@@ -2204,7 +2204,7 @@ describe("<ApplyReviewView>", () => {
         ok: true as const,
         draft: {
           ...draft,
-          state: "rendered" as const,
+          state: "promoted" as const,
         },
         validation: { passed: true, errors: [], warnings: [] },
         artifacts: {
@@ -2233,6 +2233,7 @@ describe("<ApplyReviewView>", () => {
               materialsPreview: {
                 ...item.materialsPreview,
                 resumeTextArtifactId: draftArtifact.artifactId,
+                resumePdfArtifactId: "resume-review-pdf",
               },
             }
           : item,
@@ -2267,12 +2268,17 @@ describe("<ApplyReviewView>", () => {
       return makeArtifactDetail({ ...sampleArtifact, artifactId });
     });
 
-    renderWithProviders(<ApplyReviewView />, {
+    const { queryClient } = renderWithProviders(<ApplyReviewView />, {
       ports: buildTestPorts({
         api: {
           applyReviewQueue,
           artifact,
-          createResumeReviewDraft: vi.fn(async () => ({ ok: true as const, draft })),
+          createResumeReviewDraft: vi.fn(async () => ({ ok: true as const, draft: renderCompleted && loadNewActiveDraft ? {
+            ...draft, draftId: "draft-after-promotion", baseGeneration: 3,
+            baseResumeTextArtifactId: draftArtifact.artifactId, baseResumePdfArtifactId: "resume-review-pdf",
+            state: "active" as const, currentRevisionId: null, latestRevisionNumber: 0,
+            latestRevision: null, commentThreads: [],
+          } : draft })),
           renderResumeReviewDraft,
           seedResumeReviewCommentThreads: vi.fn(async () => ({
             ok: true as const,
@@ -2304,6 +2310,21 @@ describe("<ApplyReviewView>", () => {
     expect(comparison.getByText("claim risk")).toBeInTheDocument();
     expect(screen.getByRole("region", { name: "Tailored resume preview" })).toBeInTheDocument();
 
+    if (loadNewActiveDraft) {
+      expect(await screen.findByText("draft ready")).toBeInTheDocument();
+      expect(renderButton).toBeDisabled();
+      expect(screen.queryByText("replacement rendered")).not.toBeInTheDocument();
+      queryClient.setQueryData(applyReviewKeys.queue(LOCAL_TENANT), {
+        ...refreshedQueue,
+        items: refreshedQueue.items.map((item) => item.jobKey === jobKey ? {
+          ...item, materialsPreview: { ...item.materialsPreview,
+            resumeTextArtifactId: "unrelated-generation-text", resumePdfArtifactId: "unrelated-generation-pdf" },
+        } : item),
+      });
+      expect(await comparison.findByText("Render a saved draft to compare it with the accepted artifact.")).toBeInTheDocument();
+      expect(comparison.queryByText("Accepted resume")).not.toBeInTheDocument();
+      return;
+    }
     await waitFor(() => expect(renderButton).not.toBeDisabled());
     await userEvent.click(renderButton);
     await waitFor(() => expect(renderResumeReviewDraft).toHaveBeenCalledTimes(2));

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -2040,6 +2040,37 @@ describe("<ApplyReviewView>", () => {
     expect(JSON.stringify(saveResumeReviewDraftRevision.mock.calls[0]![1].plateDocument)).not.toContain("helvetica");
   });
 
+  it("keeps unsaved edits scoped when selecting an identical cached draft", async () => {
+    const first = sampleApplyReviewQueue.items[0]!;
+    const other = sampleApplyReviewQueue.items[1]!;
+    const second = { ...first, jobKey: other.jobKey, title: other.title,
+      materialsPreview: { ...first.materialsPreview, resumeTextArtifactId: "other-job-b-text", resumePdfArtifactId: "other-job-b-pdf" } };
+    const draftA = makeResumeReviewDraft(first.jobKey, { draftId: "other-draft-a" });
+    const draftB = { ...makeResumeReviewDraft(second.jobKey, { draftId: "other-draft-b" }),
+      baseResumeTextArtifactId: "other-job-b-text", baseResumePdfArtifactId: "other-job-b-pdf" };
+    expect(draftA.latestRevision?.plateDocument).toEqual(draftB.latestRevision?.plateDocument);
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(applyReviewKeys.draft(LOCAL_TENANT, first.jobKey), { ok: true, draft: draftA });
+    queryClient.setQueryData(applyReviewKeys.draft(LOCAL_TENANT, second.jobKey), { ok: true, draft: draftB });
+    const createResumeReviewDraft = vi.fn((): Promise<{ok:true;draft:ResumeReviewDraft}> => new Promise(() => {}));
+    renderWithProviders(<ApplyReviewView />, { queryClient, ports: buildTestPorts({ api: {
+      applyReviewQueue: vi.fn(async () => ({ ...sampleApplyReviewQueue, items: [first, second] })),
+      createResumeReviewDraft,
+      seedResumeReviewCommentThreads: vi.fn(async (draftId: string) => {
+        const draft = draftId === draftA.draftId ? draftA : draftB;
+        return { ok: true as const, draft, commentThreads: [], seededCount: 0, updatedCount: 0 };
+      }),
+    } }) });
+    await findResumeShadowRoot();
+    await chooseSelectOption("Font", "Garamond");
+    expect(shadowElementWithText(await findResumeShadowRoot(), "Principal Platform Engineer").style.fontFamily).toContain("Garamond");
+    expect(screen.getByLabelText("Editable resume page")).toHaveAttribute("data-draft-dirty", "true");
+    await userEvent.click(within(screen.getByLabelText("Application review queue")).getByRole("button", { name: new RegExp(second.title) }));
+    await waitFor(() => expect(createResumeReviewDraft).toHaveBeenCalledTimes(2));
+    expect(shadowElementWithText(await findResumeShadowRoot(), "Principal Platform Engineer").style.fontFamily).not.toContain("Garamond");
+    expect(screen.getByLabelText("Editable resume page")).toHaveAttribute("data-draft-dirty", "false");
+  });
+
   it("preserves formatting while the initial revision-zero draft is loading", async () => {
     const draft = makeResumeReviewDraft(sampleApplyReviewQueue.items[0]!.jobKey, null);
     let finishCreating: (() => void) | undefined;

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -2040,6 +2040,38 @@ describe("<ApplyReviewView>", () => {
     expect(JSON.stringify(saveResumeReviewDraftRevision.mock.calls[0]![1].plateDocument)).not.toContain("helvetica");
   });
 
+  it("preserves formatting while the initial revision-zero draft is loading", async () => {
+    const draft = makeResumeReviewDraft(sampleApplyReviewQueue.items[0]!.jobKey, null);
+    let finishCreating: (() => void) | undefined;
+    renderWithProviders(<ApplyReviewView />, {
+      ports: buildTestPorts({ api: {
+        applyReviewQueue: vi.fn(async () => sampleApplyReviewQueue),
+        createResumeReviewDraft: vi.fn(async () => {
+          await new Promise<void>((resolve) => { finishCreating = resolve; });
+          return { ok: true as const, draft };
+        }),
+        seedResumeReviewCommentThreads: vi.fn(async () => ({
+          ok: true as const, draft, commentThreads: [], seededCount: 0, updatedCount: 0,
+        })),
+      } }),
+    });
+
+    await screen.findByRole("textbox", { name: "Tailored resume preview editor" });
+    expect(screen.getByText("loading draft")).toBeInTheDocument();
+    await chooseSelectOption("Font", "Garamond");
+    const shadow = await findResumeShadowRoot();
+    expect(shadowElementWithText(shadow, "Principal Platform Engineer").style.fontFamily).toContain("Garamond");
+    expect(screen.getByLabelText("Editable resume page")).toHaveAttribute("data-draft-dirty", "true");
+
+    finishCreating!();
+    await waitFor(() => expect(screen.queryByText("loading draft")).not.toBeInTheDocument());
+    expect(shadowElementWithText(await findResumeShadowRoot(), "Principal Platform Engineer").style.fontFamily).toContain("Garamond");
+    expect(screen.getByText("unsaved changes")).toBeInTheDocument();
+    expect(screen.getByLabelText("Editable resume page")).toHaveAttribute("data-draft-dirty", "true");
+    expect(screen.getByRole("button", { name: "Save draft" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Render replacement" })).toBeDisabled();
+  });
+
   it("keeps the cached resume review draft visible while create/load is pending", async () => {
     const jobKey = sampleApplyReviewQueue.items[0]!.jobKey;
     const draft = makeResumeReviewDraft(jobKey, {

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -2040,6 +2040,44 @@ describe("<ApplyReviewView>", () => {
     expect(JSON.stringify(saveResumeReviewDraftRevision.mock.calls[0]![1].plateDocument)).not.toContain("helvetica");
   });
 
+  it("preserves a return to the prior baseline while a saved snapshot is pending", async () => {
+    const draft = makeResumeReviewDraft();
+    let acknowledge: (() => void) | undefined;
+    const saveResumeReviewDraftRevision = vi.fn(async (_draftId, body) => {
+      await new Promise<void>((resolve) => { acknowledge = resolve; });
+      const saved = makeResumeReviewDraft(draft.jobKey, {
+        ...body, revisionId: "saved-2", revisionNumber: 2,
+      });
+      return { ok: true as const, draft: saved, revision: saved.latestRevision! };
+    });
+    renderWithProviders(<ApplyReviewView />, {
+      ports: buildTestPorts({ api: {
+        applyReviewQueue: vi.fn(async () => sampleApplyReviewQueue),
+        createResumeReviewDraft: vi.fn(async () => ({ ok: true as const, draft })),
+        saveResumeReviewDraftRevision,
+        seedResumeReviewCommentThreads: vi.fn(async () => ({
+          ok: true as const, draft, commentThreads: [], seededCount: 0, updatedCount: 0,
+        })),
+      } }),
+    });
+    const editor = await screen.findByRole("textbox", { name: "Tailored resume preview editor" });
+    await chooseSelectOption("Font", "Garamond");
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save draft" })).toBeEnabled());
+    await userEvent.click(screen.getByRole("button", { name: "Save draft" }));
+    await waitFor(() => expect(acknowledge).toBeDefined());
+    await chooseSelectOption("Font", "Resume");
+    await waitFor(() => expect(screen.getByLabelText("Editable resume page")).toHaveAttribute("data-draft-dirty", "false"));
+    await userEvent.click(editor);
+    acknowledge!();
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save draft" })).toBeEnabled());
+    expect(screen.getByRole("textbox", { name: "Tailored resume preview editor" })).toBe(editor);
+    expect(editor).toHaveFocus();
+    expect(screen.getByLabelText("Editable resume page")).toHaveAttribute("data-draft-dirty", "true");
+    expect(shadowElementWithText(await findResumeShadowRoot(), "Principal Platform Engineer").style.fontFamily).not.toContain("Garamond");
+    expect(JSON.stringify(saveResumeReviewDraftRevision.mock.calls[0]![1].plateDocument)).toContain("garamond");
+    expect(screen.getByRole("button", { name: "Render replacement" })).toBeDisabled();
+  });
+
   it("keeps unsaved edits scoped when selecting an identical cached draft", async () => {
     const first = sampleApplyReviewQueue.items[0]!;
     const other = sampleApplyReviewQueue.items[1]!;

--- a/apps/web/src/views/apply-review/ApplyReviewView.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.tsx
@@ -43,6 +43,7 @@ import { useResumeReviewDraftQuery } from "../../contexts/operations/hooks/useRe
 import { useResumeTemplatesQuery } from "../../contexts/profile/hooks/useResumeTemplatesQuery.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
 import { usePorts } from "../../shared/providers/PortsProvider.js";
+import { useTenantId } from "../../shared/providers/TenantProvider.js";
 import { Alert, AlertDescription, AlertTitle } from "../../shared/ui/alert.js";
 import { Button, buttonVariants } from "../../shared/ui/button.js";
 import {
@@ -1066,21 +1067,26 @@ function ResumeLineReview({
   readonly onSelectLine: (line: PdfAuditLineSelection | null) => void;
 }) {
   const { api } = usePorts();
+  const tenantId = useTenantId();
   const createDraft = useCreateResumeReviewDraftMutation();
   const saveDraftRevision = useSaveResumeReviewDraftRevisionMutation();
   const seedCommentThreads = useSeedResumeReviewCommentThreadsMutation();
   const replyToComment = useReplyToResumeReviewCommentMutation();
   const renderDraft = useRenderResumeReviewDraftMutation();
   const requestedDraftKey = useRef<string | null>(null);
-  const renderBaselineArtifactId = useRef<string | null>(null);
+  const renderBaseline = useRef<{ tenantId: typeof tenantId; jobKey: string; artifactId: string | null } | null>(null);
+  const renderBaselineArtifactId = renderBaseline.current?.tenantId === tenantId
+    && renderBaseline.current.jobKey === item.jobKey ? renderBaseline.current.artifactId : null;
   const pdfArtifactId = item.materialsPreview.resumePdfArtifactId;
   const auditArtifactId = item.materialsPreview.resumeTextArtifactId ?? pdfArtifactId;
   const lineTargets = useMemo(() => resumeLineTargets(item.materialsPreview.resumeText), [item.materialsPreview.resumeText]);
-  const draftSeedKey = pdfArtifactId && auditArtifactId ? `${item.jobKey}:${auditArtifactId}:${pdfArtifactId}` : null;
+  const draftSeedKey = pdfArtifactId && auditArtifactId ? `${tenantId}:${item.jobKey}:${auditArtifactId}:${pdfArtifactId}` : null;
   const draftQuery = useResumeReviewDraftQuery(item.jobKey, false);
   const draft = draftQuery.data?.draft.jobKey === item.jobKey ? draftQuery.data.draft : null;
-  const renderedDraftResult = renderDraft.data?.draft.jobKey === item.jobKey
-    && renderDraft.data.draft.draftId === draft?.draftId ? renderDraft.data : null;
+  const renderedDraftResult = renderDraft.context?.tenantId === tenantId
+    && renderDraft.data?.draft.jobKey === item.jobKey ? renderDraft.data : null;
+  const currentDraftRenderResult = renderedDraftResult?.draft.draftId === draft?.draftId
+    ? renderedDraftResult : null;
   const draftError = createDraft.error instanceof Error ? createDraft.error.message : null;
   const saveError = saveDraftRevision.error instanceof Error ? saveDraftRevision.error.message : null;
   const seedError = seedCommentThreads.error instanceof Error ? seedCommentThreads.error.message : null;
@@ -1090,8 +1096,9 @@ function ResumeLineReview({
   const renderDraftAsync = renderDraft.mutateAsync;
   const handleRenderDraft = useCallback(async () => {
     if (!draft?.currentRevisionId) return false;
-    renderBaselineArtifactId.current =
-      renderBaselineArtifactId.current ?? draftBaseArtifactId(draft) ?? auditArtifactId;
+    renderBaseline.current = { tenantId, jobKey: item.jobKey,
+      artifactId: comparisonDraftTarget(renderedDraftResult, draft, renderBaselineArtifactId, auditArtifactId, pdfArtifactId)?.acceptedArtifactId
+        ?? draftBaseArtifactId(draft) ?? auditArtifactId };
     const result = await renderDraftAsync({
       draftId: draft.draftId,
       jobId: item.jobKey,
@@ -1100,23 +1107,22 @@ function ResumeLineReview({
       },
     });
     return result.ok;
-  }, [auditArtifactId, draft?.currentRevisionId, draft?.draftId, item.jobKey, renderDraftAsync]);
+  }, [auditArtifactId, draft, item.jobKey, pdfArtifactId, renderBaselineArtifactId, renderDraftAsync, renderedDraftResult, tenantId]);
   const comparisonTarget = useMemo(
     () =>
       comparisonDraftTarget(
         renderedDraftResult,
         draft,
-        renderBaselineArtifactId.current ?? draftBaseArtifactId(draft) ?? auditArtifactId,
+        renderBaselineArtifactId ?? draftBaseArtifactId(draft) ?? auditArtifactId,
+        auditArtifactId,
+        pdfArtifactId,
       ),
-    [auditArtifactId, draft, renderedDraftResult],
+    [auditArtifactId, draft, pdfArtifactId, renderBaselineArtifactId, renderedDraftResult],
   );
 
   useEffect(() => {
     onComparisonTargetChange?.(comparisonTarget);
   }, [comparisonTarget, onComparisonTargetChange]);
-  useEffect(() => {
-    renderBaselineArtifactId.current = null;
-  }, [item.jobKey]);
 
   useEffect(() => {
     if (!draftSeedKey || !pdfArtifactId || !auditArtifactId) return;
@@ -1157,7 +1163,7 @@ function ResumeLineReview({
         profileSourceFields={item.materialsPreview.profileSourceFields}
         renderError={renderError}
         renderPending={renderDraft.isPending}
-        renderResult={renderedDraftResult}
+        renderResult={currentDraftRenderResult}
         resumeText={item.materialsPreview.resumeText}
         saveError={saveError ?? seedError}
         savePending={saveDraftRevision.isPending}
@@ -1212,14 +1218,23 @@ function comparisonDraftTarget(
   renderResult: ResumeReviewDraftRenderResponse | null,
   draft: ResumeReviewDraft | null,
   acceptedArtifactId: string | null,
+  currentTextArtifactId: string | null,
+  currentPdfArtifactId: string | null,
 ): ArtifactComparisonDraftTarget | null {
-  if (!renderResult?.ok) {
-    return null;
-  }
+  if (!renderResult?.ok) return null;
+  const source = renderResult.draft;
+  // Promotion creates the next editable draft. The completed render still
+  // owns its comparison until this job moves to unrelated artifact identities.
+  const isSource = currentTextArtifactId === draftBaseArtifactId(source)
+    && currentPdfArtifactId === source.baseResumePdfArtifactId;
+  const isRendered = currentTextArtifactId === renderResult.artifacts.resumeText.artifactId
+    && currentPdfArtifactId === renderResult.artifacts.resumePdf.artifactId;
+  if (!isSource && !isRendered) return null;
+  const renderedDraft = draft?.draftId === source.draftId ? draft : source;
   return {
-    acceptedArtifactId: acceptedArtifactId ?? draftBaseArtifactId(draft),
+    acceptedArtifactId: acceptedArtifactId ?? draftBaseArtifactId(source),
     artifactId: renderResult.artifacts.resumeText.artifactId,
-    riskLabels: uniqueRiskLabels(draft?.commentThreads ?? []),
+    riskLabels: uniqueRiskLabels(renderedDraft.commentThreads),
   };
 }
 

--- a/apps/web/src/views/apply-review/ApplyReviewView.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.tsx
@@ -1078,32 +1078,15 @@ function ResumeLineReview({
   const lineTargets = useMemo(() => resumeLineTargets(item.materialsPreview.resumeText), [item.materialsPreview.resumeText]);
   const draftSeedKey = pdfArtifactId && auditArtifactId ? `${item.jobKey}:${auditArtifactId}:${pdfArtifactId}` : null;
   const draftQuery = useResumeReviewDraftQuery(item.jobKey, false);
-  const queriedDraft =
-    draftQuery.data?.draft.jobKey === item.jobKey ? draftQuery.data.draft : null;
-  const createdDraft =
-    createDraft.data?.draft.jobKey === item.jobKey ? createDraft.data.draft : null;
-  const savedDraft =
-    saveDraftRevision.data?.draft.jobKey === item.jobKey ? saveDraftRevision.data.draft : null;
-  const seededDraft =
-    seedCommentThreads.data?.draft.jobKey === item.jobKey ? seedCommentThreads.data.draft : null;
-  const renderedDraftResult =
-    renderDraft.data?.draft.jobKey === item.jobKey ? renderDraft.data : null;
-  const renderedDraft =
-    renderedDraftResult?.draft ?? null;
-  const baseDraft = useMemo(
-    () => selectLatestResumeReviewDraft([renderedDraft, seededDraft, savedDraft, createdDraft, queriedDraft]),
-    [createdDraft, queriedDraft, renderedDraft, savedDraft, seededDraft],
-  );
-  const draft = useMemo(
-    () => mergeDraftThread(baseDraft, replyToComment.data?.thread ?? null),
-    [baseDraft, replyToComment.data?.thread],
-  );
+  const draft = draftQuery.data?.draft.jobKey === item.jobKey ? draftQuery.data.draft : null;
+  const renderedDraftResult = renderDraft.data?.draft.jobKey === item.jobKey
+    && renderDraft.data.draft.draftId === draft?.draftId ? renderDraft.data : null;
   const draftError = createDraft.error instanceof Error ? createDraft.error.message : null;
   const saveError = saveDraftRevision.error instanceof Error ? saveDraftRevision.error.message : null;
   const seedError = seedCommentThreads.error instanceof Error ? seedCommentThreads.error.message : null;
   const replyError = replyToComment.error instanceof Error ? replyToComment.error.message : null;
   const renderError = renderDraft.error instanceof Error ? renderDraft.error.message : null;
-  const draftLoading = createDraft.isPending && !baseDraft;
+  const draftLoading = createDraft.isPending && !draft;
   const renderDraftAsync = renderDraft.mutateAsync;
   const handleRenderDraft = useCallback(async () => {
     if (!draft?.currentRevisionId) return false;
@@ -1174,7 +1157,7 @@ function ResumeLineReview({
         profileSourceFields={item.materialsPreview.profileSourceFields}
         renderError={renderError}
         renderPending={renderDraft.isPending}
-        renderResult={renderDraft.data ?? null}
+        renderResult={renderedDraftResult}
         resumeText={item.materialsPreview.resumeText}
         saveError={saveError ?? seedError}
         savePending={saveDraftRevision.isPending}
@@ -1225,23 +1208,6 @@ function ResumeLineReview({
   );
 }
 
-function mergeDraftThread(
-  draft: ResumeReviewDraft | null,
-  thread: ResumeCommentThread | null,
-): ResumeReviewDraft | null {
-  if (!draft || !thread || thread.draftId !== draft.draftId) return draft;
-  const seen = new Set<string>();
-  const commentThreads = draft.commentThreads.map((existing) => {
-    if (existing.threadId !== thread.threadId) return existing;
-    seen.add(thread.threadId);
-    return thread;
-  });
-  if (!seen.has(thread.threadId)) {
-    commentThreads.unshift(thread);
-  }
-  return { ...draft, commentThreads };
-}
-
 function comparisonDraftTarget(
   renderResult: ResumeReviewDraftRenderResponse | null,
   draft: ResumeReviewDraft | null,
@@ -1271,20 +1237,6 @@ function uniqueRiskLabels(commentThreads: readonly ResumeCommentThread[]): strin
     result.push(label);
   }
   return result;
-}
-
-function selectLatestResumeReviewDraft(
-  drafts: ReadonlyArray<ResumeReviewDraft | null>,
-): ResumeReviewDraft | null {
-  return drafts
-    .filter((draft): draft is ResumeReviewDraft => Boolean(draft))
-    .sort((left, right) => resumeReviewDraftRank(right) - resumeReviewDraftRank(left))[0] ?? null;
-}
-
-function resumeReviewDraftRank(draft: ResumeReviewDraft): number {
-  const stateRank = draft.state === "promoted" ? 3 : draft.state === "rendered" ? 2 : 1;
-  const updatedAt = Date.parse(draft.updatedAt);
-  return draft.latestRevisionNumber * 1_000_000_000_000 + stateRank * 1_000_000_000 + (Number.isFinite(updatedAt) ? updatedAt : 0);
 }
 
 function ResumeReviewSurface({

--- a/apps/web/test/isolated-workspace.test.ts
+++ b/apps/web/test/isolated-workspace.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment node
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { createOwnedDocsScreenshotDirectory } =
+  require("../e2e/fixtures/docs-screenshot-workspace.cjs") as {
+    createOwnedDocsScreenshotDirectory(): Promise<string>;
+  };
+const { assertIsolatedE2eWorkspace, assertExpectedWorkspace } =
+  require("../e2e/fixtures/isolated-workspace.cjs") as {
+    assertIsolatedE2eWorkspace(env: Record<string, string>): Promise<string>;
+    assertExpectedWorkspace(
+      workspace: { appDir: string; dbPath: string },
+      env: Record<string, string>,
+    ): void;
+  };
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0))
+    fs.rmSync(root, { recursive: true, force: true });
+});
+
+async function fixture() {
+  const root = await createOwnedDocsScreenshotDirectory();
+  roots.push(root);
+  return {
+    root,
+    env: {
+      JOBCTRL_E2E_ISOLATED: "1",
+      JOBCTRL_DOCS_SCREENSHOTS: "1",
+      JOBCTRL_DIR: root,
+      JOBCTRL_E2E_APP_DIR: root,
+      JOBCTRL_DB_PATH: path.join(root, "jobctrl.db"),
+      JOBCTRL_E2E_DB_PATH: path.join(root, "jobctrl.db"),
+      JOBCTRL_CONFIG_PATH: path.join(root, "config.json"),
+      JOBCTRL_E2E_CONFIG_PATH: path.join(root, "config.json"),
+      JOBCTRL_E2E_STATE_FILE: path.join(root, "state.json"),
+      JOBCTRL_E2E_SERVICE_HOME: path.join(root, "service-home"),
+      TMPDIR: path.join(root, "tmp"),
+    },
+  };
+}
+
+describe("isolated browser fixture paths", () => {
+  it("admits an explicitly marked workspace before its files exist", async () => {
+    const { root, env } = await fixture();
+    expect(await assertIsolatedE2eWorkspace(env)).toBe(root);
+  });
+  it("fails closed on missing marker, escaped DB/config and mismatched environment", async () => {
+    const { root, env } = await fixture();
+    for (const name of [
+      "JOBCTRL_DB_PATH",
+      "JOBCTRL_CONFIG_PATH",
+      "JOBCTRL_E2E_STATE_FILE",
+      "TMPDIR",
+    ]) {
+      await expect(
+        assertIsolatedE2eWorkspace({
+          ...env,
+          [name]: path.join(os.tmpdir(), "foreign-fixture"),
+        }),
+      ).rejects.toThrow();
+    }
+    await expect(
+      assertIsolatedE2eWorkspace({
+        ...env,
+        JOBCTRL_E2E_DB_PATH: path.join(root, "other.db"),
+      }),
+    ).rejects.toThrow("mismatch");
+    fs.rmSync(path.join(root, ".jobctrl-docs-screenshots-owned.json"));
+    await expect(assertIsolatedE2eWorkspace(env)).rejects.toThrow();
+  });
+  it("rejects another marker-owned run in the seed report or teardown state", async () => {
+    const current = await fixture();
+    const sibling = await fixture();
+    const expected = {
+      appDir: current.root,
+      dbPath: current.env.JOBCTRL_DB_PATH,
+    };
+    expect(() => assertExpectedWorkspace(expected, current.env)).not.toThrow();
+    expect(() =>
+      assertExpectedWorkspace(
+        { appDir: sibling.root, dbPath: sibling.env.JOBCTRL_DB_PATH },
+        current.env,
+      ),
+    ).toThrow("different run");
+    expect(() =>
+      assertExpectedWorkspace(
+        { ...expected, dbPath: sibling.env.JOBCTRL_DB_PATH },
+        current.env,
+      ),
+    ).toThrow("different run");
+  });
+  it("rejects dangling symlinks at a destination and an intermediate directory", async () => {
+    const { root, env } = await fixture();
+    const missingTarget = path.join(root, "not-created");
+    fs.symlinkSync(missingTarget, env.JOBCTRL_DB_PATH);
+    await expect(assertIsolatedE2eWorkspace(env)).rejects.toThrow("symlink");
+    fs.unlinkSync(env.JOBCTRL_DB_PATH);
+    fs.symlinkSync(missingTarget, path.join(root, "dangling-directory"));
+    await expect(
+      assertIsolatedE2eWorkspace({
+        ...env,
+        TMPDIR: path.join(root, "dangling-directory", "tmp"),
+      }),
+    ).rejects.toThrow("symlink");
+  });
+  it("rejects symlinked destinations before any database open", async () => {
+    const { root, env } = await fixture();
+    fs.symlinkSync(os.tmpdir(), path.join(root, "escape"));
+    await expect(
+      assertIsolatedE2eWorkspace({
+        ...env,
+        TMPDIR: path.join(root, "escape", "nested"),
+      }),
+    ).rejects.toThrow("symlink");
+  });
+});

--- a/apps/web/test/playwright-config.test.ts
+++ b/apps/web/test/playwright-config.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 const managedEnvironmentKeys = [
   "CI",
   "JOBCTRL_DOCS_SCREENSHOTS",
+  "JOBCTRL_E2E_ISOLATED",
   "JOBCTRL_E2E_APP_DIR",
   "JOBCTRL_E2E_DB_PATH",
   "JOBCTRL_E2E_CONFIG_PATH",
@@ -108,6 +109,13 @@ describe("Playwright server isolation", () => {
 
     expect(firstState).not.toBe(secondState);
     expect(first.outputDir).not.toBe(second.outputDir);
+  });
+
+  test("isolated product QA uses the guarded test server and never reuses servers", async () => {
+    const config = await loadPlaywrightConfig({ JOBCTRL_E2E_ISOLATED: "1", JOBCTRL_DOCS_SCREENSHOTS: "1" });
+    if (!Array.isArray(config.webServer)) throw new Error("Missing E2E servers");
+    expect(config.webServer[0]?.command).toContain("test/e2e-server.ts");
+    expect(config.webServer.map((server) => server.reuseExistingServer)).toEqual([false, false]);
   });
 
   test("ordinary local E2E may still reuse explicitly selected ports", async () => {

--- a/docs/architecture/frontend/state-and-ports.md
+++ b/docs/architecture/frontend/state-and-ports.md
@@ -41,6 +41,8 @@ is the canonical decision matrix.
 | Daily digest and digest acknowledge state | **Server** (Query + mutation) | `GET /v1/digest` is a passive local read. Only explicit acknowledge advances `digest_state`; digest deep links carry filters/sort in the URL. |
 | Jobs list response | **Server** (Query) | Same. |
 | Job detail | **Server** (Query) | Same. |
+| Saved resume review draft | **Server** (Query) | The apply-context reconciler publishes create/save/seed/render/reply responses to the initiating tenant/job key. Draft identity and base generation precede revision/state/time ordering; threads, replies and feedback signals merge independently by their IDs. |
+| Unsaved resume review edits | **Mounted Plate session** | Acknowledging saved snapshot A updates the baseline while later text or formatting B stays dirty. Comment-only updates do not reset focus or selection. |
 | Artifacts list / detail | **Server** (Query) | Same. |
 | Apply run live timeline | **Server** (Query) — appended via `setQueryData` from SSE | High-frequency; see §7.5. |
 | Resume import wizard step state (uploaded file metadata, parsed draft) | **Client** (Zustand+persist) | Cross-step, refresh-safe, but not URL-bound (the URL identifies *which step*, not *the data*). |

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -116,6 +116,25 @@ order preserve the saved sequence. Apply **Sort newest first** and verify it
 restores current/latest roles first. A role with a summary but no bullets must
 not render an empty list or the full bullet-bearing entry gap.
 
+For saved review-draft reconciliation, run the artifact-comparison browser
+fixture with controlled response ordering: save A, type B, receive A; then
+render a saved revision before releasing an older comment-seed snapshot.
+Verify B remains editable/dirty, focus remains in Plate, rendering stays gated
+until the later edit is saved, and the rendered revision/comparison do not
+regress. Focused mutation fixtures also cover draft replacement with restarted
+revision numbering, independent replies/feedback, and tenant/job switches.
+
+The isolated browser mode (`JOBCTRL_E2E_ISOLATED=1`) uses the test-only API
+entry point with synthetic capability/credential responses and denied provider
+subprocesses. It requires `JOBCTRL_DOCS_SCREENSHOTS=1`, the existing owned
+screenshot-directory marker, and matching contained app/database/config/state/
+temporary paths before setup, API construction and teardown. Use the existing
+`createOwnedDocsScreenshotDirectory` and `createDocsScreenshotEnvironment`
+helpers with fresh ports; isolate telemetry and dotenv loading in the child
+environment. This mode never reuses a listening server. It retains real seeded
+API/SQLite reads and writes; browser responses can control only the feature
+requests needed by an individual race fixture.
+
 ## Pick The Right Checklist
 
 | You changed… | Use |

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -130,8 +130,19 @@ subprocesses. It requires `JOBCTRL_DOCS_SCREENSHOTS=1`, the existing owned
 screenshot-directory marker, and matching contained app/database/config/state/
 temporary paths before setup, API construction and teardown. Use the existing
 `createOwnedDocsScreenshotDirectory` and `createDocsScreenshotEnvironment`
-helpers with fresh ports; isolate telemetry and dotenv loading in the child
-environment. This mode never reuses a listening server. It retains real seeded
+helpers with fresh ports. Extend the returned child environment with
+`JOBCTRL_E2E_ISOLATED=1`, `JOBCTRL_DIR=JOBCTRL_E2E_APP_DIR`,
+`JOBCTRL_DB_PATH=JOBCTRL_E2E_DB_PATH`, and
+`JOBCTRL_CONFIG_PATH=JOBCTRL_E2E_CONFIG_PATH` (assign the corresponding values,
+not the variable names). Set `TMPDIR` to a child of the owned app directory,
+such as `<appDir>/tmp`; do not retain the helper's forwarded host `TMPDIR`.
+The Playwright configuration supplies
+`JOBCTRL_E2E_STATE_FILE=<appDir>/.jobctrl-e2e-state.json`; set that value yourself
+if invoking the ownership guard directly. Keep the helper's contained
+`JOBCTRL_E2E_SERVICE_HOME`. On macOS, create the owned directory beneath a short
+temporary parent such as a fresh directory under `/private/tmp` so the contained
+tsx IPC socket path fits the operating system's path limit. Isolate telemetry
+and dotenv loading in the child environment. This mode never reuses a listening server. It retains real seeded
 API/SQLite reads and writes; browser responses can control only the feature
 requests needed by an individual race fixture.
 

--- a/docs/plans/2026-09-06-simplification-stack.md
+++ b/docs/plans/2026-09-06-simplification-stack.md
@@ -1,0 +1,365 @@
+# Preserve behavior while removing duplicated state and execution
+
+Status: accepted for implementation on 6 September 2026. Four PRs are planned;
+none is implemented by this plan alone. The owner authorized implementation,
+review, synthetic QA, commits, pushes, and creation of the ordered PR stack.
+The new stack is to remain open for review; merging it is a separate action.
+
+## Starting point and delivery order
+
+Cleanup PRs [#862](https://github.com/ebarti/JobCtrl/pull/862) and
+[#863](https://github.com/ebarti/JobCtrl/pull/863) are merged. The starting
+`main` commit is `782d3d5ff3c4eac17c8ff1c9be91f89a420bdc07`; the canonical
+checkout was fast-forwarded to that commit and verified clean. Implementation
+uses the existing dedicated task worktree, never the main checkout. Preserve
+all unrelated local changes and exclude them from commits.
+
+| Phase | Branch | PR base | Change |
+| --- | --- | --- | --- |
+| 1 | `refactor/review-draft-authority` | `main` | One owner for saved review-draft reconciliation |
+| 2 | `refactor/structured-profile-draft` | Phase 1 | Object-valued profile and style editing |
+| 3 | `refactor/canonical-batch-tailor` | Phase 2 | Batch selection delegates to the existing per-job lifecycle |
+| 4 | `refactor/evaluated-tailor-candidates` | Phase 3 | Carry candidate evaluation evidence through selection |
+
+This order makes each change independently reviewable within the requested
+linear stack. It does not introduce dependencies between frontend contexts or
+between frontend and worker implementations. Phase 4 builds on Phase 3's
+single lifecycle for acceptance and persistence.
+
+Use `gh stack` non-interactively. Create each child only after its parent's
+focused validation and independent gates pass. Verify its base against the
+published parent head. Each PR must contain only that phase's code, necessary
+regressions, owning documentation, and plan progress. Do not create an extra
+PR solely for this plan. Use Conventional Commit titles and commit messages.
+
+## Objective and protected behavior
+
+Remove duplicated ownership and repeated transformations while preserving
+the product's saved facts and accepted artifacts. Success is measured by
+deleted mechanisms plus regression evidence, not by file splitting or a line
+count alone.
+
+The relevant facts have distinct owners:
+
+| Fact | Owner and invariant |
+| --- | --- |
+| Saved profile | Profile aggregate; unedited and unknown fields survive an edit/save round trip |
+| Saved review draft | Server draft identity and revision; the apply context publishes its reconciled query-cache representation |
+| Unsaved editor value | Mounted editor/form session; a late acknowledgement cannot replace later local edits |
+| Accepted material | Materials generation and artifact lineage; a failed replacement leaves the accepted generation reviewable |
+| Candidate evidence | One concrete candidate value for one exact payload/text; evidence must change whenever its text changes |
+| Execution ownership | Existing workflow/attempt and transaction fences; stale or canceled owners cannot publish |
+
+Read [frontend state ownership](../architecture/frontend/state-and-ports.md),
+the [tailoring contract](../architecture/tailoring.md),
+[pipeline operations](../architecture/pipeline/operations.md), and the
+[QA matrix](../local-reliability-qa.md) at their respective phase boundaries.
+Follow root and web `AGENTS.md` instructions.
+
+Excluded work: a generic gate/workflow framework, global candidate caching,
+new services, schema migrations, wire-contract changes, automatic retry-policy
+redesign, single-leg analysis promotion, a broad shared Plate lifecycle
+extraction, unrelated persistence/SSE cleanup, and dependency upgrades.
+
+## Phase 1: one saved-draft reconciliation owner
+
+### Evidence and replacement
+
+`ApplyReviewView` combines a cached draft with retained create/save/seed/render
+mutation responses and merges replies separately. Those mutations already
+write draft responses to the query cache, creating two reconciliation paths.
+
+Move response publication into one pure apply-context reconciler used by all
+draft mutations. The view reads the job-scoped cache and retains only local
+pending/error/unsaved state and necessary render/comparison metadata. Delete
+the view's multi-snapshot selector and thread merger.
+
+Ordering must be explicit. Revision numbers are local to a draft: establish
+`draftId` and `baseGeneration` identity before comparing revision, state and
+time. Preserve the existing intended same-draft rendered-state precedence.
+An older request must not restore a replaced draft; a new generation's first
+revision must not be rejected behind a previous generation's higher revision.
+Use the available request/generation identity to resolve this boundary rather
+than inventing chronological ordering for opaque IDs.
+
+Threads, replies and feedback signals evolve independently of the document
+revision. Reconcile by their existing IDs and update/state information so a
+late full snapshot cannot erase a newer reply or signal. Preserve unchanged
+references where appropriate, without relying on structural sharing to guard
+unsaved edits.
+
+The review Plate editor currently resets from incoming saved-value identity.
+Add the smallest acknowledged-save/document-identity guard required to keep
+typed value B when the save response for A arrives. Preserve formatting as
+well as text. Do not use this as a reason to extract the entire shared editor.
+
+### Ownership
+
+- `apps/web/src/contexts/apply/hooks/useApplyReviewMutations.ts` and its tests;
+  a colocated pure draft reconciler and focused tests.
+- `apps/web/src/views/apply-review/ApplyReviewView.tsx` and its existing tests.
+- Only the relevant review-session reset/acknowledgement path in
+  `apps/web/src/contexts/materials/components/ResumeAuditPins.tsx`.
+- Existing artifact-comparison browser fixtures and frontend state/QA docs.
+- Test-only isolated API entry point and guarded E2E mode, reusing the existing
+  marked screenshot workspace/environment helpers. Ordinary E2E action stubs
+  do not intercept API startup capability dispatch, so the isolated process
+  injects synthetic provider/credential ports and denies other subprocesses
+  before running the required browser proof.
+
+### Acceptance evidence
+
+1. Controlled reversed completion of create/save/seed/render never regresses
+   the selected saved revision or resurrects an obsolete draft.
+2. New-generation revision 1 can replace an older-generation revision 9;
+   delayed responses for the old generation cannot reverse it.
+3. Reply then stale full snapshot preserves replies, thread state and feedback
+   signals; independent replies do not depend on document revision ordering.
+4. Requests completing after a job/tenant switch update only their original
+   cache key and do not change the new selection/comparison baseline.
+5. Save A, type B, receive A: B and its dirty/save state survive. Unrelated
+   thread updates preserve unsaved formatting, focus and editor selection.
+6. Render-on-approval uses the selected saved revision. Accepted-artifact
+   comparison, unmatched comments, reload restoration and failure states work.
+
+Required browser path: extend and run
+`apps/web/e2e/tests/artifact-comparison.spec.ts` with synthetic responses that
+prove the relevant ordering/edit preservation, not only static rendering.
+
+## Phase 2: keep editable profile values structured
+
+### Evidence and replacement
+
+The profile form currently stringifies API objects, parses them in the
+structured editor, stringifies every edit, and parses again for validation and
+Plate projection. A raw JSON editor is no longer a product requirement.
+
+Keep editable `profile` and `style` as immutable object values in TanStack
+Form. Keep actual template text as text. Serialize only when constructing the
+existing string-valued update request. Use `safeParse` for validation while
+preserving the edited original object; do not replace it with parsed/coerced
+schema output that strips unknown data or erases incomplete typing states.
+
+Adapt the existing semantic Plate projector to object input/output. Preserve
+its source identity, conflict detection, target tracking and selective undo;
+do not substitute whole-profile replacement or array-index matching.
+
+### Ownership
+
+- `apps/web/src/contexts/profile/forms/profile-form.tsx` and its tests.
+- `apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx`,
+  focused tests, accessibility test and story.
+- Relevant `ProfileEditor` integration tests; touch its production code only
+  if required by the representation change.
+- Existing `apps/web/e2e/tests/profile-edit.spec.ts` and owning frontend/QA docs.
+
+### Acceptance evidence
+
+1. Saving preserves unknown nested fields, unedited fields and the current
+   request schema/field names. Profile and style serialize at the boundary.
+2. Incomplete numeric/date input remains editable; invalid chronological dates
+   prevent save with the existing useful validation feedback.
+3. An unrelated boxed edit plus a Plate edit both survive. Conflicting edits
+   to the same field are surfaced and do not overwrite the boxed value.
+4. Deletion, splitting, reordering and undo retain source-bound targeting;
+   punctuation/digits and formatting-only changes preserve current semantics.
+5. A stale autosave response or refreshed initial prop cannot erase newer
+   local edits. Save/reload retains exact synthetic values and ordering.
+6. `/profile` and `/preferences` retain applicable controls, accessibility,
+   dirty state and user-visible validation; no profile persistence behavior
+   or discovery-setting behavior changes.
+
+## Phase 3: delegate batch Tailor to the canonical lifecycle
+
+### Evidence and replacement
+
+Selected-job preparation already uses `tailor_job_by_id`, including its
+ownership/cancellation fences, attempts, prerequisites and commit recovery.
+Unscoped `run_tailoring` duplicates execution maps and stage writes and does
+not receive the enclosing cooperative cancellation event through generation.
+
+Retain the current bounded cohort selector, one captured profile/policy
+snapshot and a bounded executor. Delegate each selected JobId to
+`tailor_job_by_id` with existing model/judge/tenant/threshold/retailor options,
+workflow identity and cancellation token. Delete the duplicate lifecycle's
+start/attempt/terminal-write loop and maps. If sharing the existing selected
+executor requires extraction, use one concrete application helper callable
+from both routes; avoid a dependency from the runner back into activities.
+
+Keep aggregation adapters explicit: the unscoped activity escalates aggregate
+errors/failures/exhaustion for its existing retry contract; selected work can
+return partial success and approved IDs. Preserve no-work keys, elapsed/count
+fields, completed-owner filtering and callable signatures. Do not begin
+sharing injected repositories across worker threads. Map `already_done`,
+prerequisite skips and exhausted `inner_status` deliberately.
+
+Stage-start events should reflect actual item dispatch rather than claiming
+all selected jobs are running before workers start. Preserve any required
+durable queued cohort and document this cancellation-correctness change.
+
+### Ownership
+
+- `workers/automation/src/jobctrl/scoring/tailor.py`.
+- `workers/automation/src/jobctrl/pipeline/runner.py`.
+- `workers/automation/src/jobctrl/materials/activities.py` and a narrowly
+  extracted application executor only if needed.
+- Existing Tailor, material activity/recovery, workflow and UoW test families;
+  pipeline operations and QA documentation.
+
+### Acceptance evidence
+
+1. Exercise `tailor_activity` without `job_ids`, not only the per-job helper.
+   Compare its resulting canonical state with the selected entry path.
+2. With more jobs than workers, cancellation during a fake generation stops
+   later dispatch; canceled/stale owners cannot write material or terminal
+   success/failure. A successor owner's work remains intact.
+3. Commit-before-cancel stays succeeded. Crash-after-commit retry reuses the
+   accepted generation without another model call.
+4. Prerequisite blocks do not increment attempts; the fifth durable failure
+   remains exhausted; explicit reset and downstream blocking keep their rules.
+5. Preserve tenant isolation, limits, saved thresholds, model/judge choices,
+   retailor selection, mixed results and approved-only downstream Cover scope.
+6. Preserve the last accepted artifact on cancellation, rejection, exception
+   and rollback. Empty frozen cohorts do not invoke an unscoped fallback.
+
+Before executing `scripts/reliability-demo.sh`, remove inherited database,
+configuration and provider overrides, prohibit dotenv/Keychain/provider lookup,
+inject a synthetic API dispatcher, assert owned paths before worker bootstrap,
+and pass non-null expected application/database paths to the workflow. Retain
+captured-PID shutdown. The existing harness must not run unchanged for this
+stack; cover its required isolation with negative fixtures first.
+
+Use the existing synthetic material/activity fixtures and relevant
+preparation cancellation/recovery matrix. Audit the repository's four-process
+reliability harness before using it; if required by the touched operational
+path, run both documented restart orders using only its captured temporary
+workspace and PIDs. Never substitute an existing user runtime for this proof.
+
+## Phase 4: carry evidence with each evaluated candidate
+
+### Evidence and replacement
+
+The generation loop computes validation, provenance and fit, then selection
+and voice/audit reconstruct evidence for unchanged text. Fabrication checks
+also occur after paid review even when deterministic rejection is possible.
+
+Extend the existing concrete `_TailorCandidate` in Materials to retain the
+exact payload/text, validation, provenance, fabrication findings, grounding/
+coverage, fit, verdict and audit information that belong to that candidate.
+Build execution-invariant profile evidence/plan once. Selection returns the
+evaluated value; unchanged selected text carries its evidence forward.
+
+```text
+payload -> deterministic evaluation -> eligible candidate -> paid review
+                                      -> selected candidate + its evidence
+                                         -> unchanged: reuse
+                                         -> changed voice: evaluate anew
+                                            -> rejection: retain accepted base
+```
+
+Move deterministic fabrication blockers before judge/adversarial calls while
+preserving distinct validation, fit, semantic, rendering and fabrication
+responsibilities. A voice rewrite is a new candidate and must pass its full
+required evaluation. Do not reuse evidence for different text, weaken gates,
+alter ranking/retry policy, or hide audit warnings to achieve fewer calls.
+
+### Ownership
+
+- `workers/automation/src/jobctrl/domain/materials/use_cases.py`, extending
+  the existing value rather than adding a generic evaluation framework.
+- `test_materials_use_cases.py`, `test_tailor_voice_audit_integration.py`,
+  and relevant materials acceptance/provenance/UoW fixtures.
+- Tailoring contract and QA documentation, including changed gate ordering.
+
+### Acceptance evidence
+
+1. Counting fakes establish one evaluation of unchanged base text/provenance,
+   with no repeated evaluation at selection or no-op voice/audit boundaries.
+2. A deterministically fabricated candidate makes zero paid judge/adversarial
+   calls; typed repair guidance and bounded repair behavior remain coherent.
+3. Changed voice text receives complete evaluation; rejection retains the
+   accepted base text/evidence and labels the rejected attempt accurately.
+4. Persisted provenance, fit/coverage and artifact bytes refer to the selected
+   candidate; warning lifecycle and judge/audit details remain inspectable.
+5. Candidate ranking, lenient/strict behavior, all-candidates-fail outcomes,
+   prerequisite handling and safe retry guidance retain existing contracts.
+6. Acceptance or rendering failure preserves the previous accepted generation
+   and provenance atomically.
+
+## Validation, isolation and delivery gates
+
+All four phases are **Tier 3** because their changed executable paths touch
+saved user edits, artifact approval/preservation or execution ownership. Each
+phase requires focused tests plus an independent reviewer and QA `Gate: PASS`.
+Use the same reviewer and QA agents throughout, and rerun failed gates after
+fixes. Do not start the next phase with unresolved Blocker/High findings.
+
+All executable validation must use synthetic/disposable data. Establish
+`JOBCTRL_DIR` and relevant database/config/telemetry environment variables in
+the child process environment **before any application import or bootstrap**.
+Before opening a database or starting a product path, assert the resolved
+paths are inside the owned disposable root. Fail closed if that check fails.
+Use the repository's existing isolation fixtures and fake providers. Do not
+read, copy or mutate a real user database, profile, settings, generated
+material, browser profile, credentials or live Temporal/API state. Do not
+start application submission, real discovery or paid model operations.
+
+For process/browser QA, inspect fixture configuration first, use dedicated
+ports and only terminate process trees captured by that fixture. Do not reuse
+an existing server or default supervisor tracking directory. Preserve existing
+dependency locks; use the provisioned Python environment with `--no-sync`
+when necessary, and record that choice. No tests may rewrite unrelated work.
+
+For phases 1 and 2, the command set is:
+
+- `corepack pnpm web:check` and `corepack pnpm --filter @jobctrl/web test`
+  (focused file selection during implementation; complete web suite for the
+  final frontend phase).
+- `corepack pnpm --filter @jobctrl/web test-d` and `corepack pnpm web:build`.
+- `corepack pnpm --filter @jobctrl/web e2e -- tests/artifact-comparison.spec.ts`
+  and, for phase 2, `tests/profile-edit.spec.ts`, extending these fixtures to
+  prove the changed race/preservation behavior.
+- Build Storybook and run the relevant browser/a11y coverage for touched
+  mounted editors/stories. Existing critical/serious violations cannot be
+  silently carried into the changed flow.
+
+For phases 3 and 4, run Ruff over the touched Python source/tests and focused
+pytest families listed above with the isolated environment already set. The
+final Python phase runs the full Python suite. Include the existing workflow,
+activity cancellation/recovery and materials transaction matrix that proves
+the changed boundary, plus the exact unscoped activity and candidate-counting
+product fixtures. Tests that only call a replacement helper do not prove the
+removed entry path.
+
+Every phase runs `git diff --check`. Owning docs for active high-risk behavior
+change in that phase; do not defer cancellation or gate-order truth. Run
+`corepack pnpm docs:build` for changed site content/links. On the final branch,
+run the cumulative web and Python gates and the required synthetic product
+scenarios; reuse already passing unaffected results rather than inventing
+unrelated checks. Confirm all applicable GitHub checks pass on published heads.
+
+The coordinator owns plan maintenance and gate dispatch. One implementation
+agent, `gpt-6-astra` at `high` reasoning, owns the four sequential changes,
+focused validation, commits and PR publication. It must not spawn replacement
+reviewers or broaden the scope. A newly discovered prerequisite is included
+only when necessary for these acceptance criteria; otherwise record it outside
+this stack without implementing it.
+
+## Completion record
+
+Update this table with actual results; do not mark proposals implemented.
+
+| Phase | PR and head | Deleted mechanism | Tests and product proof | Review / QA |
+| --- | --- | --- | --- | --- |
+| 1 | Publication pending | View-owned five-snapshot draft selector and reply merger removed; cache mutation publication reconciles saved state | Focused web regression, type/build, Storybook build and docs checks pass; isolated browser race/a11y fixture ready | Independent review and product QA pending |
+| 2 | Pending | Pending | Pending | Pending |
+| 3 | Pending | Pending | Pending | Pending |
+| 4 | Pending | Pending | Pending | Pending |
+
+Delivery means four published PRs with the exact base chain above, necessary
+docs, passing independent gates and applicable CI, no unresolved Blocker/High
+findings, a clean canonical main checkout, and all pre-existing unrelated work
+preserved. Report any remaining Medium/Low observation with its concrete
+impact. If required validation cannot run, leave that phase explicitly
+unverified rather than calling the stack complete. Keep this plan active while
+the delivered PRs remain unmerged; archive it after the implementation lands.

--- a/docs/plans/2026-09-06-simplification-stack.md
+++ b/docs/plans/2026-09-06-simplification-stack.md
@@ -351,7 +351,7 @@ Update this table with actual results; do not mark proposals implemented.
 
 | Phase | PR and head | Deleted mechanism | Tests and product proof | Review / QA |
 | --- | --- | --- | --- | --- |
-| 1 | Publication pending | View-owned five-snapshot draft selector and reply merger removed; cache mutation publication reconciles saved state | Focused web regression, type/build, Storybook build and docs checks pass; isolated browser race/a11y fixture ready | Independent review and product QA pending |
+| 1 | [#865](https://github.com/ebarti/JobCtrl/pull/865); implementation `6d6f28a18` | View-owned five-snapshot draft selector and reply merger removed; cache mutation publication reconciles saved state | 79 focused web tests, 13 type tests, web/API checks, web/Storybook/docs builds pass; isolated browser race/a11y fixture ready | Independent review and product QA pending |
 | 2 | Pending | Pending | Pending | Pending |
 | 3 | Pending | Pending | Pending | Pending |
 | 4 | Pending | Pending | Pending | Pending |

--- a/docs/plans/2026-09-06-simplification-stack.md
+++ b/docs/plans/2026-09-06-simplification-stack.md
@@ -121,6 +121,10 @@ well as text. Do not use this as a reason to extract the entire shared editor.
    thread updates preserve unsaved formatting, focus and editor selection.
 6. Render-on-approval uses the selected saved revision. Accepted-artifact
    comparison, unmatched comments, reload restoration and failure states work.
+   When promotion advances queue artifacts and creates a new revision-0 active
+   draft, completed-render evidence retains its original accepted baseline and
+   risk labels while the editor shows the new draft state. Unrelated artifact
+   identities clear the comparison; late seed QA waits for a published thread.
 
 Required browser path: extend and run
 `apps/web/e2e/tests/artifact-comparison.spec.ts` with synthetic responses that
@@ -351,7 +355,7 @@ Update this table with actual results; do not mark proposals implemented.
 
 | Phase | PR and head | Deleted mechanism | Tests and product proof | Review / QA |
 | --- | --- | --- | --- | --- |
-| 1 | [#865](https://github.com/ebarti/JobCtrl/pull/865); implementation `6d6f28a18` | View-owned five-snapshot draft selector and reply merger removed; cache mutation publication reconciles saved state | 79 focused web tests, 13 type tests, web/API checks, web/Storybook/docs builds pass; isolated browser race/a11y fixture ready | Independent review and product QA pending |
+| 1 | [#865](https://github.com/ebarti/JobCtrl/pull/865); implementation `6d6f28a18` | View-owned five-snapshot draft selector and reply merger removed; cache mutation publication reconciles saved state | 79 focused web tests, 13 type tests, web/API checks, web/Storybook/docs builds pass; isolated browser race/a11y fixture ready | Review found a promotion regression, reproduced and corrected with 71 affected tests and web typecheck passing; revised promotion/late-seed browser fixtures await the same review and QA gates |
 | 2 | Pending | Pending | Pending | Pending |
 | 3 | Pending | Pending | Pending | Pending |
 | 4 | Pending | Pending | Pending | Pending |

--- a/docs/plans/2026-09-06-simplification-stack.md
+++ b/docs/plans/2026-09-06-simplification-stack.md
@@ -355,7 +355,7 @@ Update this table with actual results; do not mark proposals implemented.
 
 | Phase | PR and head | Deleted mechanism | Tests and product proof | Review / QA |
 | --- | --- | --- | --- | --- |
-| 1 | [#865](https://github.com/ebarti/JobCtrl/pull/865); reviewed implementation `2428ce2dd` | View-owned five-snapshot draft selector and reply merger removed; cache mutation publication reconciles saved state | Original focused web/type checks and web/API/Storybook/docs builds passed; promotion fix passed 71 affected tests and all four isolated Chromium scenarios with scoped axe clean | The promotion High passed independent review and QA at `2428ce2dd`; the later pending-create Medium is addressed by the follow-up below, whose independent gates remain pending |
+| 1 | [#865](https://github.com/ebarti/JobCtrl/pull/865); reviewed implementation `2428ce2dd` | View-owned five-snapshot draft selector and reply merger removed; cache mutation publication reconciles saved state | Original focused web/type checks and web/API/Storybook/docs builds passed; promotion fix passed 71 affected tests and all four isolated Chromium scenarios with scoped axe clean | The promotion High passed independent review and QA at `2428ce2dd`; the pending-create and cached-job isolation corrections passed independent review at `55fa84f0`; cumulative synchronized-head QA remains pending |
 | 2 | Pending | Pending | Pending | Pending |
 | 3 | Pending | Pending | Pending | Pending |
 | 4 | Pending | Pending | Pending | Pending |
@@ -366,8 +366,9 @@ regression reproduces the reset on the reviewed implementation; the corrected
 view, mutation, and reconciler suites pass 73 tests. Web typecheck/build and all
 six isolated Chromium artifact-comparison scenarios pass, including actual
 typing while draft creation is pending and switching cached jobs with identical
-saved documents without carrying over local edits. Independent review and cumulative QA
-must cover this follow-up before the stack is complete.
+saved documents without carrying over local edits. Independent review passed at
+`55fa84f0`, including the unchanged cached-job counterexample and 73 focused
+tests. Cumulative synchronized-head QA remains required before completion.
 
 Delivery means four published PRs with the exact base chain above, necessary
 docs, passing independent gates and applicable CI, no unresolved Blocker/High

--- a/docs/plans/2026-09-06-simplification-stack.md
+++ b/docs/plans/2026-09-06-simplification-stack.md
@@ -355,10 +355,18 @@ Update this table with actual results; do not mark proposals implemented.
 
 | Phase | PR and head | Deleted mechanism | Tests and product proof | Review / QA |
 | --- | --- | --- | --- | --- |
-| 1 | [#865](https://github.com/ebarti/JobCtrl/pull/865); implementation `6d6f28a18` | View-owned five-snapshot draft selector and reply merger removed; cache mutation publication reconciles saved state | 79 focused web tests, 13 type tests, web/API checks, web/Storybook/docs builds pass; isolated browser race/a11y fixture ready | Review found a promotion regression, reproduced and corrected with 71 affected tests and web typecheck passing; revised promotion/late-seed browser fixtures await the same review and QA gates |
+| 1 | [#865](https://github.com/ebarti/JobCtrl/pull/865); reviewed implementation `2428ce2dd` | View-owned five-snapshot draft selector and reply merger removed; cache mutation publication reconciles saved state | Original focused web/type checks and web/API/Storybook/docs builds passed; promotion fix passed 71 affected tests and all four isolated Chromium scenarios with scoped axe clean | The promotion High passed independent review and QA at `2428ce2dd`; the later pending-create Medium is addressed by the follow-up below, whose independent gates remain pending |
 | 2 | Pending | Pending | Pending | Pending |
 | 3 | Pending | Pending | Pending | Pending |
 | 4 | Pending | Pending | Pending | Pending |
+
+The Phase 1 review follow-up preserves unsaved edits when a revision-zero draft
+acquires its identity without changing the saved document. Its formatting
+regression reproduces the reset on the reviewed implementation; the corrected
+view, mutation, and reconciler suites pass 72 tests. Web typecheck/build and all
+five isolated Chromium artifact-comparison scenarios pass, including actual
+typing while draft creation is pending. Independent review and cumulative QA
+must cover this follow-up before the stack is complete.
 
 Delivery means four published PRs with the exact base chain above, necessary
 docs, passing independent gates and applicable CI, no unresolved Blocker/High

--- a/docs/plans/2026-09-06-simplification-stack.md
+++ b/docs/plans/2026-09-06-simplification-stack.md
@@ -363,9 +363,10 @@ Update this table with actual results; do not mark proposals implemented.
 The Phase 1 review follow-up preserves unsaved edits when a revision-zero draft
 acquires its identity without changing the saved document. Its formatting
 regression reproduces the reset on the reviewed implementation; the corrected
-view, mutation, and reconciler suites pass 72 tests. Web typecheck/build and all
-five isolated Chromium artifact-comparison scenarios pass, including actual
-typing while draft creation is pending. Independent review and cumulative QA
+view, mutation, and reconciler suites pass 73 tests. Web typecheck/build and all
+six isolated Chromium artifact-comparison scenarios pass, including actual
+typing while draft creation is pending and switching cached jobs with identical
+saved documents without carrying over local edits. Independent review and cumulative QA
 must cover this follow-up before the stack is complete.
 
 Delivery means four published PRs with the exact base chain above, necessary

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -8,8 +8,8 @@ at the top of `docs/`.
   that has landed, been superseded by canonical docs, or been closed with a
   recorded outcome.
 
-As of 2026-07-29, one accepted public implementation plan is active at the top
-level. Bundled distribution and the public live demo are delivered and archived
+Accepted public implementation plans are listed below. Bundled distribution
+and the public live demo are delivered and archived
 under `implemented/`; their separately deferred operational and privacy
 follow-ups live in `docs/publish-checklist.md` and `docs/backlog.md`. Add new
 accepted-but-not-yet-delivered public product plans at the top level.
@@ -31,6 +31,8 @@ docs to describe the delivered behavior. Delivery history lives in the git log
 
 ## Active Plans
 
+- [Preserve Behavior While Removing Duplicated State And Execution](2026-09-06-simplification-stack.md)
+  — accepted; four stacked PRs for review drafts, profile editing and Tailor.
 - [Stable Job Identity, Workflow Parity, And Feedback Learning](2026-07-29-stable-job-identity-workflow-feedback-learning.md)
   — accepted; implementation in progress as small stacked PRs.
 


### PR DESCRIPTION
Delayed create, seed, save, render, and comment replies previously competed between the query cache and a second selector in Application review. Saved responses now reconcile once in the apply context, while a late save acknowledgement preserves text or formatting entered after its submitted snapshot.

- Order document state by draft/base-generation identity, revision, explicit rendered-state precedence and server timestamps; merge thread/reply and job feedback identities independently.
- Preserve the initiating tenant/job cache key, accepted-artifact comparison metadata, and the editor’s live focus/dirty state. Remove the view’s five-snapshot selector and reply merger.
- Keep completed-render evidence through promotion to a new active revision-0 draft, including its accepted baseline and risk labels; current editor status belongs to the new draft, and unrelated artifact identities clear the comparison.
- Add reversed-response, replacement-generation, independent-feedback, tenant-switch and save-acknowledgement regressions. The required browser fixtures cover delayed save/seed responses and mounted-editor accessibility.
- Add a test-only isolated API entry point and owned-path checks because ordinary action stubs do not intercept startup provider dispatch. This mode uses synthetic capabilities/credentials, denies provider subprocesses, rejects foreign/dangling-symlink paths and binds seed/teardown state to the same run. Production startup and normal wire contracts are unchanged.
- Include the accepted four-PR implementation plan and update the owning frontend/QA documentation. This is phase 1; later phases will be stacked above it and this stack remains unmerged.

Prior implementation validation (Tier 3):
- `corepack pnpm web:check` and `corepack pnpm api:check`: passed.
- Focused `corepack pnpm --filter @jobctrl/web test` over Application review, mutation/reconciliation and fixture-isolation/config suites: 5 files, 79 tests passed.
- `corepack pnpm --filter @jobctrl/web test-d`: 11 files, 13 tests passed, no type errors.
- `corepack pnpm web:build`, `corepack pnpm --filter @jobctrl/web storybook:build`, `corepack pnpm docs:build`, and `git diff --check`: passed. Existing bundle-size/docgen warnings remain.
- Review reproduced a promotion regression with a faithful new-generation fixture. The correction passes the affected reconciliation/mutation/view suites (3 files, 71 tests) and web typecheck.
- Earlier isolated product QA passed comparison/accessibility, same-job artifact detail, and save-A/type-B/ack-A. A delayed-seed fixture lacked rendered-line markers; it now supplies those markers and waits for a visible newly published thread. Independent review and QA both pass at `2428ce2ddd34a4c24c06298f33c3acfc551ef3c3`; all four isolated Chromium scenarios pass with scoped axe clean. The High review finding is resolved, and all applicable CI checks pass.

No real profile, database, artifacts, credentials, provider calls, or application submission were used for these checks.

## Review corrections and synchronization

- Preserve real typing and formatting while an initially empty draft receives its first saved identity.
- Bind that preservation to the editor session so switching between cached jobs with identical saved documents cannot carry unsaved edits into the newly selected job.
- The corrected view, mutation and reconciler suites pass 73 tests. Six isolated Chromium artifact-comparison scenarios pass, including pending-create typing and cached-job isolation.
- Independent review passed at `55fa84f0ced467ec7e87c8aa9c7faf4faf3ab019`, including the unchanged cached-job counterexample and 73 focused tests.
- Synchronize with current main and preserve the correction through all dependent layers. Range-diff confirms unchanged executable patches; ledger updates distinguish historical evidence from synchronized-head QA and CI.

Cumulative synchronized-head QA passed at `f1c8aae101a727001802d44a3433a6fdb0e28c08`; the completion evidence below is separate from the historical implementation results.

The review-fix web typecheck, web build and docs build also passed; the six Chromium scenarios included scoped accessibility checks.

## Cumulative completion evidence

Independent cumulative QA returned Gate PASS at code head `f1c8aae101a727001802d44a3433a6fdb0e28c08`: 198 guarded core/materials tests, 20 real Temporal cases with 14 balanced ephemeral-server lifecycles, eight real Chromium flows including both review-draft regressions and both structured-profile persistence cases, and three scoped axe checks. No QA case failed or was skipped. Owned pre-import admission, independently parsed JUnit results, process/port cleanup and the clean exact checkout all passed.

[Python CI](https://github.com/ebarti/JobCtrl/actions/runs/34110669959) passed on that code head: Python 3.11, 3.12 and 3.13 each passed lint, 3,742 tests with two unchanged opt-in browser skips, and sdist/wheel builds. [TypeScript CI](https://github.com/ebarti/JobCtrl/actions/runs/34110669878) passed API, web unit/types/build, Storybook, extension and browser E2E. All latest applicable workflows also passed on the synchronized phase heads; superseded cancelled runs were excluded.
