### PR TITLE
fix(dashboard): resolve source names without hiding failures

### DIFF
--- a/apps/api/src/discovery-controls.ts
+++ b/apps/api/src/discovery-controls.ts
@@ -49,6 +49,7 @@ import {
 } from "./contracts.js";
 import { allRows, getRow, type SqliteDatabase } from "./db.js";
 import { emptyPolitenessOutcomes, politenessOutcomesBySource } from "./source-politeness.js";
+import { canonicalSourceDisplayName } from "./source-display-names.js";
 import type { SourcePolitenessOutcomes } from "@jobctrl/contracts";
 import { refreshProjections } from "./projections.js";
 import { InputError, resolveJobId } from "./write-model.js";
@@ -1607,17 +1608,6 @@ function sourcePriority(value: string): SourcePriorityValue {
   return SOURCE_PRIORITY_VALUES.includes(value as SourcePriorityValue)
     ? (value as SourcePriorityValue)
     : "standard";
-}
-
-const JOBSTREAMING_SOURCE_DISPLAY_NAMES: Readonly<Record<string, string>> = {
-  "jobspy:glassdoor": "JobStreaming Glassdoor",
-  "jobspy:indeed": "JobStreaming Indeed",
-  "jobspy:linkedin": "JobStreaming LinkedIn",
-  "jobspy:zip-recruiter": "JobStreaming ZipRecruiter",
-};
-
-function canonicalSourceDisplayName(sourceId: string, fallback: string): string {
-  return JOBSTREAMING_SOURCE_DISPLAY_NAMES[sourceId] ?? fallback;
 }
 
 function sourceKindFromId(sourceId: string): SourceKindValue {

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -88,6 +88,7 @@ import { buildApplyAudit, type ApplyAuditLatestRun } from "./apply-audit.js";
 import { evaluateRepeatApplication } from "./repeat-application.js";
 import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
 import { emptyPolitenessOutcomes, politenessOutcomesBySource } from "./source-politeness.js";
+import { canonicalSourceDisplayName, sourceDisplayNames } from "./source-display-names.js";
 import type { SourcePolitenessOutcomes } from "@jobctrl/contracts";
 import { normalizeJobLocation } from "./location-normalization.js";
 import { refreshProjections } from "./projections.js";
@@ -716,6 +717,7 @@ function digestBlockedSources(db: SqliteDatabase): DailyDigest["blockedSources"]
     )
     .map((source) => ({
       sourceId: source.sourceId,
+      ...(source.displayName ? { displayName: source.displayName } : {}),
       recommendedState: source.recommendedState,
       consecutiveFailures: source.consecutiveFailures,
     }));
