### PR TITLE
fix(pipeline): recover automatic preparation with exact ownership

### DIFF
--- a/docs/architecture/pipeline/operations.md
+++ b/docs/architecture/pipeline/operations.md
@@ -32,6 +32,64 @@ spendful workflow and reuses this **same** preflight — the `check_spend_budget
 activity + the `dailyBudgetUsd` ledger — before its LLM candidate extraction.
 There is no second spend table or preflight.
 
+## Automatic Preparation Recovery
+
+The worker checks saved preparation state at startup and on its 15-second
+heartbeat. `pipeline/automatic_preparation.py` resumes pending or retryable
+failed Enrich, Score, Tailor, and Cover work without running Discover or Apply.
+It waits while Temporal reports another discovery, import, or preparation
+workflow, or canonical stage rows are queued/running. An unavailable Temporal
+inventory prevents dispatch.
+
+Each recovery workflow handles one stage for at most 25 local jobs. Canonical
+queue predicates determine description, score, policy, threshold, and approved
+material prerequisites. A later heartbeat selects the next eligible stage.
+Recovery excludes explicit cancellation, blocked/non-retryable and exhausted
+states, deleted jobs, and closed/incompatible postings. Existing scores and
+approved materials are reused. Attempts are preserved, capped by the smaller
+of the stage limit and five, and delayed by `min(1800, 60 * 2^attempts)` seconds.
+Both dispatch and the workflow enforce the normal spend preflight.
+
+Owned scoring persists the requirement-fit report alongside its score evidence.
+After a rescore restores a missing report, dependency reconciliation releases
+only the retryable `REQUIREMENT_FIT_MISSING` Tailor block when the report matches
+the latest score, posting analysis, and score profile version and has requirement
+items. It preserves attempt limits and cancellation, requires no current approved
+resume, and lets normal eligibility and cooldown checks admit subsequent work.
+
+A SQLite transaction reserves the exact cohort in `queued` stage metadata and
+records `StageQueued` with its prior state and attempt count. The frozen cohort
+and deterministic workflow ID survive a worker restart or lost start
+acknowledgement. Temporal uses `USE_EXISTING` and `REJECT_DUPLICATE` to prevent
+a second execution of that reservation. Selected activities recheck ownership,
+deletion, cancellation, prerequisites, and attempt limits before processing.
+Automatic runs use one Temporal activity attempt; durable job state and the
+heartbeat own later retries. After a started activity times out, the exact
+Temporal history and a charged attempt from that cohort allow unconsumed
+reservations to return to pending without spending or resetting their attempts.
+This also releases the former `PREPARATION_RECOVERY_STOPPED` outcome when the
+same proof exists. Current eligibility and cooldowns still apply. Cancellation
+requests, termination, missing history, and batches without a consumed attempt
+retain their stopped/block outcome, preventing a preflight retry loop.
+History copied into a reset descendant cannot establish a timeout in that new
+run; the recorded original run and the scheduled activity owner must both match.
+
+Before checking for busy stage rows, the worker describes each interrupted
+automatic activity's exact Temporal execution. A closed owner restores its
+committed result or records one bounded failed attempt; canceled work stays
+canceled. Missing history leaves ownership intact. Enrichment also advances
+its execution lease so a disconnected predecessor cannot commit late results.
+Scoring and material generation fence both admission and persistence against
+cancellation or changed ownership, without holding a database lock during
+provider calls.
+
+Stopping discovery's streaming enrichment consumer for its terminal pass is an
+internal handoff, not a user cancellation. The consumer releases unfinished
+work to that pass. Historical incorrectly canceled rows are repaired only when
+their exact successful Discover execution claimed terminal enrichment after
+the stop; any recorded workflow cancellation request or terminal cancellation
+lease prevents repair.
+
 ## Standing Auto-Apply Loop
 
 Auto apply is a settings-reconciled continuous Apply workflow, not a hidden UI

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -66,6 +66,9 @@ When isolated auth is absent, setup and generation retain one-time reuse
 of a regular Codex CLI `auth.json`; the explicit Codex provider verify action
 uses the same copy-once behavior before checking the isolated login. Existing
 JobCtrl-owned auth is not overwritten, and the normal Codex home is unchanged.
+SDK processes clear ambient credential values and pin refresh/revocation URLs
+to OpenAI's default HTTPS endpoints. These URL overrides cannot be blank:
+Codex consumes an empty value literally and cannot build a refresh request.
 The auth file stays outside `codex_home/workspace/`; the permissions profile
 denies root reads and grants prompt-driven reads only to that workspace subtree,
 minimal runtime paths, and the one canonical Codex executable required to start
@@ -778,6 +781,12 @@ TypeScript Temporal SDK and without trigger-coupled reapers:
   in the audit stream. This is what lets a `kill -9`'d or restarted worker heal
   itself without confusing a later execution that reuses the deterministic
   workflow ID.
+- **Preparation recovery** — startup and heartbeat also reconcile eligible
+  saved enrichment, score, and material backlogs. Bounded, durable reservations
+  start one preparation stage at a time; no fresh discovery is required. The
+  controller preserves retry budgets and stop decisions and never starts Apply.
+  [Operations & Events](pipeline/operations.md#automatic-preparation-recovery)
+  owns dispatch, cooldown, and cancellation semantics.
 - **Dispatch-time open row** — the default starter writes a `WorkflowStarted`
   event immediately after a workflow start returns from Temporal. The in-workflow
   start marker remains as a duplicate-safe upsert, but a workflow killed or

--- a/docs/user/enrichment-and-extraction.md
+++ b/docs/user/enrichment-and-extraction.md
@@ -53,6 +53,19 @@ A failed fetch or exhausted cascade records a retryable attempt without
 manufacturing a snapshot. Failure remains isolated to that job, so useful
 results from the rest of the source batch survive.
 
+While the worker is running, unfinished enrichment and retryable failures are
+picked up automatically without a new discovery search. Recovery waits for
+existing preparation to finish, keeps each job's attempt history, and retries
+with increasing delays within its existing attempt limit. Once a description
+is available, scoring and eligible material generation follow through the same
+saved-job recovery path. A score cannot be produced from an empty description.
+
+Canceled jobs, unsafe destinations, blocked work, deleted or closed postings,
+and exhausted retries remain stopped. Recovery preserves saved scores and
+approved materials and never starts Apply. If a source still requires manual
+capture or authenticated access, retries cannot substitute for that access;
+the stage's failure or block remains visible.
+
 Application-target discovery has its own explicit outcome and retry policy:
 
 | Outcome | What it means | Automatic retry |

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -314,6 +314,9 @@ or verify that login.
 | CAPTCHA key | `CAPSOLVER_API_KEY` saved from Settings to Keychain on macOS, or supplied by the environment elsewhere; read by the owned local solver, not the model. |
 | Job-site passwords | Optional local profile value typed through a focused-field credential tool, never returned to the model. |
 
+Codex token refresh and revocation use OpenAI's default HTTPS endpoints;
+inherited endpoint overrides cannot redirect those credentials elsewhere.
+
 `config.json` contains non-secret Settings values and is replaced atomically
 with owner-only mode `0600`. The extension capability token is also `0600`.
 This limits accidental access by other local accounts, but it is not encryption

--- a/workers/automation/src/jobctrl/cli.py
+++ b/workers/automation/src/jobctrl/cli.py
@@ -2328,6 +2328,7 @@ def worker(
         from jobctrl.apply.auto_apply import reconcile_auto_apply_loop
 
         identity = current_runtime_identity()
+        await _reconcile_automatic_preparation(client, queue, identity)
         startup_auto_apply = await reconcile_auto_apply_loop(
             client,
             task_queue=queue,
@@ -2467,6 +2468,7 @@ async def _worker_heartbeat_loop(
                 from jobctrl.infrastructure.runtime_identity import current_runtime_identity
 
                 identity = current_runtime_identity()
+                await _reconcile_automatic_preparation(temporal_client, task_queue, identity)
                 auto_apply = await reconcile_auto_apply_loop(
                     temporal_client,
                     task_queue=task_queue,
@@ -2478,6 +2480,22 @@ async def _worker_heartbeat_loop(
             else:
                 if auto_apply.changed:
                     console.print(f"[yellow]Auto-apply loop {auto_apply.action}: {auto_apply.workflow_id}.[/yellow]")
+
+
+async def _reconcile_automatic_preparation(client: Any, task_queue: str, identity: Any) -> None:
+    from jobctrl.pipeline.automatic_preparation import reconcile_automatic_preparation
+
+    try:
+        queued = await reconcile_automatic_preparation(
+            client,
+            task_queue=task_queue,
+            expected_app_dir=str(identity.app_dir),
+            expected_db_path=str(identity.db_path),
+        )
+        if queued:
+            console.print(f"[yellow]Automatically recovering preparation for {queued} job(s).[/yellow]")
+    except Exception:
+        log.warning("Automatic preparation recovery failed; will retry", exc_info=True)
 
 
 def _worker_heartbeat_iteration(

--- a/workers/automation/src/jobctrl/discovery/activities.py
+++ b/workers/automation/src/jobctrl/discovery/activities.py
@@ -356,7 +356,13 @@ async def discovery_enrichment_activity(
         )
     )
 
-    cancel_event = threading.Event()
+    from jobctrl.enrichment.activities import _ActivityCancellationEvent
+
+    # Finishing the source producers cancels the live consumer before the
+    # terminal enrichment pass. That activity stop is a handoff, not a user
+    # cancellation of the job. Actual workflow cancellation is settled by the
+    # exact-run cancellation reconciler after the workflow records its outcome.
+    cancel_event = _ActivityCancellationEvent(terminal_on_cancel=not payload.stream_while_discovering)
     on_job_enriched = _build_per_job_handoff(payload)
     try:
         info = activity.info()
@@ -389,7 +395,7 @@ async def discovery_enrichment_activity(
             starting_message="discovery enrichment starting",
             progress_message="discovery enrichment still running",
             poll_interval=1.0 if payload.stream_while_discovering else 15.0,
-            on_cancel=cancel_event.set,
+            on_cancel=cancel_event.request_stop,
             activity_name="discover:enrichment",
         )
         activity.heartbeat({"status": result.get("status", "ok")})

--- a/workers/automation/src/jobctrl/enrichment/activities.py
+++ b/workers/automation/src/jobctrl/enrichment/activities.py
@@ -28,16 +28,19 @@ class _ActivityCancellationEvent(threading.Event):
 
     terminal_cancellation_requested: bool
 
-    def __init__(self) -> None:
+    def __init__(self, *, terminal_on_cancel: bool = True) -> None:
         super().__init__()
         self.terminal_cancellation_requested = False
+        self._terminal_on_cancel = terminal_on_cancel
 
     def request_stop(self) -> None:
         try:
             details = activity.cancellation_details()
         except RuntimeError:
             details = None
-        self.terminal_cancellation_requested = bool(details is None or details.cancel_requested)
+        self.terminal_cancellation_requested = self._terminal_on_cancel and bool(
+            details is None or details.cancel_requested
+        )
         self.set()
 
 
@@ -53,6 +56,7 @@ class EnrichActivityInput:
     job_ids: tuple[JobId, ...] = ()
     workflow_id: str | None = None
     workflow_run_id: str | None = None
+    recovery_workflow_id: str | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "job_ids", _canonical_job_ids(self.job_ids))
@@ -250,8 +254,11 @@ def _run_selected_enrichment(
 ) -> dict[str, Any]:
     from jobctrl.database import get_connection
     from jobctrl.enrichment.detail import _run_detail_scraper
+    from jobctrl.pipeline.automatic_preparation import automatic_recovery_job_ids
 
-    job_ids = _limited_job_ids(payload.job_ids, payload.limit)
+    job_ids = _limited_job_ids(automatic_recovery_job_ids(payload, "enrich"), payload.limit)
+    if not job_ids:
+        return {"status": "ok", "elapsed": 0.0, "errors": {}, "stages": [{"stage": "enrich", "enrichedJobIds": []}]}
     if payload.dry_run:
         return {
             "status": "ok",
@@ -276,6 +283,18 @@ def _run_selected_enrichment(
         activity_owner_token=activity_owner_token,
         conn=conn,
     )
+    if payload.recovery_workflow_id and payload.workflow_run_id:
+        # The reservation exists before Temporal allocates a run ID. Bind it
+        # inside the owning activity, before the normal exact-run selector,
+        # so a fast activity cannot outrun the dispatch acknowledgement.
+        conn.execute(
+            "UPDATE job_stage_states SET metadata_json = "
+            "json_set(metadata_json, '$.temporalRunId', ?) "
+            "WHERE tenant_id = ? AND stage = 'enrich' AND state = 'queued' "
+            "AND json_extract(metadata_json, '$.automaticPreparation.workflowId') = ?",
+            (payload.workflow_run_id, payload.tenant_id, payload.recovery_workflow_id),
+        )
+        conn.commit()
     t0 = time.time()
     scraper_kwargs: dict[str, Any] = {
         "max_per_site": payload.limit or None,

--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -3406,6 +3406,11 @@ def _release_unstarted_enrichment_cohort(
                 or metadata.get("leaseEpoch") != activity_lease.epoch
             ):
                 continue
+            # Automatic reservations are settled from exact Temporal history.
+            # Releasing one here would let a preflight failure retry forever
+            # without consuming an attempt. Keep it queued for that decision.
+            if metadata.get("automaticPreparation"):
+                continue
             set_stage_state(
                 conn,
                 job_id,
@@ -3414,7 +3419,7 @@ def _release_unstarted_enrichment_cohort(
                 tenant_id=tenant_id,
                 attempt_count=int(row[1] or 0),
                 retryable=True,
-                metadata={"recoveryReason": "workflow_selection_unprocessed"},
+                metadata={**metadata, "recoveryReason": "workflow_selection_unprocessed"},
                 validate_transition=False,
                 expected_version=int(row[3] or 0),
             )

--- a/workers/automation/src/jobctrl/infrastructure/analysis/codex_analysis_adapter.py
+++ b/workers/automation/src/jobctrl/infrastructure/analysis/codex_analysis_adapter.py
@@ -122,6 +122,10 @@ def _isolated_codex_env(codex_home: Path, process_home: Path) -> dict[str, str]:
         "CODEX_HOME": str(codex_home),
         "HOME": str(process_home),
         **{key: "" for key in CODEX_NEUTRALIZED_AUTH_ENV},
+        # Codex consumes endpoint overrides literally, including empty strings.
+        # Pin provider defaults so refresh works without inheriting a redirect.
+        "CODEX_REFRESH_TOKEN_URL_OVERRIDE": "https://auth.openai.com/oauth/token",
+        "CODEX_REVOKE_TOKEN_URL_OVERRIDE": "https://auth.openai.com/oauth/revoke",
     }
     if os.name == "nt":
         env["USERPROFILE"] = str(process_home)

--- a/workers/automation/src/jobctrl/infrastructure/preparation_recovery.py
+++ b/workers/automation/src/jobctrl/infrastructure/preparation_recovery.py
@@ -12,6 +12,10 @@ from temporalio import activity
 from jobctrl.domain.identifiers import canonical_job_id
 
 
+class PreparationReservationLost(RuntimeError):
+    """One job's reservation was revoked before its attempt began."""
+
+
 def owns_preparation_reservation(conn, *, tenant_id, job_id, stage, workflow_id) -> bool:
     """A queued automatic stage is admitted only by its reserved workflow."""
     if not workflow_id:
@@ -38,10 +42,12 @@ def claim_preparation_reservation(conn, *, tenant_id, job_id, stage, workflow_id
         return
     conn.execute("BEGIN IMMEDIATE")
     try:
-        if (cancel_event is not None and cancel_event.is_set()) or not owns_preparation_reservation(
+        if cancel_event is not None and cancel_event.is_set():
+            raise RuntimeError(f"{stage} activity canceled before dispatch")
+        if not owns_preparation_reservation(
             conn, tenant_id=tenant_id, job_id=job_id, stage=stage, workflow_id=workflow_id
         ):
-            raise RuntimeError(f"{stage} activity no longer owns its queued reservation")
+            raise PreparationReservationLost(f"{stage} activity no longer owns its queued reservation")
         yield
         conn.commit()
     except BaseException:

--- a/workers/automation/src/jobctrl/infrastructure/preparation_recovery.py
+++ b/workers/automation/src/jobctrl/infrastructure/preparation_recovery.py
@@ -3,12 +3,50 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from contextlib import contextmanager
 import json
 from typing import Any
 
 from temporalio import activity
 
 from jobctrl.domain.identifiers import canonical_job_id
+
+
+def owns_preparation_reservation(conn, *, tenant_id, job_id, stage, workflow_id) -> bool:
+    """A queued automatic stage is admitted only by its reserved workflow."""
+    if not workflow_id:
+        return False
+    return (
+        conn.execute(
+            "SELECT 1 FROM job_stage_states s WHERE tenant_id = ? AND job_id = ? AND stage = ? "
+            "AND state = 'queued' AND retryable = 1 AND attempt_count < MIN(5, max_attempts) "
+            "AND json_extract(metadata_json, '$.automaticPreparation.workflowId') = ? "
+            "AND NOT EXISTS (SELECT 1 FROM jobctrl_deleted_jobs d "
+            "WHERE d.tenant_id = s.tenant_id AND d.job_id = s.job_id "
+            "AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at)))",
+            (str(tenant_id), str(job_id), stage, workflow_id),
+        ).fetchone()
+        is not None
+    )
+
+
+@contextmanager
+def claim_preparation_reservation(conn, *, tenant_id, job_id, stage, workflow_id, cancel_event):
+    """Fence the queued-to-running transition, releasing the lock before I/O."""
+    if not workflow_id:
+        yield
+        return
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        if (cancel_event is not None and cancel_event.is_set()) or not owns_preparation_reservation(
+            conn, tenant_id=tenant_id, job_id=job_id, stage=stage, workflow_id=workflow_id
+        ):
+            raise RuntimeError(f"{stage} activity no longer owns its queued reservation")
+        yield
+        conn.commit()
+    except BaseException:
+        conn.rollback()
+        raise
 
 
 @dataclass(frozen=True)
@@ -74,10 +112,10 @@ def cancel_preparation_state_rows(
     conn: Any,
     payload: CancelPreparationStateInput,
 ) -> CancelPreparationStateOutput:
-    """Cancel only unfinished selected material rows still owned by this run."""
+    """Cancel only unfinished selected preparation rows still owned by this run."""
 
-    if payload.stage not in {"tailor", "cover"}:
-        raise ValueError("material cancellation supports tailor or cover")
+    if payload.stage not in {"score", "tailor", "cover"}:
+        raise ValueError("preparation cancellation supports score, tailor, or cover")
     from jobctrl.domain.tenant import TenantId
     from jobctrl.state import record_job_event, set_stage_state, utc_now
 
@@ -113,12 +151,16 @@ def cancel_preparation_state_rows(
             if state not in {"pending", "queued", "running"}:
                 continue
             job_id = canonical_job_id(str(row["job_id"]))
-            if state == "running" and owner == payload.workflow_id and _material_commit_exists(
-                conn,
-                payload=payload,
-                tenant_id=tenant_id,
-                job_id=job_id,
-                metadata=metadata,
+            if (
+                state == "running"
+                and owner == payload.workflow_id
+                and _preparation_commit_exists(
+                    conn,
+                    payload=payload,
+                    tenant_id=tenant_id,
+                    job_id=job_id,
+                    metadata=metadata,
+                )
             ):
                 _restore_committed(
                     conn,
@@ -264,8 +306,7 @@ def assert_material_activity_commit_allowed(
     if not workflow_id:
         return
     row = conn.execute(
-        "SELECT state, metadata_json FROM job_stage_states "
-        "WHERE tenant_id = ? AND job_id = ? AND stage = ?",
+        "SELECT state, metadata_json FROM job_stage_states WHERE tenant_id = ? AND job_id = ? AND stage = ?",
         (tenant_id, job_id, stage),
     ).fetchone()
     if (
@@ -286,17 +327,12 @@ def _preparation_commit_exists(
 ) -> bool:
     if payload.stage == "score":
         score_row = conn.execute(
-            "SELECT COALESCE(MAX(version), 0) AS version FROM job_scores "
-            "WHERE tenant_id = ? AND job_id = ?",
+            "SELECT COALESCE(MAX(version), 0) AS version FROM job_scores WHERE tenant_id = ? AND job_id = ?",
             (payload.tenant_id, str(job_id)),
         ).fetchone()
         current_version = int(score_row["version"] if score_row else 0)
         prior_version = int(metadata.get("priorScoreVersion") or 0)
-        return (
-            current_version > prior_version
-            if bool(metadata.get("rescore"))
-            else current_version > 0
-        )
+        return current_version > prior_version if bool(metadata.get("rescore")) else current_version > 0
     return _material_commit_exists(
         conn,
         payload=payload,
@@ -323,10 +359,7 @@ def _material_commit_exists(
         if materials is None or not materials.is_resume_approved:
             return False
         prior_generation = int(metadata.get("priorApprovedGeneration") or 0)
-        return (
-            not bool(metadata.get("retailor"))
-            or int(materials.generation) > prior_generation
-        )
+        return not bool(metadata.get("retailor")) or int(materials.generation) > prior_generation
     if payload.stage == "cover":
         return bool(
             materials is not None
@@ -397,11 +430,7 @@ def _fail_uncommitted(conn, *, payload, tenant_id, job_id, row, finished_at) -> 
         error_code=error_code,
         error_message="The activity stopped before committing its result.",
         retryable=not exhausted,
-        next_action=(
-            f"retry {payload.stage} --reset-attempts"
-            if exhausted
-            else f"retry {payload.stage}"
-        ),
+        next_action=(f"retry {payload.stage} --reset-attempts" if exhausted else f"retry {payload.stage}"),
         metadata={
             "recoveredFromWorkflowId": payload.workflow_id,
             "reason": "orphaned_activity_failed",

--- a/workers/automation/src/jobctrl/materials/activities.py
+++ b/workers/automation/src/jobctrl/materials/activities.py
@@ -51,6 +51,7 @@ class TailorActivityInput:
     tailor_judge_min_score: float | None = None
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
     workflow_id: str | None = None
+    recovery_workflow_id: str | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "job_ids", _canonical_job_ids(self.job_ids))
@@ -242,8 +243,9 @@ def _run_selected_tailoring(
 ) -> dict[str, Any]:
     from jobctrl.domain.tenant import TenantId
     from jobctrl.scoring.tailor import tailor_job_by_id
+    from jobctrl.pipeline.automatic_preparation import automatic_recovery_job_ids
 
-    job_ids = _limited_job_ids(payload.job_ids, payload.limit)
+    job_ids = _limited_job_ids(automatic_recovery_job_ids(payload, "tailor"), payload.limit)
     if payload.dry_run:
         return {
             "status": "ok",
@@ -285,6 +287,7 @@ def _run_selected_tailoring(
             tailor_judge_min_score=payload.tailor_judge_min_score,
             workflow_id=payload.workflow_id,
             cancel_event=cancel_event,
+            **({"recovery_workflow_id": payload.recovery_workflow_id} if payload.recovery_workflow_id else {}),
         )
 
     for job_id, result in _run_selected_material_jobs(
@@ -429,6 +432,7 @@ class CoverActivityInput:
     job_ids: tuple[JobId, ...] = ()
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
     workflow_id: str | None = None
+    recovery_workflow_id: str | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "job_ids", _canonical_job_ids(self.job_ids))
@@ -595,8 +599,9 @@ def _run_selected_cover(
 ) -> dict[str, Any]:
     from jobctrl.domain.tenant import TenantId
     from jobctrl.scoring.cover_letter import cover_letter_by_id
+    from jobctrl.pipeline.automatic_preparation import automatic_recovery_job_ids
 
-    job_ids = _limited_job_ids(payload.job_ids, payload.limit)
+    job_ids = _limited_job_ids(automatic_recovery_job_ids(payload, "cover"), payload.limit)
     if payload.dry_run:
         return {
             "status": "ok",
@@ -629,6 +634,7 @@ def _run_selected_cover(
             tenant_id=TenantId(payload.tenant_id),
             workflow_id=payload.workflow_id,
             cancel_event=cancel_event,
+            **({"recovery_workflow_id": payload.recovery_workflow_id} if payload.recovery_workflow_id else {}),
         )
 
     for job_id, result in _run_selected_material_jobs(

--- a/workers/automation/src/jobctrl/materials/executor.py
+++ b/workers/automation/src/jobctrl/materials/executor.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 from jobctrl.domain.errors import LlmTransientError
 from jobctrl.domain.identifiers import JobId
+from jobctrl.infrastructure.preparation_recovery import PreparationReservationLost
 
 
 def run_material_jobs(
@@ -28,11 +29,17 @@ def run_material_jobs(
         if cancel_event is not None and cancel_event.is_set():
             raise LlmTransientError(f"{stage} activity canceled")
 
+    def run_owned_job(job_id: JobId) -> dict[str, Any]:
+        try:
+            return run_one(job_id)
+        except PreparationReservationLost:
+            return {"job_id": str(job_id), "status": "skipped", "reason": "reservation_lost"}
+
     if worker_count == 1:
         results: list[tuple[JobId, dict[str, Any]]] = []
         for job_id in job_ids:
             ensure_active()
-            results.append((job_id, run_one(job_id)))
+            results.append((job_id, run_owned_job(job_id)))
         return results
 
     ensure_active()
@@ -40,7 +47,7 @@ def run_material_jobs(
     # stage events emitted inside the material runners keep run ownership.
     from jobctrl.infrastructure.workflow_run_context import carry_workflow_run_context
 
-    run_one_owned = carry_workflow_run_context(run_one)
+    run_one_owned = carry_workflow_run_context(run_owned_job)
     executor = ThreadPoolExecutor(
         max_workers=worker_count,
         thread_name_prefix=f"selected-{stage}",

--- a/workers/automation/src/jobctrl/pipeline/automatic_preparation.py
+++ b/workers/automation/src/jobctrl/pipeline/automatic_preparation.py
@@ -1,0 +1,762 @@
+"""Resume durable preparation backlogs without starting another discovery run.
+
+The queued stage row is the dispatch reservation. Its frozen batch survives a
+lost Temporal acknowledgement; the deterministic workflow ID rejects a second
+execution of that reservation. Each workflow runs only one stage, so every
+successor is selected afresh through the canonical prerequisite predicates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import sqlite3
+from typing import Any
+
+from temporalio.client import WorkflowExecutionStatus
+from temporalio.api.enums.v1 import TimeoutType
+from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
+from temporalio.exceptions import WorkflowAlreadyStartedError
+from temporalio.service import RPCError, RPCStatusCode
+
+from jobctrl import database
+from jobctrl.domain.identifiers import JobId, canonical_job_id
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.infrastructure.enrichment.sqlite_repository import SqliteEnrichmentRepository
+from jobctrl.state import record_job_event, set_stage_state
+
+_STAGES = ("score", "tailor", "cover", "enrich")
+_BATCH_SIZE = 25
+_ACTIVE_WORK = (
+    "ExecutionStatus = 'Running' AND (WorkflowType = 'DiscoverWorkflow' "
+    "OR WorkflowType = 'JobPipelineWorkflow' OR WorkflowType = 'JobPreparationWorkflow' "
+    "OR WorkflowType = 'JobUrlImportWorkflow' OR WorkflowType = 'ManualCaptureImportWorkflow')"
+)
+
+
+@dataclass(frozen=True)
+class RecoveryBatch:
+    workflow_id: str
+    stage: str
+    job_ids: tuple[JobId, ...]
+    min_score: int
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "workflowId": self.workflow_id,
+            "stage": self.stage,
+            "jobIds": list(self.job_ids),
+            "minScore": self.min_score,
+        }
+
+
+async def reconcile_automatic_preparation(
+    client: Any,
+    *,
+    task_queue: str,
+    expected_app_dir: str,
+    expected_db_path: str,
+) -> int:
+    """Dispatch at most one bounded batch while the preparation worker is idle."""
+    from jobctrl.infrastructure.scoring.criteria_provider import read_min_fit_score
+    from jobctrl.llm import read_spend_budget_status
+    from jobctrl.pipeline.workflow import JobPipelineWorkflow, JobPipelineWorkflowInput
+
+    # Visibility errors propagate before any reservation is written. The worker
+    # retries this read on its next heartbeat instead of guessing that it is idle.
+    async for _execution in client.list_workflows(query=_ACTIVE_WORK):
+        return 0
+    if read_spend_budget_status().exceeded:
+        return 0
+    conn = database.get_connection()
+    await _reconcile_stopped_enrichment_owners(client, conn)
+    await _reconcile_stopped_activity_owners(client, conn)
+    await _reconcile_interrupted_reservations(client, conn)
+    batch = reserve_recovery_batch(conn, min_score=read_min_fit_score(default=7))
+    if batch is None:
+        return 0
+    try:
+        description = await client.get_workflow_handle(batch.workflow_id).describe()
+    except RPCError as exc:
+        if exc.status != RPCStatusCode.NOT_FOUND:
+            raise
+    else:
+        if description.status != WorkflowExecutionStatus.RUNNING:
+            _settle_closed_reservation(conn, batch, description.status)
+        return 0
+
+    payload = JobPipelineWorkflowInput(
+        tenant_id=str(LOCAL_TENANT),
+        stages=[batch.stage],
+        job_ids=batch.job_ids,
+        min_score=batch.min_score,
+        workers=1,
+        expected_app_dir=expected_app_dir,
+        expected_db_path=expected_db_path,
+        automatic_recovery=True,
+    )
+    try:
+        await client.start_workflow(
+            JobPipelineWorkflow.run,
+            payload,
+            id=batch.workflow_id,
+            task_queue=task_queue,
+            id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
+            id_reuse_policy=WorkflowIDReusePolicy.REJECT_DUPLICATE,
+        )
+    except WorkflowAlreadyStartedError:
+        # Another worker or a lost acknowledgement already dispatched this
+        # exact reservation. Never mint a new ID to get around that decision.
+        return 0
+    return len(batch.job_ids)
+
+
+async def _reconcile_stopped_enrichment_owners(client: Any, conn: sqlite3.Connection) -> None:
+    """Fence a dead enrichment execution before releasing its durable cohort."""
+    from jobctrl.domain.enrichment import StaleEnrichmentExecutionLease
+    from jobctrl.domain.enrichment.aggregate import JobEnrichment
+    from jobctrl.domain.enrichment.value_objects import EnrichmentError, ExtractionTier
+    from jobctrl.enrichment.detail import cancel_enrichment_cohort
+    from jobctrl.infrastructure.enrichment.execution_lease import claim_enrichment_execution_lease_for_run
+
+    owners = conn.execute(
+        "SELECT DISTINCT json_extract(metadata_json, '$.workflowId') AS workflow_id, "
+        "json_extract(metadata_json, '$.temporalRunId') AS run_id FROM job_stage_states "
+        "WHERE tenant_id = ? AND stage = 'enrich' AND state IN ('queued', 'running') "
+        "AND json_extract(metadata_json, '$.workflowId') GLOB 'prepare-auto-local-*' "
+        "AND json_extract(metadata_json, '$.temporalRunId') IS NOT NULL",
+        (str(LOCAL_TENANT),),
+    ).fetchall()
+    for owner in owners:
+        workflow_id, run_id = owner["workflow_id"], owner["run_id"]
+        try:
+            description = await client.get_workflow_handle(workflow_id, run_id=run_id).describe()
+        except RPCError as exc:
+            if exc.status == RPCStatusCode.NOT_FOUND:
+                continue
+            raise
+        if description.status == WorkflowExecutionStatus.RUNNING:
+            continue
+        job_ids = tuple(
+            canonical_job_id(row[0])
+            for row in conn.execute(
+                "SELECT job_id FROM job_stage_states WHERE tenant_id = ? AND stage = 'enrich' "
+                "AND state IN ('queued', 'running') AND json_extract(metadata_json, '$.workflowId') = ? "
+                "AND json_extract(metadata_json, '$.temporalRunId') = ?",
+                (str(LOCAL_TENANT), workflow_id, run_id),
+            ).fetchall()
+        )
+        if description.status == WorkflowExecutionStatus.CANCELED:
+            cancel_enrichment_cohort(conn, job_ids, workflow_id=workflow_id, workflow_run_id=run_id)
+            continue
+        try:
+            claim_enrichment_execution_lease_for_run(
+                conn,
+                tenant_id=LOCAL_TENANT,
+                workflow_id=workflow_id,
+                run_id=run_id,
+                owner_token=f"recovery:{workflow_id}:{run_id}",
+                activity_phase=3,
+                activity_attempt=1,
+            )
+        except StaleEnrichmentExecutionLease:
+            # Cancellation may have committed its fence but lost the process
+            # before settling rows. Finish that decision even if the workflow
+            # subsequently failed; never turn it into an automatic retry.
+            terminal = conn.execute(
+                "SELECT json_extract(payload_json, '$.ownerToken'), "
+                "json_extract(payload_json, '$.activityPhase'), json_extract(payload_json, '$.activityAttempt') "
+                "FROM job_events WHERE entity_kind = 'discovery_enrichment_lease' "
+                "AND json_extract(payload_json, '$.execution.workflowId') = ? "
+                "AND json_extract(payload_json, '$.execution.runId') = ? "
+                "AND tenant_id = ? ORDER BY 2 DESC, 3 DESC, event_id ASC LIMIT 1",
+                (workflow_id, run_id, str(LOCAL_TENANT)),
+            ).fetchone()
+            if terminal is not None and tuple(terminal) == (f"cancellation:{workflow_id}:{run_id}", 3, 1):
+                cancel_enrichment_cohort(conn, job_ids, workflow_id=workflow_id, workflow_run_id=run_id)
+            continue
+        repository = SqliteEnrichmentRepository(conn)
+        now = datetime.now(timezone.utc).isoformat()
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            for job_id in job_ids:
+                row = conn.execute(
+                    "SELECT * FROM job_stage_states WHERE tenant_id = ? AND job_id = ? AND stage = 'enrich' "
+                    "AND state IN ('queued', 'running') AND json_extract(metadata_json, '$.workflowId') = ? "
+                    "AND json_extract(metadata_json, '$.temporalRunId') = ?",
+                    (str(LOCAL_TENANT), str(job_id), workflow_id, run_id),
+                ).fetchone()
+                if row is None:
+                    continue
+                aggregate = repository.load(LOCAL_TENANT, job_id)
+                attempts = int(row["attempt_count"] or 0)
+                error = None
+                if aggregate is not None and aggregate.is_enriched:
+                    state = "succeeded"
+                    attempts = max(attempts, aggregate.attempt_count)
+                else:
+                    if row["state"] == "running" and (aggregate is None or not aggregate.is_failed):
+                        aggregate = aggregate or JobEnrichment.empty(
+                            tenant_id=LOCAL_TENANT, job_id=job_id, updated_at=now
+                        )
+                        if not aggregate.is_running:
+                            aggregate = aggregate.start_attempt(
+                                extraction_tier=ExtractionTier.JSON_LD, started_at=row["started_at"] or now
+                            )
+                        aggregate = aggregate.fail_attempt(
+                            error=EnrichmentError(
+                                code="ENRICH_ACTIVITY_OWNER_STOPPED",
+                                message="Enrichment owner stopped before committing its result.",
+                                retryable=True,
+                            ),
+                            finished_at=now,
+                        )
+                        repository.save(aggregate, commit=False)
+                        attempts += 1
+                    if aggregate is not None:
+                        attempts = max(attempts, aggregate.attempt_count)
+                        error = aggregate.last_attempt.error if aggregate.last_attempt else None
+                    state = "exhausted" if attempts >= min(5, row["max_attempts"]) else "failed"
+                set_stage_state(
+                    conn,
+                    job_id,
+                    "enrich",
+                    state,
+                    attempt_count=attempts,
+                    max_attempts=row["max_attempts"],
+                    finished_at=now,
+                    error_code=error.code if error else None,
+                    error_message=error.message if error else None,
+                    retryable=state != "exhausted" and (error is None or error.retryable),
+                    metadata={"recoveredFromWorkflowId": workflow_id, "recoveredFromRunId": run_id},
+                    validate_transition=False,
+                    expected_version=row["version"],
+                )
+                record_job_event(
+                    conn,
+                    job_id,
+                    "enrich",
+                    "StageCompleted" if state == "succeeded" else "StageFailed",
+                    message="Enrichment settled after its exact workflow execution stopped.",
+                    payload={
+                        "workflowId": workflow_id,
+                        "temporalRunId": run_id,
+                        "attemptCount": attempts,
+                        "state": state,
+                    },
+                )
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+
+
+async def _reconcile_stopped_activity_owners(client: Any, conn: sqlite3.Connection) -> None:
+    """Settle running rows only after observing their exact execution closed."""
+    from jobctrl.infrastructure.preparation_recovery import (
+        CancelPreparationStateInput,
+        RecoverPreparationStateInput,
+        cancel_preparation_state_rows,
+        recover_preparation_state_rows,
+    )
+
+    owners = conn.execute(
+        "SELECT DISTINCT s.stage, "
+        "COALESCE(json_extract(s.metadata_json, '$.workflowId'), r.workflow_id) AS workflow_id, "
+        "json_extract(s.metadata_json, '$.activityOwner') AS temporal_run_id "
+        "FROM job_stage_states s LEFT JOIN workflow_run_projections r "
+        "ON r.tenant_id = s.tenant_id "
+        "AND r.temporal_run_id = json_extract(s.metadata_json, '$.activityOwner') "
+        "WHERE s.tenant_id = ? AND s.stage IN ('score', 'tailor', 'cover') "
+        "AND s.state = 'running' AND ("
+        "(json_extract(s.metadata_json, '$.automaticRecovery') = 1 "
+        "AND json_extract(s.metadata_json, '$.workflowId') IS NOT NULL "
+        "AND json_extract(s.metadata_json, '$.temporalRunId') = json_extract(s.metadata_json, '$.activityOwner')) "
+        "OR (r.workflow_type = 'JobPipelineWorkflow' AND r.workflow_id GLOB 'prepare-auto-local-*'))",
+        (str(LOCAL_TENANT),),
+    ).fetchall()
+    for owner in owners:
+        # A projection is a lookup index, not proof of closure. Missing or
+        # unavailable history leaves the original ownership intact.
+        try:
+            description = await client.get_workflow_handle(
+                owner["workflow_id"], run_id=owner["temporal_run_id"]
+            ).describe()
+        except RPCError as exc:
+            if exc.status == RPCStatusCode.NOT_FOUND:
+                continue
+            raise
+        if description.status == WorkflowExecutionStatus.RUNNING:
+            continue
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            if description.status == WorkflowExecutionStatus.CANCELED:
+                cancel_preparation_state_rows(
+                    conn,
+                    CancelPreparationStateInput(
+                        tenant_id=str(LOCAL_TENANT),
+                        workflow_id=owner["temporal_run_id"],
+                        stage=owner["stage"],
+                        job_ids=(),
+                    ),
+                )
+            else:
+                recover_preparation_state_rows(
+                    conn,
+                    RecoverPreparationStateInput(
+                        tenant_id=str(LOCAL_TENANT),
+                        workflow_id=owner["temporal_run_id"],
+                        stage=owner["stage"],
+                    ),
+                )
+        except BaseException:
+            conn.rollback()
+            raise
+
+
+def reserve_recovery_batch(
+    conn: sqlite3.Connection,
+    *,
+    min_score: int = 7,
+    now: datetime | None = None,
+) -> RecoveryBatch | None:
+    now = now or datetime.now(timezone.utc)
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        existing = conn.execute(
+            "SELECT metadata_json FROM job_stage_states "
+            "WHERE tenant_id = ? AND state = 'queued' "
+            "AND json_extract(metadata_json, '$.automaticPreparation.workflowId') IS NOT NULL "
+            "ORDER BY updated_at, job_id LIMIT 1",
+            (str(LOCAL_TENANT),),
+        ).fetchone()
+        if existing is not None:
+            saved = json.loads(existing[0])["automaticPreparation"]
+            batch = RecoveryBatch(
+                workflow_id=saved["workflowId"],
+                stage=saved["stage"],
+                job_ids=tuple(canonical_job_id(value) for value in saved["jobIds"]),
+                min_score=int(saved["minScore"]),
+            )
+            conn.commit()
+            return batch
+        # A dispatch belonging to another producer may not yet be visible in
+        # Temporal. Its canonical queue/running rows take precedence as well.
+        busy = conn.execute(
+            "SELECT 1 FROM job_stage_states WHERE tenant_id = ? "
+            "AND stage IN ('enrich', 'score', 'tailor', 'cover') "
+            "AND state IN ('queued', 'running') LIMIT 1",
+            (str(LOCAL_TENANT),),
+        ).fetchone()
+        if busy:
+            conn.commit()
+            return None
+        _repair_completed_discovery_handoff(conn)
+        candidates = _candidates(conn, min_score=min_score)
+        for stage in _STAGES:
+            due = [row for row in candidates[stage] if _retry_due(row, now)][:_BATCH_SIZE]
+            if not due:
+                continue
+            identity = [(row["job_id"], row["attempt_count"], row["updated_at"]) for row in due]
+            digest = hashlib.sha256(json.dumps(identity, sort_keys=True).encode()).hexdigest()[:24]
+            batch = RecoveryBatch(
+                workflow_id=f"prepare-auto-local-{stage}-{digest}",
+                stage=stage,
+                job_ids=tuple(canonical_job_id(row["job_id"]) for row in due),
+                min_score=min_score,
+            )
+            repository = SqliteEnrichmentRepository(conn)
+            for row in due:
+                job_id = canonical_job_id(row["job_id"])
+                if stage == "enrich":
+                    aggregate = repository.load(LOCAL_TENANT, job_id)
+                    if aggregate is not None and aggregate.current_status == "failed":
+                        repository.save(aggregate.reset(reset_at=now.isoformat()), commit=False)
+                set_stage_state(
+                    conn,
+                    job_id,
+                    stage,
+                    "queued",
+                    attempt_count=row["attempt_count"],
+                    max_attempts=row["max_attempts"],
+                    validate_transition=False,
+                    metadata={
+                        "workflowId": batch.workflow_id,
+                        "automaticPreparation": batch.metadata(),
+                    },
+                )
+                record_job_event(
+                    conn,
+                    job_id,
+                    stage,
+                    "StageQueued",
+                    message="Unfinished preparation queued for automatic recovery.",
+                    payload={
+                        **batch.metadata(),
+                        "reason": "automatic_preparation_recovery",
+                        "previousState": row["state"],
+                        "attemptCount": row["attempt_count"],
+                        "previousErrorCode": row["error_code"],
+                    },
+                )
+            conn.commit()
+            return batch
+        conn.commit()
+        return None
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def _repair_completed_discovery_handoff(conn: sqlite3.Connection) -> None:
+    """Repair only the historical consumer-stop bug with exact-run evidence.
+
+    A completed Discover run claiming its terminal enrichment phase *after*
+    the cancellation is positive evidence of an internal producer handoff.
+    Any workflow cancellation request or terminal cancellation lease vetoes
+    repair, including requests whose old audit lacks the exact run ID.
+    """
+    rows = conn.execute(
+        """
+        SELECT s.job_id, s.attempt_count, s.max_attempts, s.metadata_json
+        FROM job_stage_states s
+        JOIN workflow_run_projections r
+          ON r.tenant_id = s.tenant_id
+         AND r.workflow_id = json_extract(s.metadata_json, '$.workflowId')
+         AND r.temporal_run_id = json_extract(s.metadata_json, '$.temporalRunId')
+        WHERE s.tenant_id = ? AND s.stage = 'enrich' AND s.state = 'canceled'
+          AND r.workflow_type = 'DiscoverWorkflow' AND r.status = 'succeeded'
+          AND json_extract(s.metadata_json, '$.recoveryReason') = 'transient_interruption'
+          AND json_extract(s.metadata_json, '$.cancellationReason') = 'workflow_canceled'
+          AND EXISTS (
+            SELECT 1 FROM job_events e WHERE e.tenant_id = s.tenant_id
+              AND e.event_type = 'EnrichmentLeaseClaimed'
+              AND json_extract(e.payload_json, '$.execution.workflowId') = r.workflow_id
+              AND json_extract(e.payload_json, '$.execution.runId') = r.temporal_run_id
+              AND json_extract(e.payload_json, '$.activityPhase') = 2
+              AND julianday(e.occurred_at) > julianday(s.updated_at)
+              AND julianday(e.occurred_at) <= julianday(r.finished_at)
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM job_events e WHERE e.tenant_id = s.tenant_id AND (
+              (e.event_type = 'WorkflowCancellationRequested'
+                AND json_extract(e.payload_json, '$.workflowId') = r.workflow_id
+                AND (json_extract(e.payload_json, '$.temporalRunId') IS NULL
+                  OR json_extract(e.payload_json, '$.temporalRunId') = r.temporal_run_id))
+              OR (e.event_type = 'EnrichmentLeaseClaimed'
+                AND json_extract(e.payload_json, '$.execution.workflowId') = r.workflow_id
+                AND json_extract(e.payload_json, '$.execution.runId') = r.temporal_run_id
+                AND json_extract(e.payload_json, '$.activityPhase') >= 3)
+            )
+          )
+        """,
+        (str(LOCAL_TENANT),),
+    ).fetchall()
+    for row in rows:
+        job_id = canonical_job_id(row["job_id"])
+        previous = json.loads(row["metadata_json"])
+        metadata = {
+            "recoveredFromWorkflowId": previous["workflowId"],
+            "recoveredFromRunId": previous["temporalRunId"],
+            "reason": "completed_discovery_consumer_handoff",
+        }
+        set_stage_state(
+            conn,
+            job_id,
+            "enrich",
+            "pending",
+            attempt_count=row["attempt_count"],
+            max_attempts=row["max_attempts"],
+            metadata=metadata,
+            validate_transition=False,
+        )
+        record_job_event(
+            conn,
+            job_id,
+            "enrich",
+            "StageReset",
+            message="Released enrichment after a confirmed completed discovery consumer handoff.",
+            payload=metadata,
+        )
+
+
+def _candidates(conn: sqlite3.Connection, *, min_score: int) -> dict[str, list[dict[str, Any]]]:
+    rows = conn.execute(
+        """
+        SELECT j.job_id, j.discovered_at, e.current_status, e.full_description,
+               COALESCE(json_array_length(e.attempts_json), 0) AS enrich_attempts,
+               s.stage, COALESCE(s.state, 'pending') AS state,
+               COALESCE(s.attempt_count, 0) AS attempt_count,
+               COALESCE(s.max_attempts, 5) AS max_attempts,
+               COALESCE(s.retryable, 1) AS retryable, s.error_code,
+               COALESCE(s.updated_at, j.discovered_at) AS updated_at
+        FROM jobs j
+        LEFT JOIN job_enrichments e ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id
+        JOIN job_stage_states s ON s.tenant_id = j.tenant_id AND s.job_id = j.job_id
+        LEFT JOIN posting_snapshot_sets p ON p.tenant_id = j.tenant_id AND p.job_id = j.job_id
+        WHERE j.tenant_id = ? AND s.stage IN ('enrich', 'score', 'tailor', 'cover')
+          AND COALESCE(p.latest_active_state, '') NOT IN ('closed', 'expired', 'removed', 'location_incompatible')
+          AND NOT EXISTS (
+            SELECT 1 FROM jobctrl_deleted_jobs d
+            WHERE d.tenant_id = j.tenant_id AND d.job_id = j.job_id
+              AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
+          )
+        ORDER BY s.updated_at, j.job_id
+        """,
+        (str(LOCAL_TENANT),),
+    ).fetchall()
+    eligible = {
+        stage: {
+            str(job["job_id"])
+            for job in database.get_jobs_by_stage(conn=conn, stage=f"pending_{stage}", min_score=min_score, limit=0)
+            if str(job["tenant_id"]) == str(LOCAL_TENANT)
+        }
+        for stage in ("score", "tailor", "cover")
+    }
+    result: dict[str, list[dict[str, Any]]] = {stage: [] for stage in _STAGES}
+    for raw in rows:
+        row = dict(raw)
+        stage = row["stage"]
+        if stage == "enrich":
+            if row["current_status"] not in (None, "pending", "failed") or row["full_description"]:
+                continue
+            row["attempt_count"] = max(row["attempt_count"], row["enrich_attempts"])
+        elif row["job_id"] not in eligible[stage]:
+            continue
+        result[stage].append(row)
+    return result
+
+
+def _retry_due(row: dict[str, Any], now: datetime) -> bool:
+    if row["state"] not in {"pending", "failed"} or not row["retryable"]:
+        return False
+    attempts = int(row["attempt_count"])
+    if attempts >= min(5, int(row["max_attempts"])):
+        return False
+    try:
+        updated = datetime.fromisoformat(str(row["updated_at"]).replace("Z", "+00:00"))
+        if updated.tzinfo is None:
+            updated = updated.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return False
+    cooldown = min(1800, 60 * (2**attempts))
+    return (now - updated).total_seconds() >= cooldown
+
+
+async def _reconcile_interrupted_reservations(client: Any, conn: sqlite3.Connection) -> None:
+    """Release unstarted work only after a confirmed, budgeted interruption."""
+    owners = conn.execute(
+        "SELECT DISTINCT stage, json_extract(metadata_json, '$.workflowId') AS workflow_id "
+        "FROM job_stage_states WHERE tenant_id = ? AND stage IN ('enrich', 'score', 'tailor', 'cover') "
+        "AND (state = 'queued' OR (state = 'blocked' AND error_code = 'PREPARATION_RECOVERY_STOPPED')) "
+        "AND json_extract(metadata_json, '$.workflowId') GLOB 'prepare-auto-local-*'",
+        (str(LOCAL_TENANT),),
+    ).fetchall()
+    for owner in owners:
+        workflow_id, stage = owner["workflow_id"], owner["stage"]
+        try:
+            description = await client.get_workflow_handle(workflow_id).describe()
+            if description.status not in {WorkflowExecutionStatus.COMPLETED, WorkflowExecutionStatus.FAILED}:
+                continue
+            history = await client.get_workflow_handle(workflow_id, run_id=description.run_id).fetch_history()
+        except RPCError as exc:
+            if exc.status == RPCStatusCode.NOT_FOUND:
+                continue
+            raise
+        interrupted = await _interrupted_batch(
+            client, history, workflow_id=workflow_id, run_id=description.run_id, stage=stage
+        )
+        if interrupted is not None:
+            batch, started_at, interrupted_at = interrupted
+            _release_interrupted_reservations(
+                conn, batch, run_id=description.run_id, started_at=started_at, interrupted_at=interrupted_at
+            )
+
+
+async def _interrupted_batch(client: Any, history: Any, *, workflow_id: str, run_id: str, stage: str):
+    """Use the exact Temporal execution, including cancellation intent, as proof."""
+    events = history.events
+    if not events or any(event.HasField("workflow_execution_cancel_requested_event_attributes") for event in events):
+        return None
+    start = events[0].workflow_execution_started_event_attributes
+    if start.workflow_type.name != "JobPipelineWorkflow" or start.original_execution_run_id != run_id:
+        return None
+    inputs = await client.data_converter.decode(start.input.payloads)
+    if len(inputs) != 1 or not isinstance(inputs[0], dict):
+        return None
+    payload = inputs[0]
+    job_ids = payload.get("job_ids")
+    if (
+        payload.get("tenant_id") != str(LOCAL_TENANT)
+        or payload.get("automatic_recovery") is not True
+        or payload.get("stages") != [stage]
+        or not isinstance(job_ids, list)
+        or not 1 <= len(job_ids) <= _BATCH_SIZE
+    ):
+        return None
+    scheduled = {
+        event.event_id: event.activity_task_scheduled_event_attributes
+        for event in events
+        if event.HasField("activity_task_scheduled_event_attributes")
+        and event.activity_task_scheduled_event_attributes.activity_type.name == stage
+    }
+    started = {
+        event.event_id: event.activity_task_started_event_attributes.scheduled_event_id
+        for event in events if event.HasField("activity_task_started_event_attributes")
+    }
+    for event in events:
+        if not event.HasField("activity_task_timed_out_event_attributes"):
+            continue
+        timeout = event.activity_task_timed_out_event_attributes
+        activity_input = scheduled.get(timeout.scheduled_event_id)
+        if (
+            activity_input is None
+            or started.get(timeout.started_event_id) != timeout.scheduled_event_id
+            or timeout.failure.timeout_failure_info.timeout_type not in {
+                TimeoutType.TIMEOUT_TYPE_HEARTBEAT, TimeoutType.TIMEOUT_TYPE_START_TO_CLOSE,
+            }
+        ):
+            continue
+        activity_payloads = await client.data_converter.decode(activity_input.input.payloads)
+        if len(activity_payloads) != 1 or not isinstance(activity_payloads[0], dict):
+            continue
+        if (
+            activity_payloads[0].get("recovery_workflow_id") != workflow_id
+            or activity_payloads[0].get("job_ids") != job_ids
+            or activity_payloads[0].get("workflow_id") != (workflow_id if stage == "enrich" else run_id)
+            or (stage == "enrich" and activity_payloads[0].get("workflow_run_id") != run_id)
+        ):
+            continue
+        batch = RecoveryBatch(
+            workflow_id=workflow_id, stage=stage,
+            job_ids=tuple(canonical_job_id(value) for value in job_ids), min_score=int(payload.get("min_score", 7)),
+        )
+        return batch, events[0].event_time.ToJsonString(), event.event_time.ToJsonString()
+    return None
+
+
+def _release_interrupted_reservations(
+    conn: sqlite3.Connection, batch: RecoveryBatch, *, run_id: str, started_at: str, interrupted_at: str
+) -> None:
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        marks = ",".join("?" for _ in batch.job_ids)
+        # A stage that never consumed a durable attempt remains blocked. This
+        # prevents repeated preflight timeouts from creating unbounded retries.
+        progress = conn.execute(
+            "SELECT 1 FROM job_events consumed JOIN job_events reserved "
+            "ON reserved.tenant_id = consumed.tenant_id AND reserved.job_id = consumed.job_id "
+            "AND reserved.stage = consumed.stage AND reserved.event_type = 'StageQueued' "
+            "JOIN job_stage_states s ON s.tenant_id = consumed.tenant_id "
+            "AND s.job_id = consumed.job_id AND s.stage = consumed.stage "
+            "WHERE consumed.tenant_id = ? AND consumed.stage = ? "
+            f"AND consumed.job_id IN ({marks}) "
+            "AND json_extract(reserved.payload_json, '$.workflowId') = ? "
+            "AND consumed.event_id > reserved.event_id "
+            "AND consumed.event_type IN ('StageCompleted', 'StageFailed', 'StageExhausted') "
+            "AND s.attempt_count > json_extract(reserved.payload_json, '$.attemptCount') "
+            "AND (json_extract(consumed.payload_json, '$.workflowId') = ? OR "
+            "(json_extract(consumed.payload_json, '$.workflowId') = ? "
+            "AND julianday(consumed.occurred_at) BETWEEN julianday(?) AND julianday(?))) LIMIT 1",
+            (str(LOCAL_TENANT), batch.stage, *batch.job_ids, batch.workflow_id,
+             run_id, batch.workflow_id, started_at, interrupted_at),
+        ).fetchone()
+        if progress is not None:
+            eligible = {row["job_id"] for row in _candidates(conn, min_score=batch.min_score)[batch.stage]}
+            rows = conn.execute(
+                "SELECT job_id, attempt_count, max_attempts, version FROM job_stage_states "
+                f"WHERE tenant_id = ? AND stage = ? AND job_id IN ({marks}) "
+                "AND attempt_count < MIN(5, max_attempts) "
+                "AND COALESCE(json_array_length(blocked_by_json), 0) = 0 "
+                "AND ((state = 'queued' AND retryable = 1 "
+                "AND json_extract(metadata_json, '$.automaticPreparation.workflowId') = ?) "
+                "OR (state = 'blocked' AND error_code = 'PREPARATION_RECOVERY_STOPPED' "
+                "AND json_extract(metadata_json, '$.workflowId') = ?))",
+                (str(LOCAL_TENANT), batch.stage, *batch.job_ids, batch.workflow_id, batch.workflow_id),
+            ).fetchall()
+            for row in rows:
+                if row["job_id"] not in eligible:
+                    continue
+                job_id = canonical_job_id(row["job_id"])
+                metadata = {"recoveredFromWorkflowId": batch.workflow_id, "recoveredFromRunId": run_id,
+                            "reason": "interrupted_preparation_reservation"}
+                set_stage_state(
+                    conn, job_id, batch.stage, "pending", attempt_count=row["attempt_count"],
+                    max_attempts=row["max_attempts"], retryable=True, metadata=metadata,
+                    validate_transition=False, expected_version=row["version"],
+                )
+                record_job_event(
+                    conn, job_id, batch.stage, "StageReset",
+                    message="Unstarted preparation released after its batch activity timed out.", payload=metadata,
+                )
+        conn.commit()
+    except BaseException:
+        conn.rollback()
+        raise
+
+
+def automatic_recovery_job_ids(payload: Any, stage: str) -> tuple[JobId, ...]:
+    """Recheck cancellation, deletion, prerequisites and ownership at execution."""
+    workflow_id = payload.recovery_workflow_id
+    if not workflow_id:
+        return payload.job_ids
+    conn = database.get_connection()
+    candidates = _candidates(conn, min_score=getattr(payload, "min_score", 7))[stage]
+    eligible = {
+        row["job_id"]
+        for row in candidates
+        if row["state"] == "queued" and row["retryable"] and row["attempt_count"] < min(5, row["max_attempts"])
+    }
+    owned = {
+        str(row[0])
+        for row in conn.execute(
+            "SELECT job_id FROM job_stage_states WHERE tenant_id = ? AND stage = ? "
+            "AND state = 'queued' AND json_extract(metadata_json, '$.automaticPreparation.workflowId') = ?",
+            (payload.tenant_id, stage, workflow_id),
+        ).fetchall()
+    }
+    return tuple(job_id for job_id in payload.job_ids if str(job_id) in eligible & owned)
+
+
+def _settle_closed_reservation(conn: sqlite3.Connection, batch: RecoveryBatch, status: Any) -> None:
+    """Stop unconsumed reservations; a preflight failure must not launch a loop."""
+    canceled = status == WorkflowExecutionStatus.CANCELED
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        rows = conn.execute(
+            "SELECT job_id, attempt_count, max_attempts FROM job_stage_states "
+            "WHERE tenant_id = ? AND stage = ? AND state = 'queued' "
+            "AND json_extract(metadata_json, '$.automaticPreparation.workflowId') = ?",
+            (str(LOCAL_TENANT), batch.stage, batch.workflow_id),
+        ).fetchall()
+        for row in rows:
+            job_id = canonical_job_id(row["job_id"])
+            set_stage_state(
+                conn,
+                job_id,
+                batch.stage,
+                "canceled" if canceled else "blocked",
+                attempt_count=row["attempt_count"],
+                max_attempts=row["max_attempts"],
+                error_code="WORKFLOW_CANCELED" if canceled else "PREPARATION_RECOVERY_STOPPED",
+                error_message="Automatic preparation stopped before consuming this reservation.",
+                retryable=False,
+                next_action=f"retry {batch.stage}",
+                metadata={"workflowId": batch.workflow_id},
+                validate_transition=False,
+            )
+            record_job_event(
+                conn,
+                job_id,
+                batch.stage,
+                "StageCanceled" if canceled else "StageBlocked",
+                level="warning",
+                message="Automatic preparation reservation stopped with its workflow.",
+                payload={"workflowId": batch.workflow_id, "reason": "automatic_preparation_stopped"},
+            )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise

--- a/workers/automation/src/jobctrl/pipeline/automatic_preparation.py
+++ b/workers/automation/src/jobctrl/pipeline/automatic_preparation.py
@@ -197,6 +197,10 @@ async def _reconcile_stopped_enrichment_owners(client: Any, conn: sqlite3.Connec
                     state = "succeeded"
                     attempts = max(attempts, aggregate.attempt_count)
                 else:
+                    # An unclaimed row consumed no attempt. Leave its durable
+                    # reservation for timeout recovery or closed-batch blocking.
+                    if row["state"] == "queued":
+                        continue
                     if row["state"] == "running" and (aggregate is None or not aggregate.is_failed):
                         aggregate = aggregate or JobEnrichment.empty(
                             tenant_id=LOCAL_TENANT, job_id=job_id, updated_at=now

--- a/workers/automation/src/jobctrl/pipeline/workflow.py
+++ b/workers/automation/src/jobctrl/pipeline/workflow.py
@@ -89,6 +89,7 @@ class JobPipelineWorkflowInput:
     model: str = "default"
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
     continuous: bool = False
+    automatic_recovery: bool = False
 
     def __post_init__(self) -> None:
         if self.job_id is not None:
@@ -267,12 +268,12 @@ class JobPipelineWorkflow:
             try:
                 result = await _execute_stage(stage, stage_payload)
             except CancelledError:
-                if stage in {"tailor", "cover"}:
+                if stage in {"tailor", "cover"} or (stage == "score" and payload.automatic_recovery):
                     await _cancel_material_stage_state(stage, stage_payload)
                 raise
             except ActivityError as exc:
                 if _activity_error_was_cancelled(exc):
-                    if stage in {"tailor", "cover"}:
+                    if stage in {"tailor", "cover"} or (stage == "score" and payload.automatic_recovery):
                         await _cancel_material_stage_state(stage, stage_payload)
                     raise CancelledError("Workflow canceled by request.") from exc
                 if stage in {"score", "tailor", "cover"}:
@@ -444,10 +445,11 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 job_ids=_selected_job_ids(payload),
                 workflow_id=workflow_id,
                 workflow_run_id=workflow_run_id,
+                recovery_workflow_id=workflow_id if payload.automatic_recovery else None,
             ),
             start_to_close_timeout=_activity_timeout(payload),
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
-            retry_policy=_ENRICH_RETRY,
+            retry_policy=replace(_ENRICH_RETRY, maximum_attempts=1) if payload.automatic_recovery else _ENRICH_RETRY,
         )
     if stage == "score":
         return await workflow.execute_activity(
@@ -464,10 +466,11 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 current_policy_only=payload.score_current_policy_only,
                 llm_model=payload.llm_model,
                 workflow_id=activity_owner,
+                recovery_workflow_id=workflow_id if payload.automatic_recovery else None,
             ),
             start_to_close_timeout=_activity_timeout(payload),
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
-            retry_policy=_SCORE_RETRY,
+            retry_policy=replace(_SCORE_RETRY, maximum_attempts=1) if payload.automatic_recovery else _SCORE_RETRY,
         )
     if stage == "tailor":
         return await workflow.execute_activity(
@@ -494,10 +497,11 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 tailor_judge_min_score=payload.tailor_judge_min_score,
                 llm_model=payload.llm_model,
                 workflow_id=activity_owner,
+                recovery_workflow_id=workflow_id if payload.automatic_recovery else None,
             ),
             start_to_close_timeout=_activity_timeout(payload),
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
-            retry_policy=_TAILOR_RETRY,
+            retry_policy=replace(_TAILOR_RETRY, maximum_attempts=1) if payload.automatic_recovery else _TAILOR_RETRY,
         )
     if stage == "cover":
         return await workflow.execute_activity(
@@ -514,10 +518,11 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 job_ids=_selected_job_ids(payload),
                 llm_model=payload.llm_model,
                 workflow_id=activity_owner,
+                recovery_workflow_id=workflow_id if payload.automatic_recovery else None,
             ),
             start_to_close_timeout=_activity_timeout(payload),
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
-            retry_policy=_COVER_RETRY,
+            retry_policy=replace(_COVER_RETRY, maximum_attempts=1) if payload.automatic_recovery else _COVER_RETRY,
         )
     if stage == "apply":
         apply_job_id = _apply_child_job_id(payload)
@@ -623,6 +628,7 @@ def _pipeline_input_summary(payload: JobPipelineWorkflowInput) -> dict[str, Any]
         "limit": payload.limit,
         "jobId": str(payload.job_id) if payload.job_id is not None else None,
         "jobIds": [str(job_id) for job_id in payload.job_ids],
+        **({"automaticRecovery": True} if payload.automatic_recovery else {}),
     }
 
 

--- a/workers/automation/src/jobctrl/scoring/activities.py
+++ b/workers/automation/src/jobctrl/scoring/activities.py
@@ -30,6 +30,7 @@ class ScoreActivityInput:
     current_policy_only: bool = False
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
     workflow_id: str | None = None
+    recovery_workflow_id: str | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "job_ids", _canonical_job_ids(self.job_ids))
@@ -210,8 +211,9 @@ def _run_selected_scores(
 ) -> dict[str, Any]:
     from jobctrl.domain.tenant import TenantId
     from jobctrl.scoring.scorer import score_job_by_id
+    from jobctrl.pipeline.automatic_preparation import automatic_recovery_job_ids
 
-    job_ids = _limited_job_ids(payload.job_ids, payload.limit)
+    job_ids = _limited_job_ids(automatic_recovery_job_ids(payload, "score"), payload.limit)
     if payload.dry_run:
         return {
             "status": "ok",
@@ -241,6 +243,15 @@ def _run_selected_scores(
             rescore=payload.rescore,
             llm_model=payload.llm_model,
             workflow_id=payload.workflow_id,
+            **(
+                {
+                    "enforce_workflow_ownership": True,
+                    "cancel_event": cancel_event,
+                    "recovery_workflow_id": payload.recovery_workflow_id,
+                }
+                if payload.recovery_workflow_id
+                else {}
+            ),
         )
 
     worker_count = max(1, int(payload.workers or 1))

--- a/workers/automation/src/jobctrl/scoring/cover_letter.py
+++ b/workers/automation/src/jobctrl/scoring/cover_letter.py
@@ -51,6 +51,8 @@ from jobctrl.infrastructure.materials import (
 )
 from jobctrl.infrastructure.preparation_recovery import (
     assert_material_activity_commit_allowed,
+    claim_preparation_reservation,
+    owns_preparation_reservation,
 )
 from jobctrl.infrastructure.preparation.sqlite_repository import SqlitePreparationTargetReader
 from jobctrl.infrastructure.scoring import SqliteScoreRepository
@@ -191,6 +193,7 @@ def cover_letter_by_id(
     tenant_id: TenantId = LOCAL_TENANT,
     workflow_id: str | None = None,
     cancel_event: threading.Event | None = None,
+    recovery_workflow_id: str | None = None,
 ) -> dict:
     """Generate exactly one eligible cover letter by tenant-scoped JobId."""
     stable_job_id = canonical_job_id(str(job_id))
@@ -214,6 +217,7 @@ def cover_letter_by_id(
         job_id=stable_job_id,
         job=job,
         min_score=min_score,
+        recovery_workflow_id=recovery_workflow_id,
     )
     if eligibility_reason is not None:
         return _skipped_result(
@@ -265,49 +269,57 @@ def cover_letter_by_id(
         pdf_renderer = _build_pdf_renderer()
 
     url = str(job.get("url") or "")
-    ensure_job_stage_rows(
-        conn,
-        stable_job_id,
-        tenant_id=tenant_id,
-        discovered_at=job.get("discovered_at"),
-    )
-    started_at = utc_now()
-    prior_attempts = _cover_attempt_count(
-        conn,
-        tenant_id=tenant_id,
-        job_id=stable_job_id,
-    )
-    current_attempt = prior_attempts + 1
-    set_stage_state(
-        conn,
-        stable_job_id,
-        "cover",
-        "running",
-        tenant_id=tenant_id,
-        # Owner recovery advances an interrupted execution. Preserve the
-        # completed count while running so timeout and normal completion each
-        # count this execution exactly once.
-        attempt_count=prior_attempts,
-        started_at=started_at,
-        metadata=(
-            {
-                "activityOwner": workflow_id,
-                "attemptCountBasis": "completed",
-            }
-            if workflow_id
-            else None
-        ),
-        validate_transition=False,
-    )
-    record_job_event(
-        conn,
-        stable_job_id,
-        "cover",
-        "StageStarted",
-        tenant_id=tenant_id,
-        message="Cover letter generation started",
-    )
-    conn.commit()
+    if recovery_workflow_id:
+        conn.commit()
+    with claim_preparation_reservation(
+        conn, tenant_id=tenant_id, job_id=stable_job_id,
+        stage="cover", workflow_id=recovery_workflow_id, cancel_event=cancel_event,
+    ):
+        ensure_job_stage_rows(
+            conn,
+            stable_job_id,
+            tenant_id=tenant_id,
+            discovered_at=job.get("discovered_at"),
+        )
+        started_at = utc_now()
+        prior_attempts = _cover_attempt_count(
+            conn,
+            tenant_id=tenant_id,
+            job_id=stable_job_id,
+        )
+        current_attempt = prior_attempts + 1
+        set_stage_state(
+            conn,
+            stable_job_id,
+            "cover",
+            "running",
+            tenant_id=tenant_id,
+            # Owner recovery advances an interrupted execution. Preserve the
+            # completed count while running so timeout and normal completion each
+            # count this execution exactly once.
+            attempt_count=prior_attempts,
+            started_at=started_at,
+            metadata=(
+                {
+                    "activityOwner": workflow_id,
+                    "attemptCountBasis": "completed",
+                    **({"automaticRecovery": True, "workflowId": recovery_workflow_id, "temporalRunId": workflow_id}
+                       if recovery_workflow_id else {}),
+                }
+                if workflow_id
+                else None
+            ),
+            validate_transition=False,
+        )
+        record_job_event(
+            conn,
+            stable_job_id,
+            "cover",
+            "StageStarted",
+            tenant_id=tenant_id,
+            message="Cover letter generation started",
+        )
+        conn.commit()
 
     def commit_guard() -> None:
         assert_material_activity_commit_allowed(
@@ -536,6 +548,7 @@ def _cover_eligibility_reason(
     job_id: JobId,
     job: dict,
     min_score: int,
+    recovery_workflow_id: str | None = None,
 ) -> str | None:
     """Return the durable admission reason that prevents cover generation."""
     if not str(job.get("full_description") or "").strip():
@@ -596,7 +609,10 @@ def _cover_eligibility_reason(
             return None
         if cover_state == "exhausted" or attempt_count >= _COVER_MAX_ATTEMPTS:
             return "cover_exhausted"
-        if cover_state not in {"pending", "running", "failed", "stale"}:
+        owns_queue = cover_state == "queued" and owns_preparation_reservation(
+            conn, tenant_id=tenant_id, job_id=job_id, stage="cover", workflow_id=recovery_workflow_id,
+        )
+        if cover_state not in {"pending", "running", "failed", "stale"} and not owns_queue:
             return "cover_not_retryable"
 
     score = SqliteScoreRepository(conn).load(tenant_id, job_id)

--- a/workers/automation/src/jobctrl/scoring/scorer.py
+++ b/workers/automation/src/jobctrl/scoring/scorer.py
@@ -730,6 +730,9 @@ def score_job_by_id(
     analyze_use_case: AnalyzeJobUseCaseLike | None = None,
     require_employer_analysis: bool = True,
     workflow_id: str | None = None,
+    enforce_workflow_ownership: bool = False,
+    cancel_event: Any | None = None,
+    recovery_workflow_id: str | None = None,
 ) -> ScoreJobOutcome:
     """Score exactly one enriched job by tenant-scoped canonical JobId.
 
@@ -756,6 +759,48 @@ def score_job_by_id(
     if not job.get("full_description"):
         return ScoreJobOutcome(ok=False, score=None, error=f"Job is not enriched: {stable_job_id}")
 
+    owned_metadata = None
+    if enforce_workflow_ownership:
+        if not workflow_id or not recovery_workflow_id:
+            raise ValueError("Owned scoring requires the reserved workflow and activity owner")
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            "SELECT state, json_extract(metadata_json, '$.automaticPreparation.workflowId') "
+            "FROM job_stage_states WHERE tenant_id = ? AND job_id = ? AND stage = 'score'",
+            (str(tenant_id), str(stable_job_id)),
+        ).fetchone()
+        if (
+            row is None
+            or row[0] != "queued"
+            or row[1] != recovery_workflow_id
+            or (cancel_event is not None and cancel_event.is_set())
+        ):
+            conn.rollback()
+            raise RuntimeError("Score activity no longer owns its queued reservation")
+        owned_metadata = _score_activity_metadata(
+            conn,
+            tenant_id=tenant_id,
+            job_id=stable_job_id,
+            workflow_id=workflow_id,
+            rescore=rescore,
+        )
+        owned_metadata["automaticRecovery"] = True
+        owned_metadata["workflowId"] = recovery_workflow_id
+        owned_metadata["temporalRunId"] = workflow_id
+        set_stage_state(
+            conn,
+            stable_job_id,
+            "score",
+            "running",
+            tenant_id=tenant_id,
+            attempt_count=_score_attempt_count(conn, tenant_id=tenant_id, job_id=stable_job_id),
+            started_at=utc_now(),
+            metadata=owned_metadata,
+            validate_transition=False,
+        )
+        record_job_event(conn, stable_job_id, "score", "StageStarted", tenant_id=tenant_id, message="Scoring started")
+        conn.commit()
+
     if profile_snapshot is None:
         profile_snapshot = get_profile_repository().load_snapshot(tenant_id)
     if resume_text is None:
@@ -767,6 +812,12 @@ def score_job_by_id(
         criteria = LocalScoringCriteriaProvider().load(profile_snapshot)
     if repository is None:
         repository = SqliteScoreRepository(conn)
+    if enforce_workflow_ownership:
+        # Resolve the SQLite companion before the ownership decorator hides
+        # its concrete type from the use-case factory's default wiring.
+        if requirement_fit_repository is None and isinstance(repository, SqliteScoreRepository):
+            requirement_fit_repository = SqliteRequirementFitReportRepository(repository.connection)
+        repository = _OwnedScoreRepository(repository, conn, workflow_id, cancel_event)
     if policy_repository is None:
         policy_repository = SqliteScoringPolicyRepository(conn)
     existing = repository.load(tenant_id, stable_job_id)
@@ -787,7 +838,7 @@ def score_job_by_id(
             job=job,
             source_score=reusable_repost_score,
         )
-        if outcome.ok and outcome.score is not None:
+        if outcome.ok and outcome.score is not None and not enforce_workflow_ownership:
             _record_score_stage_succeeded(
                 conn,
                 job=job,
@@ -798,53 +849,56 @@ def score_job_by_id(
             )
         return outcome
     if existing is not None and not rescore:
-        _ensure_existing_score_stage_succeeded(
-            conn,
-            job=job,
-            score=existing,
-            tenant_id=tenant_id,
-        )
+        if not enforce_workflow_ownership:
+            _ensure_existing_score_stage_succeeded(
+                conn,
+                job=job,
+                score=existing,
+                tenant_id=tenant_id,
+            )
         return ScoreJobOutcome(ok=True, score=existing)
-    ensure_job_stage_rows(
-        conn,
-        stable_job_id,
-        tenant_id=tenant_id,
-        discovered_at=job.get("discovered_at"),
-    )
+    if not enforce_workflow_ownership:
+        ensure_job_stage_rows(
+            conn,
+            stable_job_id,
+            tenant_id=tenant_id,
+            discovered_at=job.get("discovered_at"),
+        )
     started_at = utc_now()
-    metadata = _score_activity_metadata(
+    metadata = owned_metadata or _score_activity_metadata(
         conn,
         tenant_id=tenant_id,
         job_id=stable_job_id,
         workflow_id=workflow_id,
         rescore=rescore,
     )
-    set_stage_state(
-        conn,
-        stable_job_id,
-        "score",
-        "running",
-        tenant_id=tenant_id,
-        # Preserve the attempt counter across re-selection — see
-        # _score_attempt_count; a bare running write would reset it to 0.
-        attempt_count=_score_attempt_count(
+    if not enforce_workflow_ownership:
+        set_stage_state(
             conn,
+            stable_job_id,
+            "score",
+            "running",
             tenant_id=tenant_id,
-            job_id=stable_job_id,
-        ),
-        started_at=started_at,
-        metadata=metadata,
-        validate_transition=False,
-    )
-    record_job_event(
-        conn,
-        stable_job_id,
-        "score",
-        "StageStarted",
-        tenant_id=tenant_id,
-        message="Scoring started",
-    )
-    conn.commit()
+            # Preserve the attempt counter across re-selection — see
+            # _score_attempt_count; a bare running write would reset it to 0.
+            attempt_count=_score_attempt_count(
+                conn,
+                tenant_id=tenant_id,
+                job_id=stable_job_id,
+            ),
+            started_at=started_at,
+            metadata=metadata,
+            validate_transition=False,
+        )
+        record_job_event(
+            conn,
+            stable_job_id,
+            "score",
+            "StageStarted",
+            tenant_id=tenant_id,
+            message="Scoring started",
+        )
+        conn.commit()
 
     if employer_analysis is None:
         try:
@@ -875,6 +929,7 @@ def score_job_by_id(
                 started_at=started_at,
                 metadata=metadata,
                 error=error,
+                cancel_event=cancel_event,
             )
             return ScoreJobOutcome(ok=False, score=None, error=error)
 
@@ -896,6 +951,11 @@ def score_job_by_id(
         require_employer_analysis=require_employer_analysis,
     )
     if outcome.ok and outcome.score is not None:
+        if enforce_workflow_ownership:
+            conn.execute("BEGIN IMMEDIATE")
+            if not _score_activity_may_write(conn, tenant_id, stable_job_id, workflow_id, cancel_event):
+                conn.rollback()
+                return outcome
         finished_at = utc_now()
         set_stage_state(
             conn,
@@ -903,7 +963,11 @@ def score_job_by_id(
             "score",
             "succeeded",
             tenant_id=tenant_id,
-            attempt_count=1,
+            attempt_count=(
+                _score_attempt_count(conn, tenant_id=tenant_id, job_id=stable_job_id) + 1
+                if enforce_workflow_ownership
+                else 1
+            ),
             started_at=started_at,
             finished_at=finished_at,
             metadata=metadata,
@@ -933,8 +997,50 @@ def score_job_by_id(
             started_at=started_at,
             metadata=metadata,
             error=outcome.error or "Scoring failed",
+            cancel_event=cancel_event,
         )
     return outcome
+
+
+class _OwnedScoreRepository:
+    """Fence the actual score commit after provider I/O, under a write lock."""
+
+    def __init__(self, repository, conn, owner, cancel_event):
+        self._repository = repository
+        self._conn = conn
+        self._owner = owner
+        self._cancel_event = cancel_event
+
+    def __getattr__(self, name):
+        return getattr(self._repository, name)
+
+    def save(self, score):
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            if not _score_activity_may_write(
+                self._conn,
+                score.tenant_id,
+                score.job_id,
+                self._owner,
+                self._cancel_event,
+            ):
+                raise RuntimeError("Score activity no longer owns score persistence")
+            self._repository.save(score)
+            self._conn.commit()
+        except BaseException:
+            self._conn.rollback()
+            raise
+
+
+def _score_activity_may_write(conn, tenant_id, job_id, owner, cancel_event) -> bool:
+    if cancel_event is not None and cancel_event.is_set():
+        return False
+    row = conn.execute(
+        "SELECT state, json_extract(metadata_json, '$.activityOwner') FROM job_stage_states "
+        "WHERE tenant_id = ? AND job_id = ? AND stage = 'score'",
+        (str(tenant_id), str(job_id)),
+    ).fetchone()
+    return row is not None and row[0] == "running" and row[1] == owner
 
 
 def _ensure_existing_score_stage_succeeded(
@@ -1059,12 +1165,18 @@ def _record_score_stage_failed(
     job: dict[str, Any],
     tenant_id: TenantId,
     started_at: str,
-    metadata: dict[str, Any],
+    metadata: dict[str, Any] | None,
     error: str,
+    cancel_event: Any | None = None,
 ) -> None:
     """Persist one bounded, retryable scoring attempt failure."""
 
     job_id = canonical_job_id(str(job["job_id"]))
+    if metadata and metadata.get("automaticRecovery"):
+        conn.execute("BEGIN IMMEDIATE")
+        if not _score_activity_may_write(conn, tenant_id, job_id, metadata.get("activityOwner"), cancel_event):
+            conn.rollback()
+            return
     finished_at = utc_now()
     set_stage_state(
         conn,
@@ -1262,8 +1374,7 @@ def _is_usable_employer_analysis(
     expected_snapshot_hash = compute_snapshot_hash(build_jd_snapshot(job))
     if analysis.snapshot_hash != expected_snapshot_hash:
         log.info(
-            "Ignoring employer analysis generation %s for tenant=%s job=%s because its "
-            "posting snapshot is stale",
+            "Ignoring employer analysis generation %s for tenant=%s job=%s because its posting snapshot is stale",
             analysis.generation,
             tenant_id,
             job_id,

--- a/workers/automation/src/jobctrl/scoring/scorer.py
+++ b/workers/automation/src/jobctrl/scoring/scorer.py
@@ -776,7 +776,7 @@ def score_job_by_id(
             or (cancel_event is not None and cancel_event.is_set())
         ):
             conn.rollback()
-            raise RuntimeError("Score activity no longer owns its queued reservation")
+            return ScoreJobOutcome(ok=False, score=None, error="Score reservation no longer owned")
         owned_metadata = _score_activity_metadata(
             conn,
             tenant_id=tenant_id,
@@ -838,7 +838,7 @@ def score_job_by_id(
             job=job,
             source_score=reusable_repost_score,
         )
-        if outcome.ok and outcome.score is not None and not enforce_workflow_ownership:
+        if outcome.ok and outcome.score is not None:
             _record_score_stage_succeeded(
                 conn,
                 job=job,
@@ -846,10 +846,17 @@ def score_job_by_id(
                 tenant_id=tenant_id,
                 started_at=utc_now(),
                 validate_transition=False,
+                metadata=owned_metadata,
+                cancel_event=cancel_event,
             )
         return outcome
     if existing is not None and not rescore:
-        if not enforce_workflow_ownership:
+        if enforce_workflow_ownership:
+            _record_score_stage_succeeded(
+                conn, job=job, score=existing, tenant_id=tenant_id,
+                metadata=owned_metadata, cancel_event=cancel_event,
+            )
+        else:
             _ensure_existing_score_stage_succeeded(
                 conn,
                 job=job,
@@ -951,44 +958,11 @@ def score_job_by_id(
         require_employer_analysis=require_employer_analysis,
     )
     if outcome.ok and outcome.score is not None:
-        if enforce_workflow_ownership:
-            conn.execute("BEGIN IMMEDIATE")
-            if not _score_activity_may_write(conn, tenant_id, stable_job_id, workflow_id, cancel_event):
-                conn.rollback()
-                return outcome
-        finished_at = utc_now()
-        set_stage_state(
-            conn,
-            stable_job_id,
-            "score",
-            "succeeded",
-            tenant_id=tenant_id,
-            attempt_count=(
-                _score_attempt_count(conn, tenant_id=tenant_id, job_id=stable_job_id) + 1
-                if enforce_workflow_ownership
-                else 1
-            ),
-            started_at=started_at,
-            finished_at=finished_at,
-            metadata=metadata,
+        _record_score_stage_succeeded(
+            conn, job=job, score=outcome.score, tenant_id=tenant_id,
+            started_at=started_at, metadata=metadata, cancel_event=cancel_event,
+            validate_transition=True,
         )
-        record_job_event(
-            conn,
-            stable_job_id,
-            "score",
-            "StageCompleted",
-            tenant_id=tenant_id,
-            message=f"Fit score {outcome.score.fit_score.value}/10",
-            payload={"keywords": list(outcome.score.matched_keywords)},
-        )
-        _sync_score_eligibility_stage_state(
-            conn,
-            tenant_id=tenant_id,
-            job_id=outcome.score.job_id,
-            score=outcome.score,
-            now=finished_at,
-        )
-        conn.commit()
     else:
         _record_score_stage_failed(
             conn,
@@ -1119,8 +1093,16 @@ def _record_score_stage_succeeded(
     started_at: str | None = None,
     finished_at: str | None = None,
     validate_transition: bool = False,
+    metadata: dict[str, Any] | None = None,
+    cancel_event: Any | None = None,
 ) -> None:
     job_id = canonical_job_id(str(score.job_id))
+    owned = bool(metadata and metadata.get("automaticRecovery"))
+    if owned:
+        conn.execute("BEGIN IMMEDIATE")
+        if not _score_activity_may_write(conn, tenant_id, job_id, metadata.get("activityOwner"), cancel_event):
+            conn.rollback()
+            return
     finished_at = finished_at or utc_now()
     ensure_job_stage_rows(
         conn,
@@ -1134,10 +1116,11 @@ def _record_score_stage_succeeded(
         "score",
         "succeeded",
         tenant_id=tenant_id,
-        attempt_count=1,
+        attempt_count=_score_attempt_count(conn, tenant_id=tenant_id, job_id=job_id) + 1 if owned else 1,
         started_at=started_at or finished_at,
         finished_at=finished_at,
         validate_transition=validate_transition,
+        metadata=metadata,
     )
     record_job_event(
         conn,

--- a/workers/automation/src/jobctrl/scoring/tailor.py
+++ b/workers/automation/src/jobctrl/scoring/tailor.py
@@ -71,6 +71,8 @@ from jobctrl.infrastructure.materials import (
 from jobctrl.infrastructure.preparation import SqlitePreparationTargetReader
 from jobctrl.infrastructure.preparation_recovery import (
     assert_material_activity_commit_allowed,
+    claim_preparation_reservation,
+    owns_preparation_reservation,
     stage_completed_by_activity_owner,
 )
 from jobctrl.infrastructure.scoring import (
@@ -605,6 +607,7 @@ def tailor_job_by_id(
     allow_low_fit_override: bool = False,
     workflow_id: str | None = None,
     cancel_event: threading.Event | None = None,
+    recovery_workflow_id: str | None = None,
 ) -> dict:
     """Tailor one active, eligible JobId for its tenant-scoped preparation step.
 
@@ -617,6 +620,10 @@ def tailor_job_by_id(
         raise RuntimeError("tailor activity canceled before dispatch")
     stable_job_id = canonical_job_id(str(job_id))
     conn = get_connection()
+    if recovery_workflow_id and not owns_preparation_reservation(
+        conn, tenant_id=tenant_id, job_id=stable_job_id, stage="tailor", workflow_id=recovery_workflow_id,
+    ):
+        raise RuntimeError("tailor activity no longer owns its queued reservation")
     target_reader = SqlitePreparationTargetReader(conn)
     target = target_reader.load(tenant_id, stable_job_id)
     if target is None:
@@ -683,6 +690,7 @@ def tailor_job_by_id(
         min_score=min_score,
         retailor=retailor,
         allow_low_fit_override=allow_low_fit_override,
+        recovery_workflow_id=recovery_workflow_id,
     )
     if job is None:
         if _record_tailor_enrichment_block(
@@ -733,48 +741,56 @@ def tailor_job_by_id(
 
     if cancel_event is not None and cancel_event.is_set():
         raise RuntimeError("tailor activity canceled before dispatch")
-    ensure_job_stage_rows(
-        conn,
-        stable_job_id,
-        tenant_id=tenant_id,
-        discovered_at=job.get("discovered_at"),
-    )
-    started_at = utc_now()
-    prior_attempts = _tailor_attempt_count(
-        conn,
-        tenant_id=tenant_id,
-        job_id=stable_job_id,
-    )
-    current_attempt = prior_attempts + 1
-    metadata = _tailor_activity_metadata(
-        SqliteMaterialsRepository(conn),
-        tenant_id=tenant_id,
-        job_id=stable_job_id,
-        workflow_id=workflow_id,
-        retailor=retailor,
-    )
-    set_stage_state(
-        conn,
-        stable_job_id,
-        "tailor",
-        "running",
-        tenant_id=tenant_id,
-        # Owner recovery increments an interrupted running row, so the start
-        # write must preserve the completed count instead of pre-incrementing.
-        attempt_count=prior_attempts,
-        started_at=started_at,
-        metadata=metadata,
-        validate_transition=False,
-    )
-    record_job_event(
-        conn,
-        stable_job_id,
-        "tailor",
-        "StageStarted",
-        tenant_id=tenant_id,
-        message="Tailoring started",
-    )
-    conn.commit()
+    if recovery_workflow_id:
+        conn.commit()
+    with claim_preparation_reservation(
+        conn, tenant_id=tenant_id, job_id=stable_job_id,
+        stage="tailor", workflow_id=recovery_workflow_id, cancel_event=cancel_event,
+    ):
+        ensure_job_stage_rows(
+            conn,
+            stable_job_id,
+            tenant_id=tenant_id,
+            discovered_at=job.get("discovered_at"),
+        )
+        started_at = utc_now()
+        prior_attempts = _tailor_attempt_count(
+            conn,
+            tenant_id=tenant_id,
+            job_id=stable_job_id,
+        )
+        current_attempt = prior_attempts + 1
+        metadata = _tailor_activity_metadata(
+            SqliteMaterialsRepository(conn),
+            tenant_id=tenant_id,
+            job_id=stable_job_id,
+            workflow_id=workflow_id,
+            retailor=retailor,
+        )
+        if recovery_workflow_id:
+            metadata.update(automaticRecovery=True, workflowId=recovery_workflow_id, temporalRunId=workflow_id)
+        set_stage_state(
+            conn,
+            stable_job_id,
+            "tailor",
+            "running",
+            tenant_id=tenant_id,
+            # Owner recovery increments an interrupted running row, so the start
+            # write must preserve the completed count instead of pre-incrementing.
+            attempt_count=prior_attempts,
+            started_at=started_at,
+            metadata=metadata,
+            validate_transition=False,
+        )
+        record_job_event(
+            conn,
+            stable_job_id,
+            "tailor",
+            "StageStarted",
+            tenant_id=tenant_id,
+            message="Tailoring started",
+        )
+        conn.commit()
 
     def commit_guard() -> None:
         assert_material_activity_commit_allowed(
@@ -1347,6 +1363,7 @@ def _load_tailor_eligible_job_by_id(
     min_score: int,
     retailor: bool,
     allow_low_fit_override: bool = False,
+    recovery_workflow_id: str | None = None,
 ) -> dict | None:
     stable_job_id = canonical_job_id(str(job_id))
     if not str(job.get("full_description") or "").strip():
@@ -1407,7 +1424,10 @@ def _load_tailor_eligible_job_by_id(
         attempt_count = int(tailor_stage["attempt_count"] or 0)
         if tailor_state == "exhausted" or attempt_count >= MAX_ATTEMPTS:
             return None
-        if not retailor and tailor_state not in {
+        owns_queue = tailor_state == "queued" and owns_preparation_reservation(
+            conn, tenant_id=tenant_id, job_id=stable_job_id, stage="tailor", workflow_id=recovery_workflow_id,
+        )
+        if not retailor and not owns_queue and tailor_state not in {
             "pending",
             "running",
             "failed",

--- a/workers/automation/src/jobctrl/scoring/tailor.py
+++ b/workers/automation/src/jobctrl/scoring/tailor.py
@@ -623,7 +623,7 @@ def tailor_job_by_id(
     if recovery_workflow_id and not owns_preparation_reservation(
         conn, tenant_id=tenant_id, job_id=stable_job_id, stage="tailor", workflow_id=recovery_workflow_id,
     ):
-        raise RuntimeError("tailor activity no longer owns its queued reservation")
+        return {"job_id": str(stable_job_id), "status": "skipped", "reason": "reservation_lost"}
     target_reader = SqlitePreparationTargetReader(conn)
     target = target_reader.load(tenant_id, stable_job_id)
     if target is None:

--- a/workers/automation/src/jobctrl/state.py
+++ b/workers/automation/src/jobctrl/state.py
@@ -385,9 +385,7 @@ def reconcile_dependency_blockers(
             terminal_clause = ""
             params: list[Any] = [str(tenant_id), downstream, *messages]
             if terminal_codes:
-                terminal_clause = (
-                    f" OR downstream.error_code IN ({', '.join('?' for _ in terminal_codes)})"
-                )
+                terminal_clause = f" OR downstream.error_code IN ({', '.join('?' for _ in terminal_codes)})"
                 params.extend(terminal_codes)
             job_filter = ""
             if stable_job_id is not None:
@@ -445,7 +443,92 @@ def reconcile_dependency_blockers(
                     },
                 )
                 repaired += 1
+    if "score" in completed_stages:
+        repaired += _reconcile_requirement_fit_blockers(conn, tenant_id=tenant_id, job_id=stable_job_id, now=updated_at)
     return repaired
+
+
+def _reconcile_requirement_fit_blockers(
+    conn,
+    *,
+    tenant_id: TenantId,
+    job_id: JobId | None,
+    now: str,
+) -> int:
+    """Release the missing-evidence condition only after its canonical repair."""
+    scope = "tenant_id = ? AND stage = 'tailor' AND state = 'blocked' "
+    scope += "AND error_code = 'REQUIREMENT_FIT_MISSING' AND retryable = 1"
+    params: list[Any] = [str(tenant_id)]
+    if job_id is not None:
+        scope += " AND job_id = ?"
+        params.append(str(job_id))
+    if conn.execute(f"SELECT 1 FROM job_stage_states WHERE {scope} LIMIT 1", params).fetchone() is None:
+        return 0
+    # Recheck under the same write transaction used for the state transition;
+    # a concurrent cancellation must never be converted back to pending.
+    if not conn.in_transaction:
+        conn.execute("BEGIN IMMEDIATE")
+    rows = conn.execute(
+        f"""
+        SELECT job_id, attempt_count, max_attempts, version
+          FROM job_stage_states AS blocked
+         WHERE {scope}
+           AND attempt_count < max_attempts
+           AND json_array_length(blocked_by_json) = 1
+           AND json_extract(blocked_by_json, '$[0]') = 'score'
+           AND EXISTS (
+               SELECT 1 FROM job_stage_states AS upstream
+                WHERE upstream.tenant_id = blocked.tenant_id
+                  AND upstream.job_id = blocked.job_id
+                  AND upstream.stage = 'score' AND upstream.state = 'succeeded'
+           )
+           AND EXISTS (
+               SELECT 1 FROM job_scores AS score
+               JOIN job_requirement_fit_reports AS report
+                 ON report.tenant_id = score.tenant_id AND report.job_id = score.job_id
+                AND report.score_version = score.version
+                WHERE score.tenant_id = blocked.tenant_id AND score.job_id = blocked.job_id
+                  AND score.version = (SELECT MAX(version) FROM job_scores
+                       WHERE tenant_id = blocked.tenant_id AND job_id = blocked.job_id)
+                  AND report.employer_analysis_generation = (SELECT MAX(generation)
+                       FROM job_employer_analysis
+                       WHERE tenant_id = blocked.tenant_id AND job_id = blocked.job_id)
+                  AND report.profile_snapshot_version =
+                       json_extract(score.trace_json, '$.profile_snapshot_version')
+                  AND EXISTS (SELECT 1 FROM job_requirement_fit_items AS item
+                       WHERE item.tenant_id = report.tenant_id AND item.job_id = report.job_id
+                         AND item.score_version = report.score_version)
+           )
+           AND NOT EXISTS (SELECT 1 FROM job_materials_artifacts AS artifact
+                WHERE artifact.tenant_id = blocked.tenant_id AND artifact.job_id = blocked.job_id
+                  AND artifact.artifact_type = 'tailored_resume' AND artifact.status = 'approved'
+                  AND artifact.superseded_at IS NULL)
+        """,
+        params,
+    ).fetchall()
+    for row in rows:
+        stable_job_id = canonical_job_id(str(row["job_id"]))
+        set_stage_state(
+            conn,
+            stable_job_id,
+            "tailor",
+            "pending",
+            tenant_id=tenant_id,
+            attempt_count=int(row["attempt_count"]),
+            max_attempts=int(row["max_attempts"]),
+            expected_version=int(row["version"]),
+        )
+        record_job_event(
+            conn,
+            stable_job_id,
+            "tailor",
+            "StageReset",
+            tenant_id=tenant_id,
+            message="Tailoring unblocked after requirement-fit evidence was restored.",
+            occurred_at=now,
+            payload={"reason": "requirement_fit_restored", "upstreamStage": "score"},
+        )
+    return len(rows)
 
 
 def reconcile_tailor_terminal_dependents(
@@ -489,15 +572,11 @@ def reconcile_tailor_terminal_dependents(
         upstream_error_code = str(terminal["error_code"] or "") or None
         error_code = f"UPSTREAM_TAILOR_{upstream_state.upper()}"
         next_action = (
-            "Reset Tailor's attempt budget and retry Tailor."
-            if upstream_state == "exhausted"
-            else "Retry Tailor."
+            "Reset Tailor's attempt budget and retry Tailor." if upstream_state == "exhausted" else "Retry Tailor."
         )
         for downstream in ("cover", "apply"):
             display_name = "Cover letter" if downstream == "cover" else "Apply"
-            message = (
-                f"{display_name} cannot start because Tailor is {upstream_state}."
-            )
+            message = f"{display_name} cannot start because Tailor is {upstream_state}."
             metadata_json = _json_dumps(
                 {
                     "reason": "upstream_tailor_terminal",
@@ -627,9 +706,7 @@ def reconcile_score_eligibility_blockers(
         stage = str(row["stage"])
         state = str(row["state"])
         if state in _TERMINAL_DOWNSTREAM_STATES and not (
-            state == "skipped"
-            and str(row["error_code"] or "")
-            == SCORE_THRESHOLD_SKIPPED_ERROR_CODE
+            state == "skipped" and str(row["error_code"] or "") == SCORE_THRESHOLD_SKIPPED_ERROR_CODE
         ):
             continue
         attempt_count = int(row["attempt_count"] or 0)
@@ -699,10 +776,7 @@ def reconcile_score_threshold_skips(
             now=updated_at,
         )
 
-    message = (
-        f"Fit score {normalized_fit_score}/10 is below the materials threshold "
-        f"{normalized_min_score}/10."
-    )
+    message = f"Fit score {normalized_fit_score}/10 is below the materials threshold {normalized_min_score}/10."
     next_action = "Lower the materials threshold or record a higher current score."
     metadata = {
         "reason": "score_below_threshold",
@@ -1108,12 +1182,7 @@ def record_job_event(
     identity aliases are removed so untrusted content cannot spoof the
     persisted or published JobId.
     """
-    if not (
-        event_type
-        and event_type.isascii()
-        and event_type.isalnum()
-        and event_type[0].isupper()
-    ):
+    if not (event_type and event_type.isascii() and event_type.isalnum() and event_type[0].isupper()):
         raise ValueError("event_type must be a PascalCase ASCII identifier")
     stable_job_id = canonical_job_id(str(job_id)) if job_id is not None else None
     current_payload = dict(payload or {})

--- a/workers/automation/tests/test_automatic_preparation.py
+++ b/workers/automation/tests/test_automatic_preparation.py
@@ -707,3 +707,54 @@ def test_enrichment_owner_recovery_fences_late_worker_and_counts_attempt(conn, s
         assert aggregate.is_failed
         assert aggregate.last_attempt.error.code == "ENRICH_ACTIVITY_OWNER_STOPPED"
     assert client.describes == [(batch.workflow_id, run_id)]
+
+
+@pytest.mark.parametrize("scraper_release", [False, True])
+def test_unclaimed_enrichment_failure_keeps_one_stopped_reservation(conn, scraper_release):
+    from jobctrl.enrichment.detail import _release_unstarted_enrichment_cohort
+
+    job_id = _job(conn)
+    batch = recovery.reserve_recovery_batch(conn, now=_NOW)
+    conn.execute(
+        "UPDATE job_stage_states SET metadata_json = json_set(metadata_json, '$.temporalRunId', 'run-1') "
+        "WHERE job_id = ? AND stage = 'enrich'", (str(job_id),),
+    )
+    conn.commit()
+    if scraper_release:
+        _release_unstarted_enrichment_cohort(
+            conn, (job_id,), tenant_id=LOCAL_TENANT,
+            workflow_id=batch.workflow_id, workflow_run_id="run-1",
+        )
+    client = _Client()
+    client.statuses[batch.workflow_id] = WorkflowExecutionStatus.FAILED
+    client.statuses[(batch.workflow_id, "run-1")] = WorkflowExecutionStatus.FAILED
+    for _ in range(4):
+        asyncio.run(_tick(client))
+        conn.execute("UPDATE job_stage_states SET updated_at = ?", (_OLD,))
+        conn.commit()
+    row = _stage(conn, job_id)
+    assert row["state"] == "blocked"
+    assert row["error_code"] == "PREPARATION_RECOVERY_STOPPED"
+    assert row["attempt_count"] == 1
+    assert client.starts == []
+    assert conn.execute("SELECT COUNT(*) FROM job_events WHERE event_type = 'StageQueued'").fetchone()[0] == 1
+
+
+@pytest.mark.parametrize("workers", [1, 2])
+def test_material_reservation_loss_at_claim_is_isolated_to_one_job(workers):
+    from jobctrl.infrastructure.preparation_recovery import PreparationReservationLost
+    from jobctrl.materials.executor import run_material_jobs
+
+    revoked, next_job = [canonical_job_id(f"10000000-0000-4000-8000-{i:012d}") for i in (1, 2)]
+    attempted = []
+
+    def run_one(job_id):
+        if job_id == revoked:
+            raise PreparationReservationLost("reservation revoked during admission")
+        attempted.append(job_id)
+        return {"status": "approved"}
+
+    result = run_material_jobs((revoked, next_job), workers=workers, cancel_event=None, stage="tailor", run_one=run_one)
+    assert attempted == [next_job]
+    assert result[0][1]["reason"] == "reservation_lost"
+    assert result[1][1]["status"] == "approved"

--- a/workers/automation/tests/test_automatic_preparation.py
+++ b/workers/automation/tests/test_automatic_preparation.py
@@ -1,0 +1,709 @@
+"""Saved jobs resume without discovery; recovery never overrides a stop decision."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+import json
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+from temporalio.client import WorkflowExecutionStatus
+from temporalio.converter import DataConverter
+from temporalio.common import WorkflowIDConflictPolicy, WorkflowIDReusePolicy
+from temporalio.service import RPCError, RPCStatusCode
+
+from jobctrl.database import init_db
+from jobctrl.domain.identifiers import canonical_job_id
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.pipeline import automatic_preparation as recovery
+from jobctrl.state import ensure_job_stage_rows, record_job_event, set_stage_state
+
+_OLD = "2026-01-01T00:00:00+00:00"
+_NOW = datetime(2026, 9, 6, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def conn(tmp_path, monkeypatch):
+    connection = init_db(tmp_path / "recovery.db")
+    monkeypatch.setattr("jobctrl.database.get_connection", lambda: connection)
+    monkeypatch.setattr("jobctrl.llm.read_spend_budget_status", lambda: SimpleNamespace(exceeded=False))
+    monkeypatch.setattr("jobctrl.infrastructure.scoring.criteria_provider.read_min_fit_score", lambda **_: 7)
+    yield connection
+    connection.close()
+
+
+def _job(conn, number=1, *, state="failed", attempts=1, retryable=True, enriched=False, tenant="local"):
+    job_id = canonical_job_id(f"10000000-0000-4000-8000-{number:012d}")
+    conn.execute(
+        "INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at) VALUES (?, ?, ?, 'Role', 'synthetic', ?)",
+        (tenant, str(job_id), f"https://example.test/jobs/{number}", _OLD),
+    )
+    ensure_job_stage_rows(conn, job_id, tenant_id=tenant, discovered_at=_OLD)
+    conn.execute(
+        "INSERT INTO job_enrichments (tenant_id, job_id, current_status, full_description, attempts_json, updated_at) "
+        "VALUES (?, ?, ?, ?, '[]', ?)",
+        (
+            tenant,
+            str(job_id),
+            "enriched" if enriched else "failed",
+            "Build Python services." if enriched else None,
+            _OLD,
+        ),
+    )
+    set_stage_state(
+        conn,
+        job_id,
+        "enrich",
+        "succeeded" if enriched else state,
+        tenant_id=tenant,
+        attempt_count=attempts,
+        retryable=retryable,
+        error_code=None if enriched else "DETAIL_ERROR",
+        validate_transition=False,
+    )
+    conn.execute(
+        "UPDATE job_stage_states SET updated_at = ? WHERE tenant_id = ? AND job_id = ?", (_OLD, tenant, str(job_id))
+    )
+    conn.commit()
+    return job_id
+
+
+def _stage(conn, job_id, stage="enrich"):
+    return dict(
+        conn.execute(
+            "SELECT * FROM job_stage_states WHERE tenant_id = 'local' AND job_id = ? AND stage = ?",
+            (str(job_id), stage),
+        ).fetchone()
+    )
+
+
+class _Client:
+    def __init__(self):
+        self.statuses = {}
+        self.starts = []
+        self.active = False
+        self.unavailable = False
+        self.lose_ack = False
+        self.describes = []
+        self.histories = {}
+        self.data_converter = DataConverter.default
+
+    async def list_workflows(self, **kwargs):
+        assert "ExecutionStatus = 'Running'" in kwargs["query"]
+        if self.unavailable:
+            raise RPCError("unavailable", RPCStatusCode.UNAVAILABLE, b"")
+        if self.active:
+            yield SimpleNamespace()
+
+    def get_workflow_handle(self, workflow_id, *, run_id=None):
+        async def describe():
+            self.describes.append((workflow_id, run_id))
+            key = (workflow_id, run_id) if run_id else workflow_id
+            if key not in self.statuses:
+                raise RPCError("not found", RPCStatusCode.NOT_FOUND, b"")
+            status = self.statuses[key]
+            if isinstance(status, BaseException):
+                raise status
+            return SimpleNamespace(status=status, run_id=run_id or f"run:{workflow_id}")
+
+        async def fetch_history():
+            return self.histories.get(workflow_id, SimpleNamespace(events=[]))
+
+        return SimpleNamespace(describe=describe, fetch_history=fetch_history)
+
+    async def start_workflow(self, workflow, payload, **kwargs):
+        self.starts.append((workflow, payload, kwargs))
+        self.statuses[kwargs["id"]] = WorkflowExecutionStatus.RUNNING
+        if self.lose_ack:
+            raise RPCError("lost acknowledgement", RPCStatusCode.UNAVAILABLE, b"")
+        return SimpleNamespace()
+
+
+async def _tick(client):
+    return await recovery.reconcile_automatic_preparation(
+        client,
+        task_queue="recovery-test",
+        expected_app_dir="/test/app",
+        expected_db_path="/test/app/recovery.db",
+    )
+
+
+def test_failed_enrichment_is_reserved_once_with_attempt_history(conn):
+    job_id = _job(conn)
+    # Use the domain serialization so this is an audit-preservation test, not
+    # a hand-written approximation of the repository's attempt format.
+    from jobctrl.domain.enrichment.aggregate import JobEnrichment
+    from jobctrl.domain.enrichment.value_objects import EnrichmentError, ExtractionTier
+    from jobctrl.infrastructure.enrichment.sqlite_repository import SqliteEnrichmentRepository
+
+    aggregate = JobEnrichment.empty(tenant_id=LOCAL_TENANT, job_id=job_id, updated_at=_OLD)
+    aggregate = aggregate.start_attempt(extraction_tier=ExtractionTier.CSS_SELECTORS, started_at=_OLD)
+    aggregate = aggregate.fail_attempt(
+        error=EnrichmentError(code="detail_error", message="no data", retryable=True), finished_at=_OLD
+    )
+    repository = SqliteEnrichmentRepository(conn)
+    repository.save(aggregate)
+    before = repository.load(LOCAL_TENANT, job_id)
+    first = recovery.reserve_recovery_batch(conn, now=_NOW)
+    second = recovery.reserve_recovery_batch(conn, now=_NOW)
+    assert first == second
+    assert first.job_ids == (job_id,)
+    assert first.stage == "enrich"
+    assert _stage(conn, job_id)["attempt_count"] == 1
+    assert repository.load(LOCAL_TENANT, job_id).attempts == before.attempts
+    assert repository.load(LOCAL_TENANT, job_id).current_status == "pending"
+    assert conn.execute("SELECT COUNT(*) FROM job_events WHERE event_type = 'StageQueued'").fetchone()[0] == 1
+
+
+@pytest.mark.parametrize(
+    "state,attempts,retryable",
+    [
+        ("canceled", 0, True),
+        ("blocked", 1, True),
+        ("exhausted", 5, True),
+        ("failed", 5, True),
+        ("failed", 1, False),
+        ("succeeded", 1, True),
+    ],
+)
+def test_terminal_safety_and_attempt_decisions_are_not_reset(conn, state, attempts, retryable):
+    job_id = _job(conn, state=state, attempts=attempts, retryable=retryable)
+    before = _stage(conn, job_id)
+    assert recovery.reserve_recovery_batch(conn, now=_NOW) is None
+    assert _stage(conn, job_id) == before
+
+
+def test_cooldown_and_configured_attempt_ceiling(conn):
+    job_id = _job(conn, attempts=2)
+    conn.execute(
+        "UPDATE job_stage_states SET updated_at = ? WHERE job_id = ? AND stage = 'enrich'",
+        ((_NOW - timedelta(seconds=239)).isoformat(), str(job_id)),
+    )
+    conn.commit()
+    assert recovery.reserve_recovery_batch(conn, now=_NOW) is None
+    conn.execute(
+        "UPDATE job_stage_states SET updated_at = ?, max_attempts = 2 WHERE job_id = ? AND stage = 'enrich'",
+        (_OLD, str(job_id)),
+    )
+    conn.commit()
+    assert recovery.reserve_recovery_batch(conn, now=_NOW) is None
+
+
+def test_deleted_closed_and_other_tenant_jobs_are_excluded(conn):
+    deleted = _job(conn, 1)
+    closed = _job(conn, 2)
+    _job(conn, 3, tenant="other")
+    conn.execute(
+        "INSERT INTO jobctrl_deleted_jobs (tenant_id, job_id, deleted_at) VALUES ('local', ?, ?)", (str(deleted), _OLD)
+    )
+    conn.execute(
+        "INSERT INTO posting_snapshot_sets (tenant_id, job_id, latest_active_state, snapshot_set_json, updated_at) VALUES ('local', ?, 'closed', '{}', ?)",
+        (str(closed), _OLD),
+    )
+    conn.commit()
+    assert recovery.reserve_recovery_batch(conn, now=_NOW) is None
+
+
+def test_pending_score_is_preferred_and_never_starts_apply(conn):
+    _job(conn, 1)
+    ready = _job(conn, 2, enriched=True)
+    client = _Client()
+    assert asyncio.run(_tick(client)) == 1
+    _, payload, options = client.starts[0]
+    assert payload.stages == ["score"]
+    assert payload.job_ids == (ready,)
+    assert payload.automatic_recovery is True
+    assert not payload.rescore and not payload.retailor and not payload.suppress_existing_artifacts
+    assert options["id_conflict_policy"] is WorkflowIDConflictPolicy.USE_EXISTING
+    assert options["id_reuse_policy"] is WorkflowIDReusePolicy.REJECT_DUPLICATE
+
+
+def test_lost_ack_and_second_worker_reattach_to_the_reserved_execution(conn):
+    job_id = _job(conn)
+    client = _Client()
+    client.lose_ack = True
+    with pytest.raises(RPCError):
+        asyncio.run(_tick(client))
+    reserved = _stage(conn, job_id)
+    assert reserved["state"] == "queued"
+    assert asyncio.run(_tick(client)) == 0
+    assert len(client.starts) == 1
+    assert _stage(conn, job_id) == reserved
+
+
+def test_crash_before_dispatch_reuses_the_frozen_batch_after_restart(conn):
+    job_id = _job(conn)
+    batch = recovery.reserve_recovery_batch(conn, now=_NOW)
+    # Independent connection models a second worker process after the first
+    # committed its reservation but died before calling Temporal.
+    path = conn.execute("PRAGMA database_list").fetchone()[2]
+    with sqlite3.connect(path) as second:
+        second.row_factory = sqlite3.Row
+        assert recovery.reserve_recovery_batch(second, now=_NOW) == batch
+    client = _Client()
+    assert asyncio.run(_tick(client)) == 1
+    assert client.starts[0][1].job_ids == (job_id,)
+    assert client.starts[0][2]["id"] == batch.workflow_id
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [
+        (WorkflowExecutionStatus.CANCELED, "canceled"),
+        (WorkflowExecutionStatus.FAILED, "blocked"),
+        (WorkflowExecutionStatus.COMPLETED, "blocked"),
+    ],
+)
+def test_unconsumed_closed_batch_stops_instead_of_restarting_forever(conn, status, expected):
+    job_id = _job(conn)
+    batch = recovery.reserve_recovery_batch(conn, now=_NOW)
+    client = _Client()
+    client.statuses[batch.workflow_id] = status
+    assert asyncio.run(_tick(client)) == 0
+    assert _stage(conn, job_id)["state"] == expected
+    assert asyncio.run(_tick(client)) == 0
+    assert client.starts == []
+
+
+async def _interrupted_history(batch, *, canceled=False, timed_out=True, automatic=True):
+    from temporalio.api.common.v1 import Payloads
+    from temporalio.api.enums.v1 import TimeoutType
+    from temporalio.api.history.v1 import HistoryEvent
+
+    events = [HistoryEvent(event_id=1), HistoryEvent(event_id=2), HistoryEvent(event_id=3)]
+    start = events[0].workflow_execution_started_event_attributes
+    start.workflow_type.name = "JobPipelineWorkflow"
+    start.original_execution_run_id = f"run:{batch.workflow_id}"
+    start.input.CopyFrom(Payloads(payloads=await DataConverter.default.encode([{
+        "tenant_id": "local", "stages": [batch.stage], "job_ids": list(batch.job_ids),
+        "min_score": batch.min_score, "automatic_recovery": automatic,
+    }])))
+    scheduled = events[1].activity_task_scheduled_event_attributes
+    scheduled.activity_type.name = batch.stage
+    scheduled.input.CopyFrom(Payloads(payloads=await DataConverter.default.encode([{
+        "recovery_workflow_id": batch.workflow_id, "job_ids": list(batch.job_ids),
+        "workflow_id": batch.workflow_id if batch.stage == "enrich" else f"run:{batch.workflow_id}",
+        **({"workflow_run_id": f"run:{batch.workflow_id}"} if batch.stage == "enrich" else {}),
+    }])))
+    events[2].activity_task_started_event_attributes.scheduled_event_id = 2
+    if timed_out:
+        timeout = HistoryEvent(event_id=4)
+        attrs = timeout.activity_task_timed_out_event_attributes
+        attrs.scheduled_event_id = 2
+        attrs.started_event_id = 3
+        attrs.failure.timeout_failure_info.timeout_type = TimeoutType.TIMEOUT_TYPE_HEARTBEAT
+        events.append(timeout)
+    if canceled:
+        cancel = HistoryEvent(event_id=5)
+        cancel.workflow_execution_cancel_requested_event_attributes.SetInParent()
+        events.append(cancel)
+    return SimpleNamespace(events=events)
+
+
+def _consumed_reservation(conn, batch, job_id):
+    before = _stage(conn, job_id, batch.stage)
+    set_stage_state(
+        conn, job_id, batch.stage, "failed", attempt_count=before["attempt_count"] + 1,
+        error_code=f"{batch.stage.upper()}_ACTIVITY_OWNER_STOPPED", retryable=True,
+        metadata={"recoveredFromWorkflowId": f"run:{batch.workflow_id}"}, validate_transition=False,
+    )
+    record_job_event(
+        conn, job_id, batch.stage, "StageFailed",
+        payload={"workflowId": f"run:{batch.workflow_id}", "reason": "orphaned_activity_failed",
+                 "attemptCount": before["attempt_count"] + 1},
+    )
+    conn.commit()
+
+
+@pytest.mark.parametrize("already_blocked", [False, True])
+def test_interrupted_batch_releases_only_unconsumed_reservations_without_spending_attempts(conn, already_blocked):
+    consumed, unstarted = _job(conn, 1), _job(conn, 2)
+    batch = recovery.reserve_recovery_batch(conn, now=_NOW)
+    _consumed_reservation(conn, batch, consumed)
+    if already_blocked:
+        recovery._settle_closed_reservation(conn, batch, WorkflowExecutionStatus.COMPLETED)
+    before = _stage(conn, unstarted)
+    client = _Client()
+    client.statuses[batch.workflow_id] = WorkflowExecutionStatus.COMPLETED
+    client.histories[batch.workflow_id] = asyncio.run(_interrupted_history(batch))
+    assert asyncio.run(_tick(client)) == 0
+    after = _stage(conn, unstarted)
+    assert after["state"] == "pending"
+    assert after["retryable"] == 1
+    assert (after["attempt_count"], after["max_attempts"]) == (before["attempt_count"], before["max_attempts"])
+    assert _stage(conn, consumed)["attempt_count"] == 2
+    assert asyncio.run(_tick(client)) == 0  # The normal cooldown still applies.
+    assert client.starts == []
+
+
+@pytest.mark.parametrize("guard", [
+    "canceled", "terminated", "cancel_requested", "not_timeout", "not_automatic", "no_progress",
+    "copied_reset_history", "wrong_activity_owner",
+])
+def test_closed_reservation_requires_interruption_and_durable_progress_before_release(conn, guard):
+    consumed, unstarted = _job(conn, 1), _job(conn, 2)
+    batch = recovery.reserve_recovery_batch(conn, now=_NOW)
+    if guard != "no_progress":
+        _consumed_reservation(conn, batch, consumed)
+    client = _Client()
+    client.statuses[batch.workflow_id] = {
+        "canceled": WorkflowExecutionStatus.CANCELED,
+        "terminated": WorkflowExecutionStatus.TERMINATED,
+    }.get(guard, WorkflowExecutionStatus.COMPLETED)
+    client.histories[batch.workflow_id] = asyncio.run(_interrupted_history(
+        batch, canceled=guard == "cancel_requested", timed_out=guard != "not_timeout",
+        automatic=guard != "not_automatic",
+    ))
+    if guard == "copied_reset_history":
+        client.histories[batch.workflow_id].events[0].workflow_execution_started_event_attributes.original_execution_run_id = "original-run"
+    if guard == "wrong_activity_owner":
+        from temporalio.api.common.v1 import Payloads
+
+        scheduled = client.histories[batch.workflow_id].events[1].activity_task_scheduled_event_attributes
+        data = asyncio.run(DataConverter.default.decode(scheduled.input.payloads))[0]
+        data["workflow_run_id"] = "another-run"
+        scheduled.input.CopyFrom(Payloads(payloads=asyncio.run(DataConverter.default.encode([data]))))
+    assert asyncio.run(_tick(client)) == 0
+    assert _stage(conn, unstarted)["state"] in {"blocked", "canceled"}
+    assert client.starts == []
+
+
+def test_unavailable_temporal_and_live_work_prevent_mutation(conn):
+    job_id = _job(conn)
+    before = _stage(conn, job_id)
+    client = _Client()
+    client.unavailable = True
+    with pytest.raises(RPCError):
+        asyncio.run(_tick(client))
+    client.unavailable = False
+    client.active = True
+    assert asyncio.run(_tick(client)) == 0
+    assert _stage(conn, job_id) == before
+
+
+def test_budget_halt_does_not_reserve_or_dispatch(conn, monkeypatch):
+    job_id = _job(conn)
+    before = _stage(conn, job_id)
+    monkeypatch.setattr("jobctrl.llm.read_spend_budget_status", lambda: SimpleNamespace(exceeded=True))
+    client = _Client()
+    assert asyncio.run(_tick(client)) == 0
+    assert _stage(conn, job_id) == before
+    assert client.starts == []
+
+
+def test_execution_rechecks_cancellation_and_never_expands_an_empty_cohort(conn, monkeypatch):
+    from jobctrl.enrichment.activities import EnrichActivityInput, _run_selected_enrichment
+
+    job_id = _job(conn)
+    batch = recovery.reserve_recovery_batch(conn, now=_NOW)
+    set_stage_state(conn, job_id, "enrich", "canceled", attempt_count=1, validate_transition=False)
+    conn.commit()
+
+    def unexpected(*_args, **_kwargs):
+        pytest.fail("Canceled selected recovery must not become an unscoped enrichment sweep")
+
+    monkeypatch.setattr("jobctrl.enrichment.detail._run_detail_scraper", unexpected)
+    result = _run_selected_enrichment(
+        EnrichActivityInput(
+            tenant_id="local",
+            job_ids=(job_id,),
+            recovery_workflow_id=batch.workflow_id,
+        )
+    )
+    assert result["stages"][0]["enrichedJobIds"] == []
+    assert _stage(conn, job_id)["state"] == "canceled"
+
+
+def test_batch_size_is_bounded(conn):
+    for number in range(1, 31):
+        _job(conn, number)
+    batch = recovery.reserve_recovery_batch(conn, now=_NOW)
+    assert len(batch.job_ids) == 25
+    assert conn.execute("SELECT COUNT(*) FROM job_stage_states WHERE state = 'queued'").fetchone()[0] == 25
+
+
+@pytest.mark.parametrize("veto", [None, "request", "terminal_lease", "different_run", "failed_workflow"])
+def test_historical_handoff_repair_requires_positive_exact_run_evidence(conn, veto):
+    from jobctrl.state import record_job_event
+
+    job_id = _job(conn, state="canceled", attempts=0)
+    metadata = {
+        "workflowId": "discover-local",
+        "temporalRunId": "discovery-1",
+        "cancellationReason": "workflow_canceled",
+        "recoveryReason": "transient_interruption",
+    }
+    conn.execute(
+        "UPDATE job_stage_states SET metadata_json = ? WHERE job_id = ? AND stage = 'enrich'",
+        (json.dumps(metadata), str(job_id)),
+    )
+    conn.execute(
+        "INSERT INTO workflow_run_projections (workflow_id, tenant_id, workflow_type, status, temporal_run_id, finished_at) "
+        "VALUES ('discover-local', 'local', 'DiscoverWorkflow', ?, 'discovery-1', '2026-01-01T00:05:00Z')",
+        ("failed" if veto == "failed_workflow" else "succeeded",),
+    )
+    execution = {"workflowId": "discover-local", "runId": "different" if veto == "different_run" else "discovery-1"}
+    record_job_event(
+        conn,
+        None,
+        "enrich",
+        "EnrichmentLeaseClaimed",
+        occurred_at="2026-01-01T00:01:00Z",
+        payload={"execution": execution, "activityPhase": 2},
+    )
+    if veto == "request":
+        record_job_event(
+            conn,
+            None,
+            "workflow",
+            "WorkflowCancellationRequested",
+            payload={"workflowId": "discover-local", "temporalRunId": "discovery-1"},
+        )
+    if veto == "terminal_lease":
+        record_job_event(
+            conn, None, "enrich", "EnrichmentLeaseClaimed", payload={"execution": execution, "activityPhase": 3}
+        )
+    conn.commit()
+    assert recovery.reserve_recovery_batch(conn, now=_NOW) is None
+    assert _stage(conn, job_id)["state"] == ("pending" if veto is None else "canceled")
+    assert _stage(conn, job_id)["attempt_count"] == 0
+
+
+def test_saved_enrichment_reaches_real_scoring_without_discovery(conn, monkeypatch):
+    from jobctrl.domain.scoring import ScoringCriteria
+    from jobctrl.infrastructure.scoring import SqliteScoreRepository
+    from jobctrl.scoring import scorer
+    from jobctrl.scoring.activities import ScoreActivityInput, _run_selected_scores
+    from .test_v7_score_runtime import _StrongLlm, _profile_snapshot
+
+    job_id = _job(conn, enriched=True)
+    client = _Client()
+    assert asyncio.run(_tick(client)) == 1
+    batch = client.starts[0][1]
+    real_score = scorer.score_job_by_id
+    llm = _StrongLlm()
+    monkeypatch.setattr(scorer, "get_connection", lambda: conn)
+
+    def score_with_synthetic_inputs(job_id, **kwargs):
+        return real_score(
+            job_id,
+            **kwargs,
+            profile_snapshot=_profile_snapshot(LOCAL_TENANT),
+            resume_text="Python platform engineer.",
+            criteria=ScoringCriteria(),
+            repository=SqliteScoreRepository(conn),
+            llm_port=llm,
+            require_employer_analysis=False,
+        )
+
+    monkeypatch.setattr(scorer, "score_job_by_id", score_with_synthetic_inputs)
+    result = _run_selected_scores(
+        ScoreActivityInput(
+            tenant_id="local",
+            job_ids=batch.job_ids,
+            workflow_id="recovery-run-1",
+            recovery_workflow_id=client.starts[0][2]["id"],
+        )
+    )
+    assert result["status"] == "ok"
+    assert llm.calls == 1
+    saved = conn.execute("SELECT version, fit_score FROM job_scores WHERE job_id = ?", (str(job_id),)).fetchall()
+    assert [tuple(row) for row in saved] == [(1, 8)]
+    assert _stage(conn, job_id, "score")["state"] == "succeeded"
+    # A heartbeat can advance to materials, but must never rescore a saved
+    # score or re-enrich its source merely because preparation resumed.
+    next_batch = recovery.reserve_recovery_batch(conn, now=datetime.now(timezone.utc) + timedelta(hours=1))
+    assert next_batch is None or next_batch.stage == "tailor"
+    assert conn.execute("SELECT COUNT(*) FROM job_scores WHERE job_id = ?", (str(job_id),)).fetchone()[0] == 1
+    assert all(start[1].stages != ["discover"] for start in client.starts)
+
+
+@pytest.mark.parametrize("committed", [False, True])
+def test_cancel_running_automatic_score_preserves_committed_result(conn, committed):
+    from jobctrl.infrastructure.preparation_recovery import CancelPreparationStateInput, cancel_preparation_state_rows
+
+    job_id = _job(conn, enriched=True)
+    set_stage_state(
+        conn,
+        job_id,
+        "score",
+        "running",
+        attempt_count=2,
+        metadata={"activityOwner": "recovery-run"},
+        validate_transition=False,
+    )
+    if committed:
+        conn.execute(
+            "INSERT INTO job_scores (tenant_id, job_id, version, fit_score, breakdown_json, keywords_json, scored_at, criteria_json, trace_json) VALUES ('local', ?, 1, 8, '{}', '[]', ?, '{}', '{}')",
+            (str(job_id), _OLD),
+        )
+    conn.commit()
+    result = cancel_preparation_state_rows(
+        conn,
+        CancelPreparationStateInput(
+            tenant_id="local",
+            workflow_id="recovery-run",
+            stage="score",
+            job_ids=(str(job_id),),
+        ),
+    )
+    assert _stage(conn, job_id, "score")["state"] == ("succeeded" if committed else "canceled")
+    assert result.restored == int(committed)
+    assert result.canceled == int(not committed)
+
+
+@pytest.mark.parametrize("stage", ["score", "tailor", "cover"])
+@pytest.mark.parametrize(
+    "status, expected",
+    [
+        (WorkflowExecutionStatus.TERMINATED, "failed"),
+        (WorkflowExecutionStatus.CANCELED, "canceled"),
+        (WorkflowExecutionStatus.RUNNING, "running"),
+        (None, "running"),
+    ],
+)
+def test_stopped_owner_requires_exact_history_and_preserves_cancel(conn, stage, status, expected):
+    job_id = _job(conn, enriched=True)
+    workflow_id, run_id = "prepare-auto-local-" + stage + "-test", "exact-run"
+    set_stage_state(
+        conn,
+        job_id,
+        stage,
+        "running",
+        attempt_count=2,
+        max_attempts=5,
+        validate_transition=False,
+        metadata={
+            "activityOwner": run_id,
+            "automaticRecovery": True,
+            "workflowId": workflow_id,
+            "temporalRunId": run_id,
+            "attemptCountBasis": "completed",
+        },
+    )
+    conn.commit()
+    client = _Client()
+    # A newer run sharing the workflow ID is not authority over this row.
+    client.statuses[workflow_id] = WorkflowExecutionStatus.TERMINATED
+    if status is not None:
+        client.statuses[(workflow_id, run_id)] = status
+    asyncio.run(recovery._reconcile_stopped_activity_owners(client, conn))
+    assert client.describes == [(workflow_id, run_id)]
+    assert _stage(conn, job_id, stage)["state"] == expected
+    assert _stage(conn, job_id, stage)["attempt_count"] == (3 if expected == "failed" else 2)
+
+
+def test_history_unavailable_does_not_release_owner(conn):
+    job_id = _job(conn, enriched=True)
+    set_stage_state(
+        conn,
+        job_id,
+        "score",
+        "running",
+        attempt_count=2,
+        validate_transition=False,
+        metadata={
+            "activityOwner": "exact-run",
+            "automaticRecovery": True,
+            "workflowId": "prepare-auto-local-score-test",
+            "temporalRunId": "exact-run",
+        },
+    )
+    conn.commit()
+    before = _stage(conn, job_id, "score")
+    client = _Client()
+    client.statuses[("prepare-auto-local-score-test", "exact-run")] = RPCError(
+        "unavailable", RPCStatusCode.UNAVAILABLE, b""
+    )
+    with pytest.raises(RPCError):
+        asyncio.run(_tick(client))
+    assert _stage(conn, job_id, "score") == before
+    assert client.starts == []
+
+
+def test_stopped_score_owner_restores_committed_result(conn):
+    job_id = _job(conn, enriched=True)
+    set_stage_state(
+        conn,
+        job_id,
+        "score",
+        "running",
+        attempt_count=2,
+        validate_transition=False,
+        metadata={
+            "activityOwner": "exact-run",
+            "automaticRecovery": True,
+            "workflowId": "prepare-auto-local-score-test",
+            "temporalRunId": "exact-run",
+        },
+    )
+    conn.execute(
+        "INSERT INTO job_scores (tenant_id, job_id, version, fit_score, breakdown_json, keywords_json, scored_at, criteria_json, trace_json) VALUES ('local', ?, 1, 8, '{}', '[]', ?, '{}', '{}')",
+        (str(job_id), _OLD),
+    )
+    conn.commit()
+    client = _Client()
+    client.statuses[("prepare-auto-local-score-test", "exact-run")] = WorkflowExecutionStatus.TERMINATED
+    asyncio.run(recovery._reconcile_stopped_activity_owners(client, conn))
+    assert _stage(conn, job_id, "score")["state"] == "succeeded"
+    assert _stage(conn, job_id, "score")["attempt_count"] == 3
+    assert conn.execute("SELECT COUNT(*) FROM job_scores WHERE job_id = ?", (str(job_id),)).fetchone()[0] == 1
+
+
+@pytest.mark.parametrize("status,cancellation_fenced", [
+    (WorkflowExecutionStatus.TERMINATED, False), (WorkflowExecutionStatus.CANCELED, False),
+    (None, False), (WorkflowExecutionStatus.TERMINATED, True),
+])
+def test_enrichment_owner_recovery_fences_late_worker_and_counts_attempt(conn, status, cancellation_fenced):
+    from jobctrl.domain.enrichment import StaleEnrichmentExecutionLease
+    from jobctrl.enrichment.detail import _claim_enrich_job_for_activity
+    from jobctrl.infrastructure.enrichment.execution_lease import (
+        claim_enrichment_execution_lease_for_run,
+        fence_enrichment_execution_lease,
+    )
+    from jobctrl.infrastructure.enrichment.sqlite_repository import SqliteEnrichmentRepository
+
+    job_id = _job(conn)
+    batch = recovery.reserve_recovery_batch(conn, now=_NOW)
+    run_id = "exact-enrich-run"
+    conn.execute(
+        "UPDATE job_stage_states SET metadata_json = json_set(metadata_json, '$.temporalRunId', ?) WHERE job_id = ? AND stage = 'enrich'",
+        (run_id, str(job_id)),
+    )
+    conn.commit()
+    lease = claim_enrichment_execution_lease_for_run(
+        conn,
+        tenant_id=LOCAL_TENANT,
+        workflow_id=batch.workflow_id,
+        run_id=run_id,
+        owner_token="old-enrichment-activity",
+        activity_phase=1,
+        activity_attempt=1,
+    )
+    _claim_enrich_job_for_activity(conn, job_id, started_at=_OLD, tenant_id=LOCAL_TENANT, activity_lease=lease)
+    conn.commit()
+    client = _Client()
+    if cancellation_fenced:
+        claim_enrichment_execution_lease_for_run(conn, tenant_id=LOCAL_TENANT, workflow_id=batch.workflow_id,
+            run_id=run_id, owner_token=f"cancellation:{batch.workflow_id}:{run_id}", activity_phase=3, activity_attempt=1)
+    if status is not None:
+        client.statuses[(batch.workflow_id, run_id)] = status
+    asyncio.run(recovery._reconcile_stopped_enrichment_owners(client, conn))
+    state = _stage(conn, job_id)
+    if status is None:
+        assert state["state"] == "running"
+        assert state["attempt_count"] == 1
+        return
+    canceled = status == WorkflowExecutionStatus.CANCELED or cancellation_fenced
+    assert state["state"] == ("canceled" if canceled else "failed")
+    assert state["attempt_count"] == (1 if canceled else 2)
+    with pytest.raises(StaleEnrichmentExecutionLease):
+        fence_enrichment_execution_lease(conn, lease)
+    conn.rollback()
+    if not canceled:
+        aggregate = SqliteEnrichmentRepository(conn).load(LOCAL_TENANT, job_id)
+        assert aggregate.is_failed
+        assert aggregate.last_attempt.error.code == "ENRICH_ACTIVITY_OWNER_STOPPED"
+    assert client.describes == [(batch.workflow_id, run_id)]

--- a/workers/automation/tests/test_automatic_preparation_temporal_qa.py
+++ b/workers/automation/tests/test_automatic_preparation_temporal_qa.py
@@ -1,0 +1,1087 @@
+"""Operational recovery QA: real Temporal and canonical persistence, no providers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import threading
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from temporalio import activity
+from temporalio.client import Client, WorkflowFailureError
+from temporalio.exceptions import CancelledError
+from temporalio.service import RPCError, RPCStatusCode
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import Worker, UnsandboxedWorkflowRunner
+
+from jobctrl import config, database
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.domain.scoring import ScoringCriteria
+from jobctrl.domain.materials.use_cases import TailorResumeUseCase
+from jobctrl.enrichment import detail
+from jobctrl.enrichment.activities import enrich_activity, cancel_enrichment_cohort_activity
+from jobctrl.infrastructure.preparation_recovery import (
+    recover_preparation_state_activity,
+    cancel_preparation_state_activity,
+)
+from jobctrl.infrastructure.scoring import SqliteScoreRepository, SqliteRequirementFitReportRepository
+from jobctrl.infrastructure.materials import SqliteEmployerAnalysisRepository
+from jobctrl.infrastructure.temporal.finalize import record_workflow_started, record_workflow_outcome
+from jobctrl.infrastructure.temporal.run_in_activity import shutdown_activity_executors
+from jobctrl.llm import check_spend_budget
+from jobctrl.materials.activities import tailor_activity, cover_activity
+from jobctrl.pipeline import automatic_preparation as recovery
+from jobctrl.pipeline.workflow import JobPipelineWorkflow, JobPipelineWorkflowInput
+from jobctrl.scoring import scorer, tailor
+from jobctrl.scoring.activities import score_activity
+from jobctrl.state import set_stage_state
+from .temporal_env import local_env
+from .test_automatic_preparation import _job, _stage
+from .test_discover_reliability import _FakePlaywright, _long_description
+from .test_v7_score_runtime import _StrongLlm, _profile_snapshot
+from .test_scorer import _employer_analysis
+from .politeness_helpers import offline_gateway
+
+ACTIVITIES = [
+    check_spend_budget,
+    enrich_activity,
+    score_activity,
+    tailor_activity,
+    cover_activity,
+    cancel_enrichment_cohort_activity,
+    recover_preparation_state_activity,
+    cancel_preparation_state_activity,
+    record_workflow_started,
+    record_workflow_outcome,
+]
+
+
+@pytest.fixture
+def world(tmp_path, monkeypatch):
+    # All state and config belongs to a synthetic temporary sandbox.
+    db_path = tmp_path / "jobctrl.db"
+    monkeypatch.setattr(config, "APP_DIR", tmp_path)
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    monkeypatch.setattr(database, "DB_PATH", db_path)
+    connection = database.init_db(db_path)
+    original_start = WorkflowEnvironment.start_local
+    monkeypatch.setattr(
+        WorkflowEnvironment, "start_local", lambda: original_start(dev_server_existing_path=shutil.which("temporal"))
+    )
+    monkeypatch.setattr(detail, "sync_playwright", lambda: _FakePlaywright())
+    monkeypatch.setattr(detail, "PolitenessGateway", offline_gateway)
+    scrape_calls = []
+
+    def synthetic_scrape(page, url, session=None):
+        scrape_calls.append(url)
+        return {
+            "status": "ok",
+            "tier_used": 1,
+            "full_description": _long_description(),
+            "application_url": "https://example.test/apply",
+            "error": None,
+            "elapsed": 0.01,
+            "active_state": "active",
+            "verification_method": "json_ld",
+            "http_status": 200,
+        }
+
+    monkeypatch.setattr(detail, "scrape_detail_page", synthetic_scrape)
+    llm = _StrongLlm()
+    original_score = scorer.score_job_by_id
+
+    def synthetic_score(job_id, **kwargs):
+        return original_score(
+            job_id,
+            **kwargs,
+            profile_snapshot=_profile_snapshot(LOCAL_TENANT),
+            resume_text="Python platform engineer.",
+            criteria=ScoringCriteria(),
+            repository=SqliteScoreRepository(database.get_connection()),
+            llm_port=llm,
+            require_employer_analysis=False,
+        )
+
+    monkeypatch.setattr(scorer, "score_job_by_id", synthetic_score)
+    yield SimpleNamespace(conn=connection, path=db_path, app=tmp_path, llm=llm, scrape_calls=scrape_calls)
+    shutdown_activity_executors()
+    database.close_connection(db_path)
+
+
+def seed_for_stage(world, number, stage):
+    from .test_v7_cover_runtime import _seed_eligible_score, _seed_approved_resume
+
+    job_id = _job(world.conn, number=number, enriched=stage != "enrich")
+    if stage == "enrich":
+        world.conn.execute("UPDATE jobs SET site = 'RemoteOK' WHERE job_id=?", (str(job_id),))
+        world.conn.execute(
+            "INSERT INTO job_locators (tenant_id,job_id,locator_kind,locator_value,is_current,first_seen_at,last_seen_at) VALUES ('local',?,'posting_url',?,1,'2026-01-01','2026-01-01')",
+            (str(job_id), f"https://example.test/jobs/{number}"),
+        )
+    if stage in {"tailor", "cover"}:
+        _seed_eligible_score(world.conn, tenant_id=LOCAL_TENANT, job_id=job_id)
+        set_stage_state(world.conn, job_id, "score", "succeeded", validate_transition=False)
+    if stage == "cover":
+        _seed_approved_resume(world.conn, world.app, tenant_id=LOCAL_TENANT, job_id=job_id)
+        set_stage_state(world.conn, job_id, "tailor", "succeeded", validate_transition=False)
+    world.conn.commit()
+    return job_id
+
+
+async def tick(client, world, queue):
+    return await recovery.reconcile_automatic_preparation(
+        client, task_queue=queue, expected_app_dir=str(world.app), expected_db_path=str(world.path)
+    )
+
+
+def worker(client, queue):
+    return Worker(
+        client,
+        task_queue=queue,
+        workflows=[JobPipelineWorkflow],
+        activities=ACTIVITIES,
+        workflow_runner=UnsandboxedWorkflowRunner(),
+    )
+
+
+def reserved_id(world, job_id, stage):
+    return json.loads(_stage(world.conn, job_id, stage)["metadata_json"])["automaticPreparation"]["workflowId"]
+
+
+async def wait_idle(client):
+    for _ in range(100):
+        if not [run async for run in client.list_workflows(query=recovery._ACTIVE_WORK)]:
+            return
+        await asyncio.sleep(0.1)
+    raise AssertionError("Temporal visibility never became idle")
+
+
+async def history_types(client, workflow_id):
+    history = await client.get_workflow_handle(workflow_id).fetch_history()
+    return [
+        event.activity_task_scheduled_event_attributes.activity_type.name
+        for event in history.events
+        if event.HasField("activity_task_scheduled_event_attributes")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_recovery_enrichment_advances_to_real_score_after_worker_replacement(world):
+    job_id = _job(world.conn)
+    from jobctrl.domain.enrichment import JobEnrichment, ExtractionTier, EnrichmentError
+    from jobctrl.infrastructure.enrichment import SqliteEnrichmentRepository
+
+    failed = (
+        JobEnrichment.empty(tenant_id=LOCAL_TENANT, job_id=job_id, updated_at="2026-01-01T00:00:00+00:00")
+        .start_attempt(extraction_tier=ExtractionTier.JSON_LD, started_at="2026-01-01T00:00:00+00:00")
+        .fail_attempt(
+            error=EnrichmentError(code="DETAIL_ERROR", message="synthetic provider failure", retryable=True),
+            finished_at="2026-01-01T00:00:01+00:00",
+        )
+    )
+    SqliteEnrichmentRepository(world.conn).save(failed)
+    world.conn.execute("UPDATE jobs SET site = 'RemoteOK' WHERE job_id = ?", (str(job_id),))
+    world.conn.execute(
+        "INSERT INTO job_locators (tenant_id,job_id,locator_kind,locator_value,is_current,first_seen_at,last_seen_at) VALUES ('local',?,'posting_url',?,1,'2026-01-01','2026-01-01')",
+        (str(job_id), "https://example.test/jobs/1"),
+    )
+    world.conn.commit()
+    queue = f"qa-recovery-{uuid.uuid4()}"
+    async with local_env() as env:
+        assert await tick(env.client, world, queue) == 1
+        first_id = reserved_id(world, job_id, "enrich")
+        async with worker(env.client, queue) as first_worker:
+            result = await asyncio.wait_for(env.client.get_workflow_handle(first_id).result(), 25)
+            assert result["stages_completed"] == ["enrich"], result
+        assert first_worker.is_shutdown
+        assert _stage(world.conn, job_id)["state"] == "succeeded"
+        assert len(world.scrape_calls) == 1
+        assert _stage(world.conn, job_id)["attempt_count"] == 2
+        assert len(SqliteEnrichmentRepository(world.conn).load(LOCAL_TENANT, job_id).attempts) == 2
+        await wait_idle(env.client)
+        fresh_client = await Client.connect(env.client.service_client.config.target_host)
+        assert await tick(fresh_client, world, queue) == 1
+        score_id = reserved_id(world, job_id, "score")
+        async with worker(fresh_client, queue) as second_worker:
+            result = await asyncio.wait_for(fresh_client.get_workflow_handle(score_id).result(), 25)
+            assert result["stages_completed"] == ["score"], result
+        assert second_worker.is_shutdown
+        assert _stage(world.conn, job_id, "score")["state"] == "succeeded"
+        assert [
+            tuple(r)
+            for r in world.conn.execute("SELECT version,fit_score FROM job_scores WHERE job_id=?", (str(job_id),))
+        ] == [(1, 8)]
+        assert world.llm.calls == 1
+        assert await history_types(fresh_client, first_id) == [
+            "record_workflow_started",
+            "check_spend_budget",
+            "enrich",
+            "record_workflow_outcome",
+        ]
+        assert await history_types(fresh_client, score_id) == [
+            "record_workflow_started",
+            "check_spend_budget",
+            "score",
+            "record_workflow_outcome",
+        ]
+        runs = [run async for run in fresh_client.list_workflows()]
+        assert len(runs) == 2
+        assert {r.workflow_type for r in runs} == {"JobPipelineWorkflow"}
+
+
+@pytest.mark.asyncio
+async def test_real_start_ack_loss_and_two_workers_reuse_one_score(world):
+    job_id = _job(world.conn, enriched=True)
+    queue = f"qa-ack-{uuid.uuid4()}"
+    async with local_env() as env:
+
+        class LostAck:
+            def __getattr__(self, name):
+                return getattr(env.client, name)
+
+            async def start_workflow(self, *args, **kwargs):
+                await env.client.start_workflow(*args, **kwargs)
+                raise RPCError("synthetic lost start acknowledgement", RPCStatusCode.UNAVAILABLE, b"")
+
+        with pytest.raises(RPCError):
+            await tick(LostAck(), world, queue)
+        workflow_id = reserved_id(world, job_id, "score")
+        fresh_client = await Client.connect(env.client.service_client.config.target_host)
+        assert await tick(fresh_client, world, queue) == 0
+        async with worker(env.client, queue), worker(fresh_client, queue):
+            result = await asyncio.wait_for(env.client.get_workflow_handle(workflow_id).result(), 25)
+            assert result["stages_completed"] == ["score"], result
+        assert world.llm.calls == 1
+        assert world.conn.execute("SELECT count(*) FROM job_scores WHERE job_id=?", (str(job_id),)).fetchone()[0] == 1
+        assert (await history_types(env.client, workflow_id)).count("score") == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ["enrich", "score", "tailor", "cover"])
+async def test_canceled_reservation_does_not_fall_back_to_unrelated_work(world, stage):
+    job_id = seed_for_stage(world, 1, stage)
+    batch = recovery.reserve_recovery_batch(world.conn)
+    assert batch.stage == stage
+    # An actual frozen cohort is serialized; cancellation occurs before execution.
+    from jobctrl.pipeline.workflow import JobPipelineWorkflowInput
+
+    workflow_id = batch.workflow_id
+    set_stage_state(world.conn, job_id, batch.stage, "canceled", validate_transition=False, retryable=False)
+    other_id = seed_for_stage(world, 2, stage)
+    world.conn.commit()
+    queue = f"qa-empty-{uuid.uuid4()}"
+    async with local_env() as env:
+        async with worker(env.client, queue):
+            result = await env.client.execute_workflow(
+                JobPipelineWorkflow.run,
+                JobPipelineWorkflowInput(
+                    tenant_id="local",
+                    stages=[stage],
+                    job_ids=(job_id,),
+                    expected_app_dir=str(world.app),
+                    expected_db_path=str(world.path),
+                    automatic_recovery=True,
+                ),
+                id=workflow_id,
+                task_queue=queue,
+            )
+            assert result.stages_completed == [stage], result
+        assert _stage(world.conn, job_id, batch.stage)["state"] == "canceled"
+        assert _stage(world.conn, other_id, stage)["state"] == ("failed" if stage == "enrich" else "pending")
+        assert world.llm.calls == 0
+        assert world.scrape_calls == []
+
+
+@pytest.mark.asyncio
+async def test_automatic_score_uses_one_activity_attempt_and_preserves_ceiling(world, monkeypatch):
+    job_id = _job(world.conn, enriched=True)
+    set_stage_state(
+        world.conn,
+        job_id,
+        "score",
+        "failed",
+        attempt_count=4,
+        max_attempts=5,
+        retryable=True,
+        error_code="LLM_TRANSIENT",
+        validate_transition=False,
+    )
+    world.conn.execute(
+        "UPDATE job_stage_states SET updated_at='2026-01-01T00:00:00+00:00' WHERE job_id=?", (str(job_id),)
+    )
+    world.conn.commit()
+    calls = []
+
+    def fail_provider(*args, **kwargs):
+        calls.append(1)
+        raise RuntimeError("synthetic temporary LLM outage")
+
+    monkeypatch.setattr(world.llm, "chat_json", fail_provider)
+    queue = f"qa-limit-{uuid.uuid4()}"
+    async with local_env() as env:
+        assert await tick(env.client, world, queue) == 1
+        workflow_id = reserved_id(world, job_id, "score")
+        async with worker(env.client, queue):
+            result = await asyncio.wait_for(env.client.get_workflow_handle(workflow_id).result(), 25)
+            assert result["stages_failed"] == ["score"], result
+        state = _stage(world.conn, job_id, "score")
+        assert state["state"] == "failed", state
+        assert state["attempt_count"] == 5, state
+        assert len(calls) == 1
+        assert (await history_types(env.client, workflow_id)).count("score") == 1
+        await wait_idle(env.client)
+        world.conn.execute(
+            "UPDATE job_stage_states SET updated_at='2026-01-01T00:00:00+00:00' WHERE job_id=?", (str(job_id),)
+        )
+        world.conn.commit()
+        assert await tick(env.client, world, queue) == 0
+        assert _stage(world.conn, job_id, "score")["attempt_count"] == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("committed,provider_fails", [(False, False), (False, True), (True, False)])
+async def test_true_cancel_of_automatic_score_fences_uncommitted_and_retains_committed(
+    world, monkeypatch, committed, provider_fails
+):
+    job_id = _job(world.conn, enriched=True)
+    started = threading.Event()
+    release = threading.Event()
+    returned = threading.Event()
+    original_score = scorer.score_job_by_id
+    original_chat = world.llm.chat_json
+
+    def wait_then_chat(*args, **kwargs):
+        started.set()
+        assert release.wait(25)
+        try:
+            if provider_fails:
+                raise RuntimeError("synthetic late provider failure")
+            return original_chat(*args, **kwargs)
+        finally:
+            returned.set()
+
+    def commit_then_wait(*args, **kwargs):
+        result = original_score(*args, **kwargs)
+        started.set()
+        assert release.wait(25)
+        returned.set()
+        return result
+
+    if committed:
+        monkeypatch.setattr(scorer, "score_job_by_id", commit_then_wait)
+    else:
+        monkeypatch.setattr(world.llm, "chat_json", wait_then_chat)
+    queue = f"qa-cancel-{uuid.uuid4()}"
+    async with local_env() as env:
+        assert await tick(env.client, world, queue) == 1
+        workflow_id = reserved_id(world, job_id, "score")
+        async with worker(env.client, queue):
+            handle = env.client.get_workflow_handle(workflow_id)
+            try:
+                assert await asyncio.to_thread(started.wait, 10)
+                await handle.cancel()
+                with pytest.raises(WorkflowFailureError) as failure:
+                    await asyncio.wait_for(handle.result(), 20)
+                assert isinstance(failure.value.cause, CancelledError)
+                state = _stage(world.conn, job_id, "score")
+                assert state["state"] == ("succeeded" if committed else "canceled"), state
+            finally:
+                release.set()
+            assert await asyncio.to_thread(returned.wait, 10)
+        state = _stage(world.conn, job_id, "score")
+        assert state["state"] == ("succeeded" if committed else "canceled"), state
+        assert world.conn.execute("SELECT count(*) FROM job_scores WHERE job_id=?", (str(job_id),)).fetchone()[
+            0
+        ] == int(committed)
+        assert (await history_types(env.client, workflow_id)).count("cancel_preparation_state") == 1
+
+
+@pytest.mark.asyncio
+async def test_recovery_generates_cover_and_preserves_accepted_resume(world, monkeypatch):
+    from jobctrl.scoring import cover_letter
+    from jobctrl.infrastructure.materials import SqliteMaterialsRepository
+    from .test_v7_cover_runtime import _CoverLlm, _PdfRenderer, _seed_eligible_score, _seed_approved_resume
+
+    job_id = _job(world.conn, enriched=True)
+    _seed_eligible_score(world.conn, tenant_id=LOCAL_TENANT, job_id=job_id)
+    _seed_approved_resume(world.conn, world.app, tenant_id=LOCAL_TENANT, job_id=job_id)
+    set_stage_state(world.conn, job_id, "score", "succeeded", validate_transition=False)
+    set_stage_state(world.conn, job_id, "tailor", "succeeded", validate_transition=False)
+    world.conn.commit()
+    before = SqliteMaterialsRepository(world.conn).load_current_approved(LOCAL_TENANT, job_id)
+    assert before is not None and before.cover_letter is None
+    llm = _CoverLlm()
+    monkeypatch.setattr(cover_letter, "COVER_LETTER_DIR", world.app / "cover-letters")
+    original_cover = cover_letter.cover_letter_by_id
+
+    def cover_with_synthetic_provider(job_id, **kwargs):
+        return original_cover(
+            job_id, **kwargs, snapshot=_profile_snapshot(LOCAL_TENANT), llm_port=llm, pdf_renderer=_PdfRenderer()
+        )
+
+    monkeypatch.setattr(cover_letter, "cover_letter_by_id", cover_with_synthetic_provider)
+    queue = f"qa-cover-{uuid.uuid4()}"
+    async with local_env() as env:
+        assert await tick(env.client, world, queue) == 1
+        workflow_id = reserved_id(world, job_id, "cover")
+        async with worker(env.client, queue):
+            result = await asyncio.wait_for(env.client.get_workflow_handle(workflow_id).result(), 25)
+            assert result["stages_completed"] == ["cover"], result
+        state = _stage(world.conn, job_id, "cover")
+        assert state["state"] == "succeeded", state
+        saved = SqliteMaterialsRepository(world.conn).load_current_approved(LOCAL_TENANT, job_id)
+        assert saved is not None and saved.cover_letter is not None and saved.cover_letter_pdf is not None
+        assert saved.generation == before.generation
+        assert saved.tailored_resume == before.tailored_resume
+        assert saved.resume_pdf == before.resume_pdf
+        assert llm.calls == 1
+        await wait_idle(env.client)
+        assert await tick(env.client, world, queue) == 0
+
+
+@pytest.mark.asyncio
+async def test_automatic_tailor_reaches_generation_and_preserves_exact_selection(world, monkeypatch):
+    from jobctrl.scoring import tailor
+    from .test_v7_cover_runtime import _seed_eligible_score
+
+    job_id = _job(world.conn, enriched=True)
+    _seed_eligible_score(world.conn, tenant_id=LOCAL_TENANT, job_id=job_id)
+    set_stage_state(world.conn, job_id, "score", "succeeded", validate_transition=False)
+    world.conn.commit()
+    calls = []
+
+    def stop_at_generation(job, *args, **kwargs):
+        calls.append(job["job_id"])
+        kwargs["commit_guard"]()
+        raise RuntimeError("synthetic generation provider unavailable")
+
+    monkeypatch.setattr(tailor, "_tailor_one_job", stop_at_generation)
+    monkeypatch.setattr(tailor, "TAILORED_DIR", world.app / "tailored")
+    original_tailor = tailor.tailor_job_by_id
+
+    def tailor_with_synthetic_inputs(job_id, **kwargs):
+        return original_tailor(job_id, **kwargs, snapshot=_profile_snapshot(LOCAL_TENANT), pdf_renderer=object())
+
+    monkeypatch.setattr(tailor, "tailor_job_by_id", tailor_with_synthetic_inputs)
+    queue = f"qa-tailor-{uuid.uuid4()}"
+    async with local_env() as env:
+        assert await tick(env.client, world, queue) == 1
+        workflow_id = reserved_id(world, job_id, "tailor")
+        async with worker(env.client, queue):
+            result = await asyncio.wait_for(env.client.get_workflow_handle(workflow_id).result(), 25)
+            assert result["stages_completed"] == ["tailor"], result
+        assert calls == [str(job_id)]
+        state = _stage(world.conn, job_id, "tailor")
+        assert state["state"] == "failed", state
+        assert state["attempt_count"] == 1, state
+        await wait_idle(env.client)
+        assert await tick(env.client, world, queue) == 0
+
+
+@pytest.mark.asyncio
+async def test_terminated_owner_does_not_stall_saved_jobs_after_restart(world):
+    job_id = _job(world.conn, enriched=True)
+    queue = f"qa-orphan-{uuid.uuid4()}"
+    started = asyncio.Event()
+
+    @activity.defn(name="score")
+    async def crash_checkpoint(payload):
+        started.set()
+        await asyncio.Event().wait()
+
+    async with local_env() as env:
+        assert await tick(env.client, world, queue) == 1
+        old_id = reserved_id(world, job_id, "score")
+        old_activities = [a for a in ACTIVITIES if a is not score_activity] + [crash_checkpoint]
+        async with Worker(
+            env.client,
+            task_queue=queue,
+            workflows=[JobPipelineWorkflow],
+            activities=old_activities,
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            await asyncio.wait_for(started.wait(), 10)
+            handle = env.client.get_workflow_handle(old_id)
+            description = await handle.describe()
+            # Exact owned checkpoint left by a killed scoring process after its
+            # queued-to-running commit. Started projection came from real worker.
+            set_stage_state(
+                world.conn,
+                job_id,
+                "score",
+                "running",
+                attempt_count=2,
+                max_attempts=5,
+                started_at="2026-01-01T00:00:00+00:00",
+                validate_transition=False,
+                metadata={
+                    "workflowId": old_id,
+                    "temporalRunId": description.run_id,
+                    "activityOwner": description.run_id,
+                    "automaticRecovery": True,
+                    "rescore": False,
+                    "priorScoreVersion": 0,
+                },
+            )
+            world.conn.commit()
+            await handle.terminate("synthetic stopped predecessor")
+        other_id = _job(world.conn, number=2, enriched=True)
+        await wait_idle(env.client)
+        fresh = await Client.connect(env.client.service_client.config.target_host)
+        assert await tick(fresh, world, queue) == 1
+        settled = _stage(world.conn, job_id, "score")
+        assert settled["state"] == "failed", settled
+        assert settled["attempt_count"] == 3, settled
+        next_id = reserved_id(world, other_id, "score")
+        async with worker(fresh, queue):
+            result = await asyncio.wait_for(fresh.get_workflow_handle(next_id).result(), 25)
+            assert result["stages_completed"] == ["score"], result
+        assert _stage(world.conn, other_id, "score")["state"] == "succeeded"
+        assert world.llm.calls == 1
+        assert world.conn.execute("SELECT count(*) FROM job_scores WHERE job_id=?", (str(job_id),)).fetchone()[0] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "committed,prior_attempts,cancellation_fenced",
+    [(False, 1, False), (False, 4, False), (True, 1, False), (False, 1, True)],
+)
+async def test_terminated_enrichment_releases_exact_owner_and_fences_late_provider(
+    world, monkeypatch, committed, prior_attempts, cancellation_fenced
+):
+    from jobctrl.domain.enrichment import JobEnrichment, ExtractionTier, EnrichmentError, StaleEnrichmentExecutionLease
+    from jobctrl.enrichment import activities as enrichment_activities
+    from jobctrl.infrastructure.enrichment import SqliteEnrichmentRepository
+    from jobctrl.infrastructure.enrichment.execution_lease import (
+        fence_enrichment_execution_lease,
+        claim_enrichment_execution_lease_for_run,
+    )
+
+    job_id = seed_for_stage(world, 1, "enrich")
+    aggregate = JobEnrichment.empty(tenant_id=LOCAL_TENANT, job_id=job_id, updated_at="2026-01-01T00:00:00+00:00")
+    for _ in range(prior_attempts):
+        if aggregate.is_failed:
+            aggregate = aggregate.reset(reset_at="2026-01-01T00:00:00+00:00")
+        aggregate = aggregate.start_attempt(
+            extraction_tier=ExtractionTier.JSON_LD, started_at="2026-01-01T00:00:00+00:00"
+        ).fail_attempt(
+            error=EnrichmentError(code="DETAIL_ERROR", message="synthetic prior outage", retryable=True),
+            finished_at="2026-01-01T00:00:01+00:00",
+        )
+    SqliteEnrichmentRepository(world.conn).save(aggregate)
+    set_stage_state(
+        world.conn,
+        job_id,
+        "enrich",
+        "failed",
+        attempt_count=prior_attempts,
+        max_attempts=5,
+        retryable=True,
+        validate_transition=False,
+    )
+    world.conn.execute(
+        "UPDATE job_stage_states SET updated_at='2026-01-01T00:00:00+00:00' WHERE job_id=?", (str(job_id),)
+    )
+    world.conn.commit()
+
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    leases = []
+    original_claim = enrichment_activities._claim_activity_enrichment_lease
+    original_run = enrichment_activities._run_selected_enrichment
+    original_scrape = detail.scrape_detail_page
+
+    def observe_claim(*args, **kwargs):
+        lease = original_claim(*args, **kwargs)
+        leases.append(lease)
+        return lease
+
+    def late_provider(*args, **kwargs):
+        started.set()
+        assert release.wait(25)
+        return original_scrape(*args, **kwargs)
+
+    def observe_run(*args, **kwargs):
+        try:
+            result = original_run(*args, **kwargs)
+            if committed:
+                started.set()
+                assert release.wait(25)
+            return result
+        finally:
+            finished.set()
+
+    monkeypatch.setattr(enrichment_activities, "_claim_activity_enrichment_lease", observe_claim)
+    monkeypatch.setattr(enrichment_activities, "_run_selected_enrichment", observe_run)
+    if not committed:
+        monkeypatch.setattr(detail, "scrape_detail_page", late_provider)
+    queue = f"qa-enrich-orphan-{uuid.uuid4()}"
+    async with local_env() as env:
+        assert await tick(env.client, world, queue) == 1
+        old_id = reserved_id(world, job_id, "enrich")
+        async with worker(env.client, queue):
+            try:
+                assert await asyncio.to_thread(started.wait, 10)
+                handle = env.client.get_workflow_handle(old_id)
+                description = await handle.describe()
+                if committed:
+                    # An accepted aggregate is canonical even if a killed worker
+                    # left its old stage ownership projection incomplete.
+                    saved_before = SqliteEnrichmentRepository(world.conn).load(LOCAL_TENANT, job_id)
+                    assert saved_before.is_enriched
+                    set_stage_state(
+                        world.conn,
+                        job_id,
+                        "enrich",
+                        "running",
+                        attempt_count=prior_attempts,
+                        max_attempts=5,
+                        validate_transition=False,
+                        metadata={"workflowId": old_id, "temporalRunId": description.run_id},
+                    )
+                    world.conn.commit()
+                else:
+                    assert _stage(world.conn, job_id, "enrich")["state"] == "running"
+                if cancellation_fenced:
+                    # Cancellation committed its exact lease, then lost its
+                    # process before stage settlement and Temporal terminated.
+                    claim_enrichment_execution_lease_for_run(
+                        world.conn,
+                        tenant_id=LOCAL_TENANT,
+                        workflow_id=old_id,
+                        run_id=description.run_id,
+                        owner_token=f"cancellation:{old_id}:{description.run_id}",
+                        activity_phase=3,
+                        activity_attempt=1,
+                    )
+                    assert _stage(world.conn, job_id, "enrich")["state"] == "running"
+                await handle.terminate("synthetic predecessor process stopped")
+                await wait_idle(env.client)
+                next_job = job_id if committed else _job(world.conn, number=2, enriched=True)
+                fresh = await Client.connect(env.client.service_client.config.target_host)
+                assert await tick(fresh, world, queue) == 1
+                recovered = _stage(world.conn, job_id, "enrich")
+                expected = (
+                    "canceled"
+                    if cancellation_fenced
+                    else ("succeeded" if committed else ("exhausted" if prior_attempts == 4 else "failed"))
+                )
+                expected_attempts = prior_attempts if cancellation_fenced else prior_attempts + 1
+                assert recovered["state"] == expected, recovered
+                assert recovered["attempt_count"] == expected_attempts, recovered
+                saved = SqliteEnrichmentRepository(world.conn).load(LOCAL_TENANT, job_id)
+                assert saved.attempt_count == expected_attempts
+                if committed:
+                    assert saved == saved_before
+                elif cancellation_fenced:
+                    assert saved.full_description is None
+                else:
+                    assert saved.is_failed and saved.full_description is None
+                    assert saved.last_attempt.error.code == "ENRICH_ACTIVITY_OWNER_STOPPED"
+                assert len(leases) == 1 and leases[0] is not None
+                with pytest.raises(StaleEnrichmentExecutionLease):
+                    fence_enrichment_execution_lease(world.conn, leases[0])
+                world.conn.rollback()
+                next_id = reserved_id(world, next_job, "score")
+                result = await asyncio.wait_for(fresh.get_workflow_handle(next_id).result(), 20)
+                assert result["stages_completed"] == ["score"], result
+                assert world.llm.calls == 1
+            finally:
+                release.set()
+            assert await asyncio.to_thread(finished.wait, 10)
+        settled = _stage(world.conn, job_id, "enrich")
+        assert settled["state"] == expected and settled["attempt_count"] == expected_attempts
+        after_late_response = SqliteEnrichmentRepository(world.conn).load(LOCAL_TENANT, job_id)
+        assert after_late_response == saved
+        if not committed:
+            assert (
+                world.conn.execute("SELECT count(*) FROM job_scores WHERE job_id=?", (str(job_id),)).fetchone()[0] == 0
+            )
+
+
+ORIGINAL_SCORE = scorer.score_job_by_id
+ORIGINAL_TAILOR = tailor.tailor_job_by_id
+ORIGINAL_TAILOR_FACTORY = tailor._build_use_case
+
+
+class RequirementLlm(_StrongLlm):
+    def chat_json(self, *args, **kwargs):
+        payload = super().chat_json(*args, **kwargs)
+        payload["requirement_assessments"] = [
+            {
+                "requirement_id": "req-python-platform",
+                "requirement_text": "Own Python platform reliability.",
+                "tier": "must_have",
+                "weight": 0.9,
+                "job_evidence_span": "Need Python.",
+                "fit": {"kind": "matched", "evidence_ids": ["platform"]},
+            }
+        ]
+        return payload
+
+
+class CanonicalAnalysis:
+    def execute(self, *, job, tenant_id=LOCAL_TENANT, **kwargs):
+        analysis = SqliteEmployerAnalysisRepository(database.get_connection()).load(tenant_id, job["job_id"])
+        assert analysis is not None
+        return SimpleNamespace(analysis=analysis)
+
+
+@pytest.fixture
+def evidence_world(world, monkeypatch):
+    llm = RequirementLlm()
+    generation_calls = []
+
+    def score_with_synthetic_provider(job_id, **kwargs):
+        # Keep production default repositories and require_employer_analysis=True.
+        return ORIGINAL_SCORE(
+            job_id,
+            **kwargs,
+            profile_snapshot=_profile_snapshot(LOCAL_TENANT),
+            resume_text="Python platform engineer.",
+            criteria=ScoringCriteria(),
+            llm_port=llm,
+            analyze_use_case=CanonicalAnalysis(),
+        )
+
+    def tailor_with_synthetic_profile(job_id, **kwargs):
+        return ORIGINAL_TAILOR(
+            job_id,
+            **kwargs,
+            snapshot=_profile_snapshot(LOCAL_TENANT),
+            pdf_renderer=object(),
+        )
+
+    def factory(**kwargs):
+        return ORIGINAL_TAILOR_FACTORY(
+            **kwargs,
+            llm_port=llm,
+            analyze_use_case=CanonicalAnalysis(),
+            voice=object(),
+        )
+
+    def stop_at_generation(self, **kwargs):
+        kwargs["execution_guard"]()
+        report = kwargs["requirement_fit_report"]
+        assert report is not None
+        assert report.employer_analysis_generation == kwargs["employer_analysis"].generation
+        assert report.assessments[0].requirement_id == "req-python-platform"
+        assert report.assessments[0].fit.kind == "matched"
+        generation_calls.append((str(report.job_id), report.score_version))
+        raise RuntimeError("QA_GENERATION_BOUNDARY_REACHED")
+
+    monkeypatch.setattr(scorer, "score_job_by_id", score_with_synthetic_provider)
+    monkeypatch.setattr(tailor, "tailor_job_by_id", tailor_with_synthetic_profile)
+    monkeypatch.setattr(tailor, "_build_use_case", factory)
+    monkeypatch.setattr(tailor, "TAILORED_DIR", world.app / "tailored")
+    monkeypatch.setattr(TailorResumeUseCase, "_run_attempts", stop_at_generation)
+    world.llm = llm
+    world.generation_calls = generation_calls
+    return world
+
+
+def seed(world, number=1):
+    job_id = _job(world.conn, number=number, enriched=True)
+    world.conn.execute("UPDATE job_enrichments SET full_description='Need Python.' WHERE job_id=?", (str(job_id),))
+    world.conn.commit()
+    analysis = _employer_analysis(
+        f"https://example.test/jobs/{number}",
+        job_id=job_id,
+        title="Role",
+        description="Need Python.",
+    )
+    SqliteEmployerAnalysisRepository(world.conn).save(analysis)
+    return job_id
+
+
+def verify_report(world, job_id, version=1):
+    score = SqliteScoreRepository(world.conn).load(LOCAL_TENANT, job_id)
+    report = SqliteRequirementFitReportRepository(world.conn).load(LOCAL_TENANT, job_id, score_version=version)
+    assert score is not None and score.version == version
+    assert score.trace.resolution_reason == "requirement_fit_report"
+    assert report is not None, "Canonical requirement report missing after owned Score"
+    assert report.score_version == score.version
+    assert report.profile_snapshot_version == score.trace.profile_snapshot_version
+    assert report.resolved_fit_score == score.fit_score
+    assert report.resolved_fit_score.value == 10
+    assert report.employer_analysis_generation == 1
+    assert report.assessments[0].fit.kind == "matched"
+    assert report.assessments[0].requirement_id == "req-python-platform"
+    assert (
+        world.conn.execute(
+            "SELECT count(*) FROM job_requirement_fit_items WHERE job_id=? AND score_version=?", (str(job_id), version)
+        ).fetchone()[0]
+        == 1
+    )
+    return report
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        "coherent",
+        "missing_report",
+        "missing_items",
+        "old_score",
+        "analysis_mismatch",
+        "profile_mismatch",
+        "canceled",
+        "exhausted",
+        "nonretryable",
+        "at_limit",
+        "other_blocker",
+    ],
+)
+def test_requirement_fit_unblock_requires_current_evidence_and_retry_permission(evidence_world, condition):
+    from jobctrl.state import reconcile_dependency_blockers
+
+    world = evidence_world
+    job_id = seed(world)
+    assert scorer.score_job_by_id(job_id).ok
+    verify_report(world, job_id)
+    set_stage_state(
+        world.conn,
+        job_id,
+        "tailor",
+        condition if condition in {"canceled", "exhausted"} else "blocked",
+        attempt_count=4 if condition == "at_limit" else 2,
+        max_attempts=4,
+        retryable=condition != "nonretryable",
+        error_code="OTHER_CONDITION" if condition == "other_blocker" else "REQUIREMENT_FIT_MISSING",
+        blocked_by=["score"],
+        validate_transition=False,
+    )
+    if condition in {"missing_report", "missing_items"}:
+        world.conn.execute("DELETE FROM job_requirement_fit_items WHERE job_id=?", (str(job_id),))
+    if condition == "missing_report":
+        world.conn.execute("DELETE FROM job_requirement_fit_reports WHERE job_id=?", (str(job_id),))
+    if condition == "old_score":
+        repository = SqliteScoreRepository(world.conn)
+        score = repository.load(LOCAL_TENANT, job_id)
+        assert score is not None
+        repository.save(
+            score.next_version(
+                fit_score=score.fit_score,
+                breakdown=score.breakdown,
+                matched_keywords=score.matched_keywords,
+                scored_at=score.scored_at,
+            )
+        )
+    if condition == "analysis_mismatch":
+        world.conn.execute(
+            "UPDATE job_requirement_fit_reports SET employer_analysis_generation=2 WHERE job_id=?", (str(job_id),)
+        )
+    if condition == "profile_mismatch":
+        world.conn.execute(
+            "UPDATE job_requirement_fit_reports SET profile_snapshot_version=2 WHERE job_id=?", (str(job_id),)
+        )
+    world.conn.commit()
+    before = _stage(world.conn, job_id, "tailor")
+
+    changed = reconcile_dependency_blockers(world.conn, job_id=job_id, completed_stage="score")
+    world.conn.commit()
+
+    after = _stage(world.conn, job_id, "tailor")
+    assert changed == int(condition == "coherent")
+    assert after["attempt_count"] == before["attempt_count"]
+    assert after["max_attempts"] == before["max_attempts"]
+    if condition == "coherent":
+        assert after["state"] == "pending"
+        assert after["error_code"] is None
+        assert reconcile_dependency_blockers(world.conn, job_id=job_id, completed_stage="score") == 0
+    else:
+        assert after == before
+
+
+async def run_auto(client, world, queue, job_id, stage):
+    await wait_idle(client)
+    assert await tick(client, world, queue) == 1
+    workflow_id = reserved_id(world, job_id, stage)
+    async with worker(client, queue):
+        result = await asyncio.wait_for(client.get_workflow_handle(workflow_id).result(), 25)
+    assert result["stages_completed"] == [stage], result
+    kinds = await history_types(client, workflow_id)
+    assert kinds == ["record_workflow_started", "check_spend_budget", stage, "record_workflow_outcome"]
+    return workflow_id
+
+
+def assert_generation(world, job_id, version):
+    state = _stage(world.conn, job_id, "tailor")
+    assert world.generation_calls == [(str(job_id), version)], state
+    assert state["state"] == "failed", state
+    assert state["error_code"] != "REQUIREMENT_FIT_MISSING", state
+    assert state["error_message"] == "Tailoring ended with status error", state
+
+
+@pytest.mark.asyncio
+async def test_owned_score_persists_report_and_automatic_tailor_consumes_it(evidence_world):
+    world = evidence_world
+    job_id = seed(world)
+    queue = f"qa-evidence-{uuid.uuid4()}"
+    async with local_env() as env:
+        await run_auto(env.client, world, queue, job_id, "score")
+        verify_report(world, job_id)
+        assert _stage(world.conn, job_id, "score")["state"] == "succeeded"
+        await run_auto(env.client, world, queue, job_id, "tailor")
+        assert_generation(world, job_id, 1)
+        assert world.llm.calls == 1
+        assert len([run async for run in env.client.list_workflows()]) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("continuation", ["automatic", "normal"])
+async def test_exact_normal_rescore_repairs_historical_missing_report(evidence_world, continuation):
+    world = evidence_world
+    job_id = seed(world)
+    other_id = seed(world, 2)
+    # Preserve a canceled unrelated row to prove selected rescore is bounded.
+    from jobctrl.state import set_stage_state
+
+    set_stage_state(world.conn, other_id, "score", "canceled", retryable=False, validate_transition=False)
+    world.conn.commit()
+    queue = f"qa-remediation-{uuid.uuid4()}"
+    async with local_env() as env:
+        await run_auto(env.client, world, queue, job_id, "score")
+        verify_report(world, job_id)
+        before = tuple(world.conn.execute("SELECT * FROM job_scores WHERE job_id=?", (str(job_id),)).fetchone())
+        # Recreate the confirmed historic product defect using only synthetic rows.
+        world.conn.execute("DELETE FROM job_requirement_fit_items WHERE job_id=?", (str(job_id),))
+        world.conn.execute("DELETE FROM job_requirement_fit_reports WHERE job_id=?", (str(job_id),))
+        world.conn.commit()
+        await run_auto(env.client, world, queue, job_id, "tailor")
+        blocked = _stage(world.conn, job_id, "tailor")
+        assert blocked["error_code"] == "REQUIREMENT_FIT_MISSING", blocked
+        assert world.generation_calls == []
+        await wait_idle(env.client)
+        rescore_id = f"qa-normal-rescore-{uuid.uuid4()}"
+        async with worker(env.client, queue):
+            result = await asyncio.wait_for(
+                env.client.execute_workflow(
+                    JobPipelineWorkflow.run,
+                    JobPipelineWorkflowInput(
+                        tenant_id="local",
+                        stages=["score"],
+                        job_ids=(job_id,),
+                        rescore=True,
+                        expected_app_dir=str(world.app),
+                        expected_db_path=str(world.path),
+                    ),
+                    id=rescore_id,
+                    task_queue=queue,
+                ),
+                25,
+            )
+        assert result.stages_completed == ["score"], result
+        verify_report(world, job_id, 2)
+        assert (
+            tuple(
+                world.conn.execute("SELECT * FROM job_scores WHERE job_id=? AND version=1", (str(job_id),)).fetchone()
+            )
+            == before
+        )
+        assert world.conn.execute("SELECT count(*) FROM job_scores WHERE job_id=?", (str(job_id),)).fetchone()[0] == 2
+        assert world.conn.execute("SELECT count(*) FROM job_scores WHERE job_id=?", (str(other_id),)).fetchone()[0] == 0
+        assert _stage(world.conn, other_id, "score")["state"] == "canceled"
+        assert await history_types(env.client, rescore_id) == [
+            "record_workflow_started",
+            "check_spend_budget",
+            "score",
+            "record_workflow_outcome",
+        ]
+        assert _stage(world.conn, job_id, "tailor")["attempt_count"] == blocked["attempt_count"]
+        if continuation == "automatic":
+            repaired = _stage(world.conn, job_id, "tailor")
+            assert repaired["state"] == "pending"
+            await wait_idle(env.client)
+            assert await tick(env.client, world, queue) == 0
+            updated = datetime.fromisoformat(repaired["updated_at"].replace("Z", "+00:00"))
+            cooldown = min(1800, 60 * (2 ** repaired["attempt_count"]))
+            remaining = cooldown - (datetime.now(timezone.utc) - updated).total_seconds()
+            await asyncio.sleep(max(0, remaining) + 0.2)
+            await run_auto(env.client, world, queue, job_id, "tailor")
+        else:
+            await wait_idle(env.client)
+            tailor_id = f"qa-normal-tailor-{uuid.uuid4()}"
+            async with worker(env.client, queue):
+                result = await asyncio.wait_for(
+                    env.client.execute_workflow(
+                        JobPipelineWorkflow.run,
+                        JobPipelineWorkflowInput(
+                            tenant_id="local",
+                            stages=["tailor"],
+                            job_ids=(job_id,),
+                            expected_app_dir=str(world.app),
+                            expected_db_path=str(world.path),
+                        ),
+                        id=tailor_id,
+                        task_queue=queue,
+                    ),
+                    25,
+                )
+            assert result.stages_completed == ["tailor"], result
+            assert await history_types(env.client, tailor_id) == [
+                "record_workflow_started",
+                "check_spend_budget",
+                "tailor",
+                "record_workflow_outcome",
+            ]
+        assert_generation(world, job_id, 2)
+        assert world.llm.calls == 2
+        assert len([run async for run in env.client.list_workflows()]) == 4
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("committed", [False, True])
+async def test_cancel_fences_uncommitted_report_and_retains_committed_pair(evidence_world, monkeypatch, committed):
+    world = evidence_world
+    job_id = seed(world)
+    started, release, returned = threading.Event(), threading.Event(), threading.Event()
+    original_chat, original_score = world.llm.chat_json, scorer.score_job_by_id
+
+    def delayed_chat(*args, **kwargs):
+        started.set()
+        assert release.wait(25)
+        try:
+            return original_chat(*args, **kwargs)
+        finally:
+            returned.set()
+
+    def delayed_ack(*args, **kwargs):
+        result = original_score(*args, **kwargs)
+        started.set()
+        assert release.wait(25)
+        returned.set()
+        return result
+
+    if committed:
+        monkeypatch.setattr(scorer, "score_job_by_id", delayed_ack)
+    else:
+        monkeypatch.setattr(world.llm, "chat_json", delayed_chat)
+    queue = f"qa-cancel-evidence-{uuid.uuid4()}"
+    async with local_env() as env:
+        assert await tick(env.client, world, queue) == 1
+        workflow_id = reserved_id(world, job_id, "score")
+        async with worker(env.client, queue):
+            handle = env.client.get_workflow_handle(workflow_id)
+            try:
+                assert await asyncio.to_thread(started.wait, 10)
+                await handle.cancel()
+                with pytest.raises(WorkflowFailureError) as failure:
+                    await asyncio.wait_for(handle.result(), 20)
+                assert isinstance(failure.value.cause, CancelledError)
+            finally:
+                release.set()
+            assert await asyncio.to_thread(returned.wait, 10)
+        assert _stage(world.conn, job_id, "score")["state"] == ("succeeded" if committed else "canceled")
+        for table in ("job_scores", "job_requirement_fit_reports", "job_requirement_fit_items"):
+            assert world.conn.execute(f"SELECT count(*) FROM {table} WHERE job_id=?", (str(job_id),)).fetchone()[
+                0
+            ] == int(committed)
+        if committed:
+            verify_report(world, job_id)
+        assert (await history_types(env.client, workflow_id)).count("cancel_preparation_state") == 1

--- a/workers/automation/tests/test_automatic_preparation_temporal_qa.py
+++ b/workers/automation/tests/test_automatic_preparation_temporal_qa.py
@@ -1085,3 +1085,76 @@ async def test_cancel_fences_uncommitted_report_and_retains_committed_pair(evide
         if committed:
             verify_report(world, job_id)
         assert (await history_types(env.client, workflow_id)).count("cancel_preparation_state") == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ["score", "tailor"])
+async def test_revoked_job_after_batch_filter_does_not_strand_other_jobs(world, monkeypatch, stage):
+    revoked = seed_for_stage(world, 1, stage)
+    other = seed_for_stage(world, 2, stage)
+    original_filter = recovery.automatic_recovery_job_ids
+
+    def revoke_after_filter(payload, selected_stage):
+        selected = original_filter(payload, selected_stage)
+        conn = database.get_connection()
+        set_stage_state(conn, revoked, stage, "canceled", validate_transition=False)
+        conn.commit()
+        assert selected == (revoked, other)
+        return selected
+
+    monkeypatch.setattr(recovery, "automatic_recovery_job_ids", revoke_after_filter)
+    if stage == "tailor":
+        def stop_at_generation(job, *args, **kwargs):
+            kwargs["commit_guard"]()
+            raise RuntimeError("synthetic generation provider unavailable")
+
+        monkeypatch.setattr(tailor, "_tailor_one_job", stop_at_generation)
+        monkeypatch.setattr(tailor, "TAILORED_DIR", world.app / "tailored")
+        original_tailor = tailor.tailor_job_by_id
+
+        def tailor_with_inputs(job_id, **kwargs):
+            return original_tailor(job_id, **kwargs, snapshot=_profile_snapshot(LOCAL_TENANT), pdf_renderer=object())
+
+        monkeypatch.setattr(tailor, "tailor_job_by_id", tailor_with_inputs)
+    queue = f"qa-revoked-{uuid.uuid4()}"
+    async with local_env() as env:
+        assert await tick(env.client, world, queue) == 2
+        workflow_id = reserved_id(world, other, stage)
+        async with worker(env.client, queue):
+            await asyncio.wait_for(env.client.get_workflow_handle(workflow_id).result(), 25)
+        assert _stage(world.conn, revoked, stage)["state"] == "canceled"
+        assert _stage(world.conn, other, stage)["state"] == ("succeeded" if stage == "score" else "failed")
+        assert _stage(world.conn, other, stage)["attempt_count"] == 1
+        await wait_idle(env.client)
+        await recovery._reconcile_stopped_activity_owners(env.client, world.conn)
+        await recovery._reconcile_interrupted_reservations(env.client, world.conn)
+        assert _stage(world.conn, other, stage)["error_code"] != "PREPARATION_RECOVERY_STOPPED"
+
+
+@pytest.mark.asyncio
+async def test_real_enrichment_batch_failure_before_first_claim_stops_recovery(world, monkeypatch):
+    from jobctrl.domain.errors import TransientNetworkError
+
+    job_id = seed_for_stage(world, 1, "enrich")
+
+    def fail_site_before_claim(*args, **kwargs):
+        raise TransientNetworkError("synthetic network outage before the first job claim")
+
+    monkeypatch.setattr(detail, "scrape_site_batch", fail_site_before_claim)
+    queue = f"qa-enrich-preflight-{uuid.uuid4()}"
+    async with local_env() as env:
+        assert await tick(env.client, world, queue) == 1
+        workflow_id = reserved_id(world, job_id, "enrich")
+        async with worker(env.client, queue):
+            await asyncio.wait_for(env.client.get_workflow_handle(workflow_id).result(), 25)
+        await wait_idle(env.client)
+        for _ in range(3):
+            world.conn.execute("UPDATE job_stage_states SET updated_at='2026-01-01T00:00:00Z'")
+            world.conn.commit()
+            assert await tick(env.client, world, queue) == 0
+        row = _stage(world.conn, job_id, "enrich")
+        assert row["state"] == "blocked"
+        assert row["error_code"] == "PREPARATION_RECOVERY_STOPPED"
+        assert row["attempt_count"] == 1
+        executions = [run async for run in env.client.list_workflows()]
+        assert len(executions) == 1

--- a/workers/automation/tests/test_codex_home_isolation.py
+++ b/workers/automation/tests/test_codex_home_isolation.py
@@ -15,6 +15,7 @@ import stat
 import tomllib
 from pathlib import Path
 from typing import Any
+from urllib.request import Request
 
 import pytest
 
@@ -58,6 +59,15 @@ def _profile_filesystem_permissions(overrides: tuple[str, ...]) -> dict[str, obj
     )
     parsed = tomllib.loads(profile_override)
     return parsed["permissions"][adapter._CODEX_PERMISSION_PROFILE]["filesystem"]
+
+
+def _assert_isolated_auth_env(env: dict[str, str]) -> None:
+    credential_keys = set(setup_probes.CODEX_NEUTRALIZED_AUTH_ENV) - {
+        "CODEX_REFRESH_TOKEN_URL_OVERRIDE", "CODEX_REVOKE_TOKEN_URL_OVERRIDE",
+    }
+    assert all(env[key] == "" for key in credential_keys)
+    assert env["CODEX_REFRESH_TOKEN_URL_OVERRIDE"] == "https://auth.openai.com/oauth/token"
+    assert env["CODEX_REVOKE_TOKEN_URL_OVERRIDE"] == "https://auth.openai.com/oauth/revoke"
 
 
 def test_config_overrides_select_workspace_only_permission_profile() -> None:
@@ -169,7 +179,33 @@ def test_isolated_codex_env_is_minimal_for_jobctrl_home(tmp_path: Path) -> None:
 
     assert env["CODEX_HOME"] == str(codex_home)
     assert env["HOME"] == str(process_home)
-    assert all(env[key] == "" for key in setup_probes.CODEX_NEUTRALIZED_AUTH_ENV)
+    _assert_isolated_auth_env(env)
+
+
+@pytest.mark.parametrize(
+    ("env_key", "expected_path"),
+    (
+        ("CODEX_REFRESH_TOKEN_URL_OVERRIDE", "/oauth/token"),
+        ("CODEX_REVOKE_TOKEN_URL_OVERRIDE", "/oauth/revoke"),
+    ),
+)
+def test_sdk_auth_endpoints_remain_valid_and_ignore_ambient_redirects(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    env_key: str,
+    expected_path: str,
+) -> None:
+    monkeypatch.setenv(env_key, "https://untrusted.invalid/collect")
+    overrides = adapter._isolated_codex_env(tmp_path / "codex", tmp_path / "home")
+    child_env = {**os.environ, **overrides}  # the SDK merges overrides into ambient env
+
+    # Build the request without sending it: an empty override fails here before
+    # authentication can report an expired/rejected saved login.
+    request = Request(child_env[env_key], data=b"synthetic", method="POST")
+
+    assert request.type == "https"
+    assert request.host == "auth.openai.com"
+    assert request.selector == expected_path
 
 
 def test_bundled_codex_uses_persisted_auth_and_neutralizes_raw_keys(
@@ -202,8 +238,8 @@ def test_bundled_codex_uses_persisted_auth_and_neutralizes_raw_keys(
         "CODEX_API_KEY": "",
         "CODEX_ACCESS_TOKEN": "",
         "CODEX_AGENT_IDENTITY_AUTH": "",
-        "CODEX_REFRESH_TOKEN_URL_OVERRIDE": "",
-        "CODEX_REVOKE_TOKEN_URL_OVERRIDE": "",
+        "CODEX_REFRESH_TOKEN_URL_OVERRIDE": "https://auth.openai.com/oauth/token",
+        "CODEX_REVOKE_TOKEN_URL_OVERRIDE": "https://auth.openai.com/oauth/revoke",
     }
 
 
@@ -236,10 +272,7 @@ def test_bundled_codex_factory_uses_persisted_credentials(
     assert codex.config.codex_bin == str(binary.resolve())
     assert codex.config.config_overrides == adapter._codex_config_overrides(binary.resolve())
     assert codex.config.env["OPENAI_API_KEY"] == ""
-    assert all(
-        codex.config.env[key] == ""
-        for key in setup_probes.CODEX_NEUTRALIZED_AUTH_ENV
-    )
+    _assert_isolated_auth_env(codex.config.env)
 
 
 @pytest.mark.parametrize("factory_name", ["_load_async_codex_factory", "_load_catalog_async_codex_factory"])

--- a/workers/automation/tests/test_discovery_enrichment_handoff.py
+++ b/workers/automation/tests/test_discovery_enrichment_handoff.py
@@ -1,0 +1,107 @@
+"""The producer's activity stop must leave its jobs available to the terminal pass."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from jobctrl.database import init_db
+from jobctrl.discovery.activities import DiscoveryEnrichmentActivityInput, discovery_enrichment_activity
+from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.enrichment.detail import (
+    _queue_enrichment_cohort,
+    _settle_interrupted_enrichment_cohort,
+    cancel_enrichment_cohort,
+)
+from jobctrl.state import ensure_job_stage_rows
+
+
+def test_live_activity_stop_preserves_the_terminal_enrichment_cohort(tmp_path, monkeypatch):
+    conn = init_db(tmp_path / "handoff.db")
+    job_id = JobId("10000000-0000-4000-8000-000000000001")
+    execution = DiscoveryExecutionRef(tenant_id="local", workflow_id="discover-local", temporal_run_id="run-1")
+    conn.execute(
+        "INSERT INTO jobs (tenant_id, job_id, url, title, site) VALUES ('local', ?, ?, ?, 'linkedin')",
+        (str(job_id), "https://www.linkedin.com/jobs/view/1234567890", "Engineering lead"),
+    )
+    ensure_job_stage_rows(conn, job_id)
+    conn.commit()
+    _queue_enrichment_cohort(
+        conn,
+        (job_id,),
+        tenant_id=LOCAL_TENANT,
+        workflow_id=execution.workflow_id,
+        workflow_run_id=execution.temporal_run_id,
+    )
+
+    def stop_live_consumer(**kwargs):
+        _settle_interrupted_enrichment_cohort(
+            conn,
+            (job_id,),
+            tenant_id=LOCAL_TENANT,
+            workflow_id=execution.workflow_id,
+            workflow_run_id=execution.temporal_run_id,
+            cancel_event=kwargs["cancel_event"],
+        )
+        return {"status": "ok"}
+
+    async def stop_then_run(fn, *, on_cancel, **_kwargs):
+        on_cancel()
+        return fn()
+
+    monkeypatch.setattr("jobctrl.pipeline.runner.run_discovery_enrichment_stage", stop_live_consumer)
+    monkeypatch.setattr("jobctrl.infrastructure.temporal.run_in_activity.run_blocking_with_heartbeat", stop_then_run)
+    monkeypatch.setattr("jobctrl.discovery.activities.activity.heartbeat", lambda *_args: None)
+    monkeypatch.setattr(
+        "jobctrl.enrichment.activities.activity.cancellation_details", lambda: SimpleNamespace(cancel_requested=True)
+    )
+    asyncio.run(
+        discovery_enrichment_activity(
+            DiscoveryEnrichmentActivityInput(
+                tenant_id="local",
+                stream_while_discovering=True,
+                discovery_execution=execution,
+            )
+        )
+    )
+
+    stage = conn.execute(
+        "SELECT state, attempt_count FROM job_stage_states WHERE job_id = ? AND stage = 'enrich'", (str(job_id),)
+    ).fetchone()
+    assert tuple(stage) == ("pending", 0)
+    assert conn.execute("SELECT COUNT(*) FROM job_events WHERE event_type = 'StageCanceled'").fetchone()[0] == 0
+    # The real terminal selector can reclaim the released job under the same run.
+    _queue_enrichment_cohort(
+        conn,
+        (job_id,),
+        tenant_id=LOCAL_TENANT,
+        workflow_id=execution.workflow_id,
+        workflow_run_id=execution.temporal_run_id,
+    )
+    assert (
+        conn.execute(
+            "SELECT state FROM job_stage_states WHERE job_id = ? AND stage = 'enrich'", (str(job_id),)
+        ).fetchone()[0]
+        == "queued"
+    )
+
+    # A real workflow cancellation still terminalizes that exact cohort.
+    assert (
+        cancel_enrichment_cohort(
+            conn,
+            (job_id,),
+            tenant_id=LOCAL_TENANT,
+            workflow_id=execution.workflow_id,
+            workflow_run_id=execution.temporal_run_id,
+        )
+        == 1
+    )
+    assert (
+        conn.execute(
+            "SELECT state FROM job_stage_states WHERE job_id = ? AND stage = 'enrich'", (str(job_id),)
+        ).fetchone()[0]
+        == "canceled"
+    )
+    conn.close()

--- a/workers/automation/tests/test_discovery_enrichment_handoff.py
+++ b/workers/automation/tests/test_discovery_enrichment_handoff.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+
+import pytest
 from types import SimpleNamespace
 
 from jobctrl.database import init_db
@@ -18,7 +20,8 @@ from jobctrl.enrichment.detail import (
 from jobctrl.state import ensure_job_stage_rows
 
 
-def test_live_activity_stop_preserves_the_terminal_enrichment_cohort(tmp_path, monkeypatch):
+@pytest.mark.parametrize("workflow_canceled", [False, True])
+def test_live_activity_stop_preserves_the_terminal_enrichment_cohort(tmp_path, monkeypatch, workflow_canceled):
     conn = init_db(tmp_path / "handoff.db")
     job_id = JobId("10000000-0000-4000-8000-000000000001")
     execution = DiscoveryExecutionRef(tenant_id="local", workflow_id="discover-local", temporal_run_id="run-1")
@@ -72,6 +75,22 @@ def test_live_activity_stop_preserves_the_terminal_enrichment_cohort(tmp_path, m
     ).fetchone()
     assert tuple(stage) == ("pending", 0)
     assert conn.execute("SELECT COUNT(*) FROM job_events WHERE event_type = 'StageCanceled'").fetchone()[0] == 0
+    if workflow_canceled:
+        from jobctrl.cli import _reconcile_canceled_enrichment_cohorts
+        from jobctrl.pipeline.automatic_preparation import reserve_recovery_batch
+
+        conn.execute(
+            "INSERT INTO workflow_run_projections "
+            "(workflow_id, tenant_id, workflow_type, status, temporal_run_id) "
+            "VALUES (?, 'local', 'DiscoverWorkflow', 'canceled', ?)",
+            (execution.workflow_id, execution.temporal_run_id),
+        )
+        conn.commit()
+        assert _reconcile_canceled_enrichment_cohorts(conn, tenant_id="local") == 1
+        assert reserve_recovery_batch(conn) is None
+        conn.close()
+        return
+
     # The real terminal selector can reclaim the released job under the same run.
     _queue_enrichment_cohort(
         conn,

--- a/workers/automation/tests/test_scorer.py
+++ b/workers/automation/tests/test_scorer.py
@@ -180,8 +180,7 @@ def _stage_row(conn: sqlite3.Connection, url: str, stage: str) -> sqlite3.Row | 
 def _seed_pending_job(conn: sqlite3.Connection, url: str) -> None:
     job_id = _job_id(url)
     conn.execute(
-        "INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at) "
-        "VALUES (?, ?, ?, ?, ?, ?)",
+        "INSERT INTO jobs (tenant_id, job_id, url, title, site, discovered_at) VALUES (?, ?, ?, ?, ?, ?)",
         (LOCAL_TENANT, job_id, url, "Engineer", "Acme", "2024-01-01T00:00:00+00:00"),
     )
     conn.execute(
@@ -298,9 +297,7 @@ def profile_snapshot(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_score_job_writes_only_to_job_scores(
-    conn: sqlite3.Connection, profile_snapshot
-) -> None:
+def test_score_job_writes_only_to_job_scores(conn: sqlite3.Connection, profile_snapshot) -> None:
     url = "https://example.com/job/single"
     _seed_pending_job(conn, url)
     repo = SqliteScoreRepository(conn)
@@ -315,9 +312,7 @@ def test_score_job_writes_only_to_job_scores(
         }
     )
 
-    job_dict = dict(
-        conn.execute("SELECT * FROM jobs WHERE tenant_id = ? AND url = ?", (LOCAL_TENANT, url)).fetchone()
-    )
+    job_dict = dict(conn.execute("SELECT * FROM jobs WHERE tenant_id = ? AND url = ?", (LOCAL_TENANT, url)).fetchone())
     outcome = scorer_module.score_job(
         profile_snapshot,
         job_dict,
@@ -368,9 +363,7 @@ def test_score_job_with_explicit_sqlite_repository_uses_persisted_policy(
         }
     )
 
-    job_dict = dict(
-        conn.execute("SELECT * FROM jobs WHERE tenant_id = ? AND url = ?", (LOCAL_TENANT, url)).fetchone()
-    )
+    job_dict = dict(conn.execute("SELECT * FROM jobs WHERE tenant_id = ? AND url = ?", (LOCAL_TENANT, url)).fetchone())
     outcome = scorer_module.score_job(
         profile_snapshot,
         job_dict,
@@ -683,9 +676,7 @@ def test_score_job_prompt_uses_company_not_source(
 # ---------------------------------------------------------------------------
 
 
-def test_run_scoring_persists_via_repository_only(
-    conn: sqlite3.Connection, profile_snapshot, monkeypatch
-) -> None:
+def test_run_scoring_persists_via_repository_only(conn: sqlite3.Connection, profile_snapshot, monkeypatch) -> None:
     url = "https://example.com/job/batch"
     _seed_pending_job(conn, url)
     repo = SqliteScoreRepository(conn)
@@ -1038,6 +1029,78 @@ def test_run_scoring_refreshes_stale_posting_analysis_before_persisting_fit_repo
     assert report.employer_analysis_generation == 2
 
 
+@pytest.mark.parametrize("automatic_recovery", [False, True])
+def test_selected_score_retains_requirement_fit_persistence(
+    conn: sqlite3.Connection,
+    profile_snapshot,
+    monkeypatch,
+    automatic_recovery: bool,
+) -> None:
+    url = "https://example.com/job/selected-score-requirement-evidence"
+    _seed_pending_job(conn, url)
+    job_id = _job_id(url)
+    workflow_id = "prepare-auto-local-score-evidence-regression"
+    owner = "score-evidence-execution"
+    if automatic_recovery:
+        set_stage_state(
+            conn,
+            job_id,
+            "score",
+            "queued",
+            metadata={"automaticPreparation": {"workflowId": workflow_id}},
+            validate_transition=False,
+        )
+        conn.commit()
+    llm = _ScriptedLlm(
+        {
+            "score": 8,
+            "technical_fit": 8,
+            "experience_fit": 7,
+            "role_fit": 8,
+            "fit_band": "strong",
+            "confidence": "high",
+            "eligibility": {"status": "eligible", "hard_blockers": [], "warnings": []},
+            "matched_signals": [],
+            "missing_signals": ["Python platform experience"],
+            "transferable_signals": [],
+            "keywords": ["python"],
+            "reasoning": "No supplied profile evidence matches the posting requirement.",
+            "requirement_assessments": [
+                {
+                    "requirement_id": "req-python-platform",
+                    "requirement_text": "Own Python platform reliability.",
+                    "tier": "must_have",
+                    "weight": 0.9,
+                    "job_evidence_span": "Need Python.",
+                    "fit": {"kind": "missing", "reason": "No profile evidence."},
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(scorer_module, "get_connection", lambda: conn)
+
+    outcome = scorer_module.score_job_by_id(
+        job_id,
+        profile_snapshot=profile_snapshot,
+        resume_text="Engineer with Python.",
+        criteria=ScoringCriteria(),
+        llm_port=llm,
+        workflow_id=owner if automatic_recovery else None,
+        recovery_workflow_id=workflow_id if automatic_recovery else None,
+        enforce_workflow_ownership=automatic_recovery,
+    )
+
+    assert outcome.ok
+    assert outcome.score is not None
+    report = SqliteRequirementFitReportRepository(conn).load(LOCAL_TENANT, job_id, score_version=outcome.score.version)
+    assert report is not None
+    assert report.employer_analysis_generation == 1
+    assert report.resolved_fit_score == outcome.score.fit_score
+    assert report.assessments[0].requirement_id == "req-python-platform"
+    assert report.assessments[0].fit.kind == "missing"
+    assert _stage_row(conn, url, "score")["state"] == "succeeded"
+
+
 def test_run_scoring_generates_employer_analysis_before_prompt(
     conn: sqlite3.Connection,
     profile_snapshot,
@@ -1167,8 +1230,7 @@ def test_run_scoring_records_safe_per_leg_causes_when_analysis_ensemble_fails(
     assert llm.calls == 0
     stage_row = _stage_row(conn, url, "score")
     assert stage_row["error_message"] == (
-        "Employer analysis failed: all ensemble legs failed "
-        "(claude:model-a: TimeoutError; codex:model-b: ValueError)"
+        "Employer analysis failed: all ensemble legs failed (claude:model-a: TimeoutError; codex:model-b: ValueError)"
     )
     assert "provider timed out" not in stage_row["error_message"]
     assert "private raw output" not in stage_row["error_message"]
@@ -1228,9 +1290,7 @@ def test_run_scoring_reuses_same_content_score_for_duplicate_jobs(
 
     assert summary["scored"] == 2
     assert summary["errors"] == 0
-    assert sorted(summary["scoredJobIds"]) == sorted(
-        [str(_job_id(first_url)), str(_job_id(duplicate_url))]
-    )
+    assert sorted(summary["scoredJobIds"]) == sorted([str(_job_id(first_url)), str(_job_id(duplicate_url))])
     assert llm.calls == 1
     first_score = repo.load(LOCAL_TENANT, _job_id(first_url))
     duplicate_score = repo.load(LOCAL_TENANT, _job_id(duplicate_url))

--- a/workers/automation/tests/test_scorer.py
+++ b/workers/automation/tests/test_scorer.py
@@ -513,10 +513,12 @@ def test_score_job_by_url_syncs_existing_blocked_score_to_downstream_stages(
     assert all("candidate requires sponsorship" in row["error_message"] for row in rows)
 
 
+@pytest.mark.parametrize("automatic_recovery", [False, True])
 def test_score_job_by_url_reuses_direct_score_for_reference_repost(
     conn: sqlite3.Connection,
     profile_snapshot,
     monkeypatch,
+    automatic_recovery,
 ) -> None:
     direct_url = "https://es.indeed.com/viewjob?jk=direct-ai-security"
     repost_url = "https://www.linkedin.com/jobs/view/reference-ai-security"
@@ -588,8 +590,21 @@ def test_score_job_by_url_reuses_direct_score_for_reference_repost(
         }
     )
 
-    outcome = scorer_module.score_job_by_url(
-        repost_url,
+    owned_args = {}
+    if automatic_recovery:
+        set_stage_state(
+            conn, _job_id(repost_url), "score", "queued", attempt_count=2,
+            metadata={"automaticPreparation": {"workflowId": "prepare-auto-local-score-reuse"}},
+            validate_transition=False,
+        )
+        conn.commit()
+        owned_args = {
+            "workflow_id": "reuse-run", "recovery_workflow_id": "prepare-auto-local-score-reuse",
+            "enforce_workflow_ownership": True,
+        }
+    outcome = scorer_module.score_job_by_id(
+        _job_id(repost_url),
+        **owned_args,
         profile_snapshot=profile_snapshot,
         resume_text="AI security leader.",
         criteria=criteria,
@@ -602,6 +617,9 @@ def test_score_job_by_url_reuses_direct_score_for_reference_repost(
     repost_score = repo.load(LOCAL_TENANT, _job_id(repost_url))
     assert repost_score is not None
     assert repost_score.fit_score.value == 9
+    stage = _stage_row(conn, repost_url, "score")
+    assert stage["state"] == "succeeded"
+    assert stage["attempt_count"] == (3 if automatic_recovery else 1)
     event = conn.execute(
         """
         SELECT event_type, message
@@ -1616,3 +1634,47 @@ def test_score_job_by_url_increments_score_attempts_on_failure(
         )
         assert outcome.ok is False
         assert _score_attempt_count(conn, url) == expected
+
+
+@pytest.mark.parametrize("cancel_before_finish", [False, True])
+def test_owned_existing_score_finishes_with_eligibility_and_owner_fence(
+    conn, profile_snapshot, monkeypatch, cancel_before_finish,
+):
+    url = "https://example.test/existing-owned-score"
+    _seed_pending_job(conn, url)
+    job_id = _job_id(url)
+    repository = SqliteScoreRepository(conn)
+    repository.save(JobScore.initial(
+        tenant_id=LOCAL_TENANT, job_id=job_id, fit_score=FitScore.create(3),
+        breakdown=ScoreBreakdown(reasoning="Below threshold."),
+        matched_keywords=MatchedKeywords.from_iterable([]), scored_at="2026-09-01T00:00:00Z",
+    ))
+    set_stage_state(
+        conn, job_id, "score", "queued", attempt_count=2,
+        metadata={"automaticPreparation": {"workflowId": "prepare-auto-local-score-existing"}},
+        validate_transition=False,
+    )
+    conn.commit()
+    monkeypatch.setattr(scorer_module, "get_connection", lambda: conn)
+    if cancel_before_finish:
+        def revoke_before_finish(**kwargs):
+            set_stage_state(conn, job_id, "score", "canceled", attempt_count=2, validate_transition=False)
+            conn.commit()
+            return None
+        monkeypatch.setattr(scorer_module, "_preferred_direct_score_for_repost", revoke_before_finish)
+    result = scorer_module.score_job_by_id(
+        job_id, repository=repository, profile_snapshot=profile_snapshot, resume_text="Engineer.",
+        criteria=ScoringCriteria(), workflow_id="owned-run",
+        recovery_workflow_id="prepare-auto-local-score-existing", enforce_workflow_ownership=True,
+    )
+    assert result.ok
+    row = _stage_row(conn, url, "score")
+    assert row["state"] == ("canceled" if cancel_before_finish else "succeeded")
+    assert row["attempt_count"] == (2 if cancel_before_finish else 3)
+    completed = conn.execute(
+        "SELECT COUNT(*) FROM job_events WHERE job_id = ? AND stage = 'score' AND event_type = 'StageCompleted'",
+        (str(job_id),),
+    ).fetchone()[0]
+    assert completed == int(not cancel_before_finish)
+    if not cancel_before_finish:
+        assert _stage_row(conn, url, "tailor")["state"] == "skipped"


### PR DESCRIPTION
Saved preparation work could remain stranded after worker interruption, a lost workflow-start acknowledgement, or the handoff from discovery's streaming enrichment to its terminal pass. Resume eligible Enrich, Score, Tailor, and Cover work from startup and heartbeat using bounded durable reservations and exact Temporal execution ownership. Preserve cancellation, attempts, cooldowns, spend limits, approved artifacts, and persistence fences; recovery does not start Discover or Apply.

Persist requirement-fit evidence with owned scores and release only the matching retryable missing-evidence Tailor block after a valid rescore. Reconcile closed owners before dispatch and prevent disconnected predecessors from committing late results. Provider login refresh/revocation endpoints retain their required HTTPS defaults after ambient credentials are cleared.

Includes deterministic state regressions, real Temporal recovery/cancellation fixtures, and owning runtime, operations, enrichment, and security documentation.

Validation on cumulative head `a72c3078008482345c7ff14937cf8bc02511540d`:

- Ruff, API/web typechecks, all 828 API tests, 9 focused dashboard tests, 13 web type tests, production web build, docs build, and `git diff --check` pass. The fresh full Python run passed **3841 tests with 2 optional skips**.
- Independent cumulative review: **Gate: PASS**, no findings; 48 guarded Python cases, 4 API digest cases and all 9 dashboard cases passed.
- Independent cumulative product QA: **Gate: PASS**, no findings; 29 material-validation cases and 30 Temporal cases passed, with 19 real owned server lifecycles and balanced shutdowns. Three actual API surfaces and three desktop/mobile browser scenarios preserved canonical source data, failure/block information, readable labels and Inspect navigation; scoped accessibility, console and network checks passed.
- Prior SDK isolation and timeout/reservation gates were carried forward after source and dependency equality checks. The separate authenticated-provider/owner-extension operational requirement on #860 remains open.

These three PRs extend the existing unreleased stack. Owning contract and safety documentation accompanies the relevant phase; the final recovery PR carries the shared canonical product documentation and cumulative QA checklist.

This PR’s latest [Python CI](https://github.com/ebarti/JobCtrl/actions/runs/34125358301) and [TypeScript CI](https://github.com/ebarti/JobCtrl/actions/runs/34125358399) passed at its published head. All five TypeScript jobs passed, including E2E and Storybook; other applicable workflows passed and DCO was explicitly skipped. The final cumulative Python CI also passed lint, all 3841 tests (2 optional skips), and package builds on Python 3.11, 3.12 and 3.13.