@@ -4315,12 +4317,20 @@ function defaultDashboardRow(): DashboardProjectionRow {
 }
 
 function listSourceHealth(db: SqliteDatabase): DashboardSummary["sourceHealth"] {
+  const names = sourceDisplayNames(db);
+  const withDisplayName = (source: DashboardSummary["sourceHealth"][number]) => {
+    const displayName = canonicalSourceDisplayName(
+      source.sourceId,
+      names.get(source.sourceId) || source.sourceId,
+    );
+    return displayName === source.sourceId ? source : { ...source, displayName };
+  };
   const operationalBySource = operationalSourceRollups(db);
   const politenessBySource = politenessOutcomesBySource(db);
   const seen = new Set<string>();
   if (!tableExists(db, "source_quality_stats")) {
     return [...operationalBySource.values()].map((source) =>
-      sourceRollupToHealth(source, politenessBySource.get(source.sourceId ?? source.key)),
+      withDisplayName(sourceRollupToHealth(source, politenessBySource.get(source.sourceId ?? source.key))),
     );
   }
   const rows = allRows<SourceQualityProjectionRow>(
@@ -4366,7 +4376,7 @@ function listSourceHealth(db: SqliteDatabase): DashboardSummary["sourceHealth"] 
     if (!source.sourceId || seen.has(source.sourceId)) continue;
     sourceHealth.push(sourceRollupToHealth(source, politenessBySource.get(source.sourceId)));
   }
-  return sourceHealth;
+  return sourceHealth.map(withDisplayName);
 }
 
 function buildOperationalMetrics(db: SqliteDatabase): DashboardSummary["operationalMetrics"] {

--- a/apps/api/src/source-display-names.ts
+++ b/apps/api/src/source-display-names.ts
@@ -8,7 +8,16 @@ const JOBSTREAMING_SOURCE_DISPLAY_NAMES: Readonly<Record<string, string>> = {
 };
 
 export function canonicalSourceDisplayName(sourceId: string, fallback: string): string {
-  return JOBSTREAMING_SOURCE_DISPLAY_NAMES[sourceId] ?? fallback;
+  const knownName = JOBSTREAMING_SOURCE_DISPLAY_NAMES[sourceId];
+  if (knownName) return knownName;
+  if (!sourceId.startsWith("jobspy:")) return fallback;
+  // Match the worker's title-casing rule for other configured board slugs.
+  const board = sourceId.slice("jobspy:".length)
+    .replace(/[-_]/g, " ")
+    .trim()
+    .toLowerCase()
+    .replace(/[a-z]+/g, (word) => word.charAt(0).toUpperCase() + word.slice(1));
+  return `JobStreaming ${board}`;
 }
 
 /** Resolve names once per read while retaining stable source identities. */

--- a/apps/api/src/source-display-names.ts
+++ b/apps/api/src/source-display-names.ts
@@ -1,0 +1,24 @@
+import { allRows, tableExists, type SqliteDatabase } from "./db.js";
+
+const JOBSTREAMING_SOURCE_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  "jobspy:glassdoor": "JobStreaming Glassdoor",
+  "jobspy:indeed": "JobStreaming Indeed",
+  "jobspy:linkedin": "JobStreaming LinkedIn",
+  "jobspy:zip-recruiter": "JobStreaming ZipRecruiter",
+};
+
+export function canonicalSourceDisplayName(sourceId: string, fallback: string): string {
+  return JOBSTREAMING_SOURCE_DISPLAY_NAMES[sourceId] ?? fallback;
+}
+
+/** Resolve names once per read while retaining stable source identities. */
+export function sourceDisplayNames(db: SqliteDatabase): Map<string, string> {
+  if (!tableExists(db, "source_registry_entries")) return new Map();
+  return new Map(
+    allRows<{ source_id: string; display_name: string }>(
+      db,
+      "SELECT source_id, display_name FROM source_registry_entries WHERE tenant_id = ?",
+      ["local"],
+    ).map((row) => [row.source_id, canonicalSourceDisplayName(row.source_id, row.display_name)]),
+  );
+}

--- a/apps/api/test/digest.test.ts
+++ b/apps/api/test/digest.test.ts
@@ -42,6 +42,7 @@ interface DigestParityFixture {
     dailyBudgetUsd: number;
   };
   jobs: FixtureJob[];
+  sourceRegistry: Array<{ sourceId: string; displayName: string }>;
   sourceQuality: Array<{
     sourceId: string;
     recommendedState: string;
@@ -87,6 +88,7 @@ interface DigestParityFixture {
       count: number;
       sources: Array<{
         sourceId: string;
+        displayName?: string;
         recommendedState: string;
         consecutiveFailures: number;
       }>;
@@ -118,18 +120,12 @@ describe("daily digest read model", () => {
       seedDigestDatabase(dbPath, tempDir);
       const db = new Database(dbPath);
       try {
-        db.prepare("UPDATE source_quality_stats SET source_id = ? WHERE source_id = ?")
-          .run("jobspy:linkedin", "workday:unstable-example");
-        db.prepare(`INSERT INTO source_registry_entries (
-          tenant_id, source_id, kind, display_name, owner, priority, state, policy_id, created_at, updated_at
-        ) VALUES ('local', 'jobspy:linkedin', 'broad_board', 'JobStreaming LinkedIn', 'system', 'lead_generator', 'experimental', 'broad_board_lead_generator', ?, ?)`)
-          .run(fixture.now, fixture.now);
-
-        const source = buildDashboardSummary(db).sourceHealth.find((item) => item.sourceId === "jobspy:linkedin");
-        expect(source).toMatchObject({ displayName: "JobStreaming LinkedIn", recommendedState: "quarantined", consecutiveFailures: 3 });
-        expect(buildDigest(db).blockedSources.sources).toContainEqual({
-          sourceId: "jobspy:linkedin", displayName: "JobStreaming LinkedIn", recommendedState: "quarantined", consecutiveFailures: 3,
-        });
+        const summary = buildDashboardSummary(db);
+        for (const source of fixture.expected.blockedSources.sources) {
+          expect(summary.sourceHealth.find((item) => item.sourceId === source.sourceId))
+            .toMatchObject(source);
+        }
+        expect(buildDigest(db).blockedSources).toEqual(fixture.expected.blockedSources);
       } finally {
         db.close();
       }
@@ -187,8 +183,14 @@ describe("daily digest read model", () => {
 
       const response = await app.inject({ method: "GET", url: "/v1/digest" });
       expect(response.statusCode).toBe(200);
-      const digest = response.json() as { ok: true; since: string | null; newMatches: { count: number } };
+      const digest = response.json() as {
+        ok: true;
+        since: string | null;
+        newMatches: { count: number };
+        blockedSources: DigestParityFixture["expected"]["blockedSources"];
+      };
 
+      expect(digest.blockedSources).toEqual(fixture.expected.blockedSources);
       expect(digest.ok).toBe(true);
       expect(digest.since).toBe(fixture.expected.since);
       expect(digest.newMatches.count).toBe(fixture.expected.newMatches.count);
@@ -466,6 +468,12 @@ function insertMaterialArtifact(
 }
 
 function seedSourceQuality(db: Database.Database): void {
+  for (const source of fixture.sourceRegistry) {
+    db.prepare(`INSERT INTO source_registry_entries (
+      tenant_id, source_id, kind, display_name, owner, priority, state, policy_id, created_at, updated_at
+    ) VALUES ('local', ?, 'broad_board', ?, 'system', 'lead_generator', 'experimental', 'broad_board_lead_generator', ?, ?)`)
+      .run(source.sourceId, source.displayName, fixture.now, fixture.now);
+  }
   const insert = db.prepare(
     `INSERT INTO source_quality_stats (
        tenant_id, source_id, window_start, window_end, run_count,

--- a/apps/api/test/digest.test.ts
+++ b/apps/api/test/digest.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
 
 import { listApplyReviewQueue } from "../src/application-feedback.js";
-import { buildDigest, readDigestState } from "../src/read-model.js";
+import { buildDashboardSummary, buildDigest, readDigestState } from "../src/read-model.js";
 import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
 import { buildApp } from "../src/server.js";
 import { describe, expect, it } from "vitest";
@@ -112,6 +112,32 @@ const fixturePath = path.resolve(
 const fixture = JSON.parse(fs.readFileSync(fixturePath, "utf8")) as DigestParityFixture;
 
 describe("daily digest read model", () => {
+  it("carries registry source names into health and digest without changing failure evidence", () => {
+    const { dbPath, tempDir, cleanup } = makeTempDb();
+    try {
+      seedDigestDatabase(dbPath, tempDir);
+      const db = new Database(dbPath);
+      try {
+        db.prepare("UPDATE source_quality_stats SET source_id = ? WHERE source_id = ?")
+          .run("jobspy:linkedin", "workday:unstable-example");
+        db.prepare(`INSERT INTO source_registry_entries (
+          tenant_id, source_id, kind, display_name, owner, priority, state, policy_id, created_at, updated_at
+        ) VALUES ('local', 'jobspy:linkedin', 'broad_board', 'JobStreaming LinkedIn', 'system', 'lead_generator', 'experimental', 'broad_board_lead_generator', ?, ?)`)
+          .run(fixture.now, fixture.now);
+
+        const source = buildDashboardSummary(db).sourceHealth.find((item) => item.sourceId === "jobspy:linkedin");
+        expect(source).toMatchObject({ displayName: "JobStreaming LinkedIn", recommendedState: "quarantined", consecutiveFailures: 3 });
+        expect(buildDigest(db).blockedSources.sources).toContainEqual({
+          sourceId: "jobspy:linkedin", displayName: "JobStreaming LinkedIn", recommendedState: "quarantined", consecutiveFailures: 3,
+        });
+      } finally {
+        db.close();
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
   it("builds the shared local digest fixture without advancing the acknowledge watermark", () => {
     const { dbPath, tempDir, cleanup } = makeTempDb();
     try {

--- a/apps/web/src/views/dashboard/DigestPanel.test.tsx
+++ b/apps/web/src/views/dashboard/DigestPanel.test.tsx
@@ -9,6 +9,18 @@ import { renderWithProviders } from "../../test/render.js";
 import { DigestPanel } from "./DigestPanel.js";
 
 describe("DigestPanel", () => {
+  it("uses the registry name for blocked sources without hiding the block", async () => {
+    server.use(http.get("*/v1/digest", () => HttpResponse.json({
+      ...sampleDailyDigest,
+      blockedSources: { count: 1, sources: [{ sourceId: "jobspy:linkedin", displayName: "JobStreaming LinkedIn", recommendedState: "quarantined", consecutiveFailures: 3 }] },
+    })));
+    renderWithProviders(<DigestPanel />);
+
+    expect(await screen.findByText("JobStreaming LinkedIn")).toBeInTheDocument();
+    expect(screen.queryByText("jobspy:linkedin")).not.toBeInTheDocument();
+    expect(within(screen.getByRole("link", { name: /blocked sources/i })).getByText("1")).toBeInTheDocument();
+  });
+
   it("renders digest rows with exact URL-owned deep links", async () => {
     renderWithProviders(<DigestPanel />);
 

--- a/apps/web/src/views/dashboard/DigestPanel.tsx
+++ b/apps/web/src/views/dashboard/DigestPanel.tsx
@@ -45,7 +45,7 @@ function formatMoney(value: number | null): string {
 function digestRows(digest: DailyDigest): readonly DigestRow[] {
   const blockedSourceNames = digest.blockedSources.sources
     .slice(0, 2)
-    .map((source) => source.sourceId)
+    .map((source) => source.displayName ?? source.sourceId)
     .join(", ");
   const budgetDetail = digest.budget.unlimited
     ? `${formatMoney(digest.budget.estimatedUsd)} spent`

--- a/apps/web/src/views/dashboard/SourceHealthCard.test.tsx
+++ b/apps/web/src/views/dashboard/SourceHealthCard.test.tsx
@@ -5,6 +5,19 @@ import { sampleDashboardSummary } from "../../test/fixtures/projections.js";
 import { SourceHealthCard } from "./SourceHealthCard.js";
 
 describe("SourceHealthCard", () => {
+  it("shows the registry name while preserving source quality failures", () => {
+    const [source] = sampleDashboardSummary.sourceHealth;
+    render(<SourceHealthCard summary={{
+      ...sampleDashboardSummary,
+      sourceHealth: [{ ...source!, sourceId: "jobspy:linkedin", displayName: "JobStreaming LinkedIn", recommendedState: "quarantined", fullDescriptionSuccessRate: 0 }],
+    }} />);
+
+    expect(screen.getByText("JobStreaming LinkedIn")).toBeInTheDocument();
+    expect(screen.queryByText("jobspy:linkedin")).not.toBeInTheDocument();
+    expect(screen.getByText("quarantined")).toBeInTheDocument();
+    expect(screen.getByText(/0% full detail/)).toBeInTheDocument();
+  });
+
   it("renders source quality rates from the dashboard summary", () => {
     render(<SourceHealthCard summary={sampleDashboardSummary} />);
 

--- a/apps/web/src/views/dashboard/SourceHealthCard.tsx
+++ b/apps/web/src/views/dashboard/SourceHealthCard.tsx
@@ -47,7 +47,7 @@ export function SourceHealthCard({ summary }: SourceHealthCardProps) {
                 {source.recommendedState}
               </StatusBadge>
               <span className="title-stack">
-                <b data-typography="strong-body">{source.sourceId}</b>
+                <b data-typography="strong-body">{source.displayName ?? source.sourceId}</b>
                 <span className="source-health-primary" data-typography="metadata">
                   {pct(source.activeVerificationRate)} active · {pct(source.applyUrlSuccessRate)} apply
                 </span>
@@ -55,7 +55,10 @@ export function SourceHealthCard({ summary }: SourceHealthCardProps) {
                   {pct(source.fullDescriptionSuccessRate)} full detail · {pct(source.duplicateRate)}{" "}
                   duplicates
                 </span>
-                <SourcePolitenessBadges politeness={source.politeness} sourceLabel={source.sourceId} />
+                <SourcePolitenessBadges
+                  politeness={source.politeness}
+                  sourceLabel={source.displayName ?? source.sourceId}
+                />
               </span>
               {source.consecutiveFailures ? (
                 <StatusBadge tone="danger">{source.consecutiveFailures} fails</StatusBadge>

--- a/docs/api/complete-contract.md
+++ b/docs/api/complete-contract.md
@@ -231,6 +231,8 @@ and budget status. Passive reads never advance `digest_state.last_acknowledged_a
 only the explicit acknowledge flow may move the watermark. The digest uses a
 timestamp watermark and a UTC follow-up cutoff, resolving the plan's local-vs-UTC
 day-boundary inconsistency in favor of UTC.
+`blockedSources.sources[]` keeps its stable `sourceId` and may include an
+optional registry-resolved `displayName`, which clients prefer for presentation.
 `POST /v1/digest/acknowledge` accepts an optional `acknowledgedAt` ISO
 timestamp, advances the watermark monotonically, and returns the updated
 `digest_state`. Acknowledge writes also record `DigestReviewed`, which lets the
@@ -338,6 +340,9 @@ scoring, tailoring, Apply, workflow, or artifact work.
 source-observation, duplicate, content snapshot, enrichment, apply-URL, and
 active-state events and user discovery feedback. It is the read-side signal the
 web dashboard uses for source health. The same response also includes
+optional `displayName` on each source-health entry. Historical board keys keep
+their identity while displaying their current JobStreaming provider name;
+renaming does not reset health, failure, or quarantine data. It also includes
 `operationalMetrics`, sourced from `operational_attempt_metrics`, plus
 per-source operational/scrape/retryable failure counts. These counters use
 structured stage/source/apply attempt rows, not label math over free-text event

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -42,6 +42,11 @@ when implementing or debugging a specific endpoint.
 | Workflow operations | `/v1/pipeline/actions/run-stage`, `/v1/pipeline/operations`, `/v1/workflow-runs`, `/v1/health` | `202` for accepted asynchronous work; `200` for projection-backed and runtime-backed reads/sync commands |
 | Realtime | `/v1/events/stream` | Server-Sent Events with replay and reconnect support |
 
+Dashboard source-health and digest blocked-source entries retain stable
+`sourceId` values and may include `displayName` from the source registry.
+Clients prefer that name, including current JobStreaming board labels for
+historical source keys. Names do not change source-health or quarantine facts.
+
 ## Profile And Preferences
 
 Profile data, preferences, discovery controls, settings, and credentials have

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -3735,6 +3735,8 @@ export interface SourcePolitenessOutcomes {
 
 export interface SourceHealthSummary {
   sourceId: string;
+  /** Registry/provider name, independent of the stable source key. */
+  displayName?: string;
   recommendedState: string;
   runCount: number;
   failedRunCount: number;
@@ -3782,6 +3784,7 @@ export interface DailyDigest {
     count: number;
     sources: Array<{
       sourceId: string;
+      displayName?: string;
       recommendedState: string;
       consecutiveFailures: number;
     }>;

--- a/packages/domain-types/test/fixtures/daily_digest_parity.json
+++ b/packages/domain-types/test/fixtures/daily_digest_parity.json
@@ -1,5 +1,5 @@
 {
-  "description": "Shared TS<->Python daily digest parity fixture. Both runtimes seed the same projection-style SQLite rows, read the same digest_state watermark, and assert identical digest counts. The fixture uses UTC timestamps to lock the digest day-boundary decision: the watermark and follow-up cutoff are timestamp-based, not local calendar buckets.",
+  "description": "Shared TS<->Python daily digest parity fixture. Both runtimes seed the same projection-style SQLite rows, read the same digest_state watermark, and assert identical digest counts and source display names, including registry names, current JobStreaming labels for known and other boards, and missing or stale registry rows. The fixture uses UTC timestamps to lock the digest day-boundary decision: the watermark and follow-up cutoff are timestamp-based, not local calendar buckets.",
   "now": "2026-07-05T12:00:00.000Z",
   "since": "2026-07-01T00:00:00.000Z",
   "minFitScore": 7,
@@ -166,9 +166,52 @@
       "activeState": "closed"
     }
   ],
+  "sourceRegistry": [
+    {
+      "sourceId": "workday:unstable-example",
+      "displayName": "Workday Example"
+    },
+    {
+      "sourceId": "jobspy:linkedin",
+      "displayName": "JobSpy LinkedIn"
+    },
+    {
+      "sourceId": "jobspy:indeed",
+      "displayName": "JobSpy Indeed"
+    },
+    {
+      "sourceId": "jobspy:bayt",
+      "displayName": "JobSpy Bayt"
+    }
+  ],
   "sourceQuality": [
     {
       "sourceId": "workday:unstable-example",
+      "recommendedState": "quarantined",
+      "consecutiveFailures": 3
+    },
+    {
+      "sourceId": "jobspy:bayt",
+      "recommendedState": "quarantined",
+      "consecutiveFailures": 3
+    },
+    {
+      "sourceId": "jobspy:google",
+      "recommendedState": "quarantined",
+      "consecutiveFailures": 3
+    },
+    {
+      "sourceId": "jobspy:indeed",
+      "recommendedState": "quarantined",
+      "consecutiveFailures": 3
+    },
+    {
+      "sourceId": "jobspy:linkedin",
+      "recommendedState": "quarantined",
+      "consecutiveFailures": 3
+    },
+    {
+      "sourceId": "jobspy:zip-recruiter",
       "recommendedState": "quarantined",
       "consecutiveFailures": 3
     }
@@ -269,12 +312,43 @@
       "highFitCount": 2
     },
     "blockedSources": {
-      "count": 2,
+      "count": 7,
       "sources": [
+        {
+          "sourceId": "jobspy:bayt",
+          "recommendedState": "quarantined",
+          "consecutiveFailures": 3,
+          "displayName": "JobStreaming Bayt"
+        },
+        {
+          "sourceId": "jobspy:google",
+          "recommendedState": "quarantined",
+          "consecutiveFailures": 3,
+          "displayName": "JobStreaming Google"
+        },
+        {
+          "sourceId": "jobspy:indeed",
+          "recommendedState": "quarantined",
+          "consecutiveFailures": 3,
+          "displayName": "JobStreaming Indeed"
+        },
+        {
+          "sourceId": "jobspy:linkedin",
+          "recommendedState": "quarantined",
+          "consecutiveFailures": 3,
+          "displayName": "JobStreaming LinkedIn"
+        },
+        {
+          "sourceId": "jobspy:zip-recruiter",
+          "recommendedState": "quarantined",
+          "consecutiveFailures": 3,
+          "displayName": "JobStreaming ZipRecruiter"
+        },
         {
           "sourceId": "workday:unstable-example",
           "recommendedState": "quarantined",
-          "consecutiveFailures": 3
+          "consecutiveFailures": 3,
+          "displayName": "Workday Example"
         },
         {
           "sourceId": "greenhouse:ops-only",

--- a/workers/automation/src/jobctrl/digest.py
+++ b/workers/automation/src/jobctrl/digest.py
@@ -320,6 +320,24 @@ def _blocked_sources(conn: sqlite3.Connection) -> dict[str, Any]:
     for source in _operational_only_source_health(conn, seen):
         if _blocked_source_predicate(source):
             sources.append(source)
+    names = {}
+    if _table_exists(conn, "source_registry_entries"):
+        names = {
+            str(_row_get(row, "source_id")): str(_row_get(row, "display_name") or "")
+            for row in conn.execute(
+                "SELECT source_id, display_name FROM source_registry_entries WHERE tenant_id = ?",
+                (TENANT_ID,),
+            ).fetchall()
+        }
+    for source in sources:
+        source_id = source["sourceId"]
+        display_name = names.get(source_id) or source_id
+        if source_id.startswith("jobspy:"):
+            from jobctrl.config import _jobstreaming_source_display_name
+
+            display_name = _jobstreaming_source_display_name(source_id.split(":", 1)[1].replace("-", "_"))
+        if display_name != source_id:
+            source["displayName"] = display_name
     return {"count": len(sources), "sources": sources}
 
 

--- a/workers/automation/tests/test_digest_parity.py
+++ b/workers/automation/tests/test_digest_parity.py
@@ -157,6 +157,12 @@ def _create_schema(conn: sqlite3.Connection) -> None:
             last_updated_at        TEXT,
             PRIMARY KEY (tenant_id, job_id)
         );
+        CREATE TABLE source_registry_entries (
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            source_id TEXT NOT NULL,
+            display_name TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, source_id)
+        );
         CREATE TABLE source_quality_stats (
             tenant_id                         TEXT NOT NULL DEFAULT 'local',
             source_id                         TEXT NOT NULL,
@@ -363,6 +369,12 @@ def _seed_fixture(conn: sqlite3.Connection, fixture: dict[str, Any]) -> None:
                 "INSERT INTO job_stage_states (job_url, stage, state, updated_at) VALUES (?, 'apply', ?, ?)",
                 (job["jobId"], job["currentState"], fixture["now"]),
             )
+
+    for source in fixture["sourceRegistry"]:
+        conn.execute(
+            "INSERT INTO source_registry_entries (tenant_id, source_id, display_name) VALUES ('local', ?, ?)",
+            (source["sourceId"], source["displayName"]),
+        )
 
     for source in fixture["sourceQuality"]:
         conn.execute(


### PR DESCRIPTION
Source health and blocked-source digest cards exposed internal source IDs even when the registry had a readable name. Resolve display names in the API and worker digest, normalize existing JobStreaming source labels, and render the name with the stable ID as a fallback. Failure counts, block reasons, source identities, and retry information remain visible.

Adds optional contract fields, API and UI regressions for named and legacy payloads, and the owning API documentation.

Validation on cumulative head `a72c3078008482345c7ff14937cf8bc02511540d`:

- Ruff, API/web typechecks, all 828 API tests, 9 focused dashboard tests, 13 web type tests, production web build, docs build, and `git diff --check` pass. The fresh full Python run passed **3841 tests with 2 optional skips**.
- Independent cumulative review: **Gate: PASS**, no findings; 48 guarded Python cases, 4 API digest cases and all 9 dashboard cases passed.
- Independent cumulative product QA: **Gate: PASS**, no findings; 29 material-validation cases and 30 Temporal cases passed, with 19 real owned server lifecycles and balanced shutdowns. Three actual API surfaces and three desktop/mobile browser scenarios preserved canonical source data, failure/block information, readable labels and Inspect navigation; scoped accessibility, console and network checks passed.
- Prior SDK isolation and timeout/reservation gates were carried forward after source and dependency equality checks. The separate authenticated-provider/owner-extension operational requirement on #860 remains open.

These three PRs extend the existing unreleased stack. Owning contract and safety documentation accompanies the relevant phase; the final recovery PR carries the shared canonical product documentation and cumulative QA checklist.

This PR’s latest [Python CI](https://github.com/ebarti/JobCtrl/actions/runs/34125336936) and [TypeScript CI](https://github.com/ebarti/JobCtrl/actions/runs/34125336912) passed at its published head. All five TypeScript jobs passed, including E2E and Storybook; other applicable workflows passed and DCO was explicitly skipped. The final cumulative Python CI also passed lint, all 3841 tests (2 optional skips), and package builds on Python 3.11, 3.12 and 3.13.

The first Python 3.13 attempt timed out waiting for the unchanged worker-loss fixture’s 30-second checkpoint signal. The original failure was retained; one [failed-job-only retry at the same commit](https://github.com/ebarti/JobCtrl/actions/runs/34125336936/attempts/2) passed. No fixture, assertion or product source was changed for the retry.
