### PR TITLE
fix(tailor): preserve grounded role and summary evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,8 @@ evidence, qualifications, and the complete capability matrix.
 - Generate tailored resumes, cover letters, PDFs, and review artifacts. Resume
   tailoring selects the smallest job-relevant set of profile achievements;
   per-role bullet limits are ceilings, and each metric stays bound to the
-  achievement that contains it.
+  achievement that contains it. Required roles with no achievement evidence
+  retain their existing role details without generated bullets.
 - Triage jobs through the real **Active**, **Deleted**, and **Hidden** queues.
   The default Active view keeps source and warning columns available but hidden,
   uses destructive styling for deletion, and opens a row through its focused
@@ -283,6 +284,11 @@ evidence, qualifications, and the complete capability matrix.
   failure reason, and Retry resets that budget. Runs keeps the durable workflow
   history; Jobs and route-level
   detail workspaces keep record-specific evidence and actions adjacent.
+- Recover unfinished enrichment, scoring, and material generation
+  automatically. While the worker is running, eligible saved jobs resume within
+  their existing retry budget without another discovery search. Explicit
+  cancellations, safety blocks, and completed results are preserved; recovery
+  does not start Apply. See [preparation recovery](docs/architecture/pipeline/operations.md#automatic-preparation-recovery).
 - Inspect Discover, preparation, and Apply through the same Runs vocabulary,
   timeline, terminal-state rules, and cancellation control. Repeated cancel
   requests are harmless, the requester/source remains in the run timeline, and

--- a/README.md
+++ b/README.md
@@ -236,8 +236,10 @@ evidence, qualifications, and the complete capability matrix.
 - Generate tailored resumes, cover letters, PDFs, and review artifacts. Resume
   tailoring selects the smallest job-relevant set of profile achievements;
   per-role bullet limits are ceilings, and each metric stays bound to the
-  achievement that contains it. Required roles with no achievement evidence
-  retain their existing role details without generated bullets.
+  achievement that contains it. Required roles with neither achievement evidence
+  nor required bullet pins retain their existing role details without generated
+  bullets. A pinned bullet still needs supporting evidence from its own role;
+  restore that evidence or remove the pin before tailoring.
 - Triage jobs through the real **Active**, **Deleted**, and **Hidden** queues.
   The default Active view keeps source and warning columns available but hidden,
   uses destructive styling for deletion, and opens a row through its focused

--- a/docs/architecture/tailoring.md
+++ b/docs/architecture/tailoring.md
@@ -440,10 +440,13 @@ profile contract:
   several bullets.
 - A covered or explicitly pinned role cannot carry positioning-only filler. A
   required role with neither receives exactly one positioning bullet when it
-  has achievement evidence. A required role with no achievement evidence keeps
-  its fixed role details and an empty bullet list; the generator must not invent
-  a claim or borrow another role's achievement. An optional unsupported role is
-  omitted.
+  has achievement evidence. A required role with neither achievement evidence
+  nor required bullet pins keeps its fixed role details and an empty bullet list;
+  the generator must not invent a claim or borrow another role's achievement.
+  Pinned bullets remain mandatory, so roles with pins are excluded from the
+  prompt's empty-bullet exception. A pin without supporting evidence from its own
+  role requires a profile correction: restore the evidence or remove the pin.
+  An optional unsupported role is omitted.
 - Generated title must be empty or exactly match the source title.
 - Each required skill category ID must appear exactly once.
 - Unknown or duplicate skill category IDs are rejected.

--- a/docs/architecture/tailoring.md
+++ b/docs/architecture/tailoring.md
@@ -23,6 +23,10 @@ behind a stack of gates. What it guarantees:
 - Every experience bullet maps to one achievement. Each numeric claim must be
   present in that same achievement's evidence; a global metric inventory is not
   claim authority.
+- When rewriting the executive profile, baseline tenure estimates are omitted
+  or expressed qualitatively unless the mapped achievement evidence supports
+  them. The generator preserves each retained metric and verified content pin;
+  it is not instructed to copy every number from the baseline summary.
 - No fabricated metric, date, title, employer, or ungrounded named technology
   survives into an approved artifact.
 - Keyword coverage is computed against the rendered resume text, never inferred
@@ -435,8 +439,11 @@ profile contract:
   one primary achievement evidence ID; the same achievement cannot produce
   several bullets.
 - A covered or explicitly pinned role cannot carry positioning-only filler. A
-  required role with neither receives exactly one evidence-backed positioning
-  bullet; an optional unsupported role is omitted.
+  required role with neither receives exactly one positioning bullet when it
+  has achievement evidence. A required role with no achievement evidence keeps
+  its fixed role details and an empty bullet list; the generator must not invent
+  a claim or borrow another role's achievement. An optional unsupported role is
+  omitted.
 - Generated title must be empty or exactly match the source title.
 - Each required skill category ID must appear exactly once.
 - Unknown or duplicate skill category IDs are rejected.

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -37,6 +37,42 @@ Start the attached full stack with `corepack pnpm dev` when the path needs the
 API, Temporal, worker, and web app together. Confirm `GET /v1/health` reports a
 healthy worker before starting worker-backed stages.
 
+For automatic preparation recovery, seed canonical failed enrichment and a
+saved enriched/unscored job, then exercise worker startup/heartbeat without a
+Discover command. Prove enrichment can advance to a persisted score, a restart
+or lost dispatch acknowledgement retains one execution, and retries preserve
+attempts and cooldowns. Include canceled/unsafe/blocked/exhausted, deleted,
+closed, and other-tenant jobs; preserve accepted scores/materials and prove no
+Apply dispatch. The historical discovery consumer-stop fixture must require
+positive evidence from the exact completed run and reject user cancellations.
+Use the real Temporal recovery fixture to prove worker replacement, late
+provider results after cancellation, and exact stopped-owner settlement.
+Missing workflow history must retain ownership; a recovered enrichment lease
+must reject a late predecessor write.
+For an automatic batch interrupted by an activity timeout, include one consumed
+job and one reservation that never started. Prove the latter returns to pending
+with unchanged attempt counters and can enter a new workflow after cooldown,
+including when the earlier cleanup already marked it `PREPARATION_RECOVERY_STOPPED`.
+Require the exact execution's timeout and durable attempt progress; cancellation,
+termination, missing history, mismatched cohorts, and preflight-only failures
+must not release reservations. Include copied timeout history in a reset
+descendant and a mismatched scheduled activity owner. Recheck protected rows
+while holding the write lock.
+An owned Score must persist a requirement-fit report for its exact score version,
+and real Tailor prerequisite evaluation must consume it. Reproduce a historical
+missing report, rescore only that job through the normal workflow, preserve the
+old score, and prove both explicit and automatic Tailor continuation. Automatic
+continuation must respect the real cooldown. Incoherent or empty reports and
+canceled, exhausted, non-retryable, or budget-exhausted rows must remain blocked
+from automatic resumption.
+Dashboard source-health and digest QA must show JobStreaming names while
+retaining the underlying quarantine, failure counts, and stable source IDs.
+For summary metric grounding, seed a baseline tenure estimate with no supporting
+achievement and a separately pinned verified metric. The normal Tailor use case
+must reject the tenure claim even with an unrelated citation, retain that failure
+in the audit, accept a grounded qualitative rewrite, and preserve the pinned
+metric and original profile. Retry instructions remain code-owned guidance.
+
 ## Pull-request CI
 
 CI is plain path-filtered GitHub Actions with no routing layer: each workflow
@@ -638,6 +674,12 @@ rollback before calling the public deployment healthy.
 
 ### Provider setup gate
 
+For the isolated Codex SDK environment, merge hostile ambient credential and
+auth-endpoint overrides as the real SDK does. Credential values must remain
+cleared, while refresh/revocation requests must build valid HTTPS URLs for
+OpenAI's default endpoints. Empty URLs must not mask an expired or rejected
+saved login as a request-builder failure.
+
 When provider auth, Settings credentials, model routing, or employer analysis
 changes, prove each sanctioned provider independently: Codex persisted CLI auth,
 Claude API/cloud auth, Google Gemini key, Google standard ADC, and an existing
@@ -723,6 +765,12 @@ a fabricated or judge-rejected candidate with invalid JSON and prove the run
 stays rejected, its history remains inspectable, and the previous accepted
 artifact bytes survive. Retain the transaction and render-failure fixtures that
 protect the previous accepted generation and provenance.
+Include a required experience entry with no source bullets or achievement
+evidence: Tailor must accept an empty bullet list while the assembled artifact
+preserves its employer, title, and dates. The same empty list must fail for a
+role with achievement evidence; an invented positioning bullet must still fail
+its evidence check. Keep this case in the real Materials use-case fixture so
+field validation, claim validation, assembly, and accepted provenance all run.
 Also return parsed JSON with `skill_category_updates: null` before a valid
 candidate: field validation must reject it before assembly, preserve its audit
 and continue bounded repair. Exhausting that malformed response must leave the

--- a/docs/user/materials-and-tailoring.md
+++ b/docs/user/materials-and-tailoring.md
@@ -46,7 +46,9 @@ last accepted resume.
    and skill-category IDs, preserve source titles, respect bullet limits, and
    use skills that already exist in the profile. The generator selects the
    smallest sufficient achievement set: a maximum bullet count is a ceiling,
-   not a quota, and optional inventory does not become required content.
+   not a quota, and optional inventory does not become required content. Required
+   roles with no achievement evidence retain their existing role details without
+   generated bullets.
 3. **Validate the assembled resume, not just model JSON.** Deterministic checks
    run over the actual candidate text for grounding, preserved employers,
    education, section structure, prohibited claims, metrics, seniority, and
@@ -167,6 +169,11 @@ and Apply Review, but the resume is never required to claim them. An unknown
 office-attendance preference can therefore warn or ask for confirmation; it
 cannot reject a resume candidate or spend Tailor retries.
 
+When summary rewriting is enabled, an old years-of-experience estimate may be
+expressed qualitatively if it lacks supporting achievement evidence. Verified
+metrics and required achievement bullets remain subject to their normal
+preservation checks.
+
 Cover letters follow the same evidence boundary. They may describe employer
 priorities from the posting, but posting-only numbers and dates are omitted or
 expressed qualitatively. Only numeric/date facts already grounded in the
@@ -177,6 +184,11 @@ generation, JobCtrl shows Tailor as blocked by Score and asks you to rescore the
 job. This prerequisite block does not consume a Tailor retry. It prevents an
 empty coverage plan from being retried as though it were a model-quality
 failure.
+
+When rescoring restores missing evidence, JobCtrl returns that retryable Tailor
+block to pending after checking the current score and posting analysis. The
+worker can then continue automatically after the normal cooldown and eligibility
+checks. This preserves prior attempts, canceled decisions, and approved resumes.
 
 The minimum-fit policy is a different terminal decision. When the current
 score is below the live materials threshold, Tailor, Cover, and Apply are

--- a/docs/user/materials-and-tailoring.md
+++ b/docs/user/materials-and-tailoring.md
@@ -47,8 +47,10 @@ last accepted resume.
    use skills that already exist in the profile. The generator selects the
    smallest sufficient achievement set: a maximum bullet count is a ceiling,
    not a quota, and optional inventory does not become required content. Required
-   roles with no achievement evidence retain their existing role details without
-   generated bullets.
+   roles with neither achievement evidence nor required bullet pins retain their
+   existing role details without generated bullets. If a required bullet remains
+   pinned after its supporting achievement is removed, restore that role's
+   evidence or remove the pin before tailoring; pins are still mandatory.
 3. **Validate the assembled resume, not just model JSON.** Deterministic checks
    run over the actual candidate text for grounding, preserved employers,
    education, section structure, prohibited claims, metrics, seniority, and

--- a/workers/automation/src/jobctrl/domain/materials/services.py
+++ b/workers/automation/src/jobctrl/domain/materials/services.py
@@ -36,6 +36,7 @@ from jobctrl.domain.materials.value_objects import ValidationResult
 from jobctrl.domain.profile.snapshot import ProfileSnapshot
 from jobctrl.resume_profile import (
     experience_updates_by_id,
+    get_achievement_evidence,
     get_education_entries,
     get_experience_entries,
     get_max_experience_bullets,
@@ -212,6 +213,9 @@ def _validate_master_json_fields(
     all_experience_ids = {entry.get("id") for entry in experience_entries}
     required_experience_ids = set(get_required_experience_entry_ids(profile)) & all_experience_ids
     required_bullets_by_entry = get_required_bullets_by_experience_id(profile)
+    evidence_entry_ids = {
+        item["experience_entry_id"] for item in get_achievement_evidence(profile)
+    }
     required_skill_ids = set(get_required_skill_category_ids(profile))
     max_bullets = get_max_experience_bullets(profile)
 
@@ -230,7 +234,10 @@ def _validate_master_json_fields(
             errors.append(f"Duplicate experience update: {entry_id}")
             continue
         seen_experience_ids.add(entry_id)
-        if not isinstance(bullets, list) or not bullets:
+        if not isinstance(bullets, list) or (
+            not bullets
+            and (entry_id in evidence_entry_ids or required_bullets_by_entry.get(entry_id))
+        ):
             errors.append(f"Experience update '{entry_id}' must include bullets")
             continue
         effective_bullets = [str(bullet).strip() for bullet in bullets if str(bullet).strip()]

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -1700,11 +1700,13 @@ def build_master_tailor_prompt(
     require_resume_master(profile)
     resume = get_resume_master(profile)
     required_experience_ids = get_required_experience_entry_ids(profile)
+    required_bullets = get_required_bullets_by_experience_id(profile)
     evidence_entry_ids = {
         item["experience_entry_id"] for item in get_achievement_evidence(profile)
     }
-    required_roles_without_evidence = [
-        entry_id for entry_id in required_experience_ids if entry_id not in evidence_entry_ids
+    required_roles_allowing_empty_bullets = [
+        entry_id for entry_id in required_experience_ids
+        if entry_id not in evidence_entry_ids and not required_bullets.get(entry_id)
     ]
     required_skill_ids = get_required_skill_category_ids(profile)
     all_experience_entries = get_experience_entries(profile)
@@ -1749,7 +1751,6 @@ def build_master_tailor_prompt(
         for entry in education_entries
     ]
 
-    required_bullets = get_required_bullets_by_experience_id(profile)
     tailoring_policy = get_tailoring_policy(profile)
     writing_style = get_writing_style(profile)
     custom_tailoring_prompt = get_custom_tailoring_prompt(profile)
@@ -1855,9 +1856,10 @@ HARD RULES:
 - If a required role has target-covered or explicitly pinned evidence, include
   only those bullets and no positioning-only filler. If it has neither, include
   exactly one positioning bullet citing an achievement from that role when one exists
-- For REQUIRED EXPERIENCE IDS WITHOUT ACHIEVEMENT EVIDENCE, return bullets: []
+- For REQUIRED EXPERIENCE IDS ALLOWING EMPTY BULLETS, return bullets: []
   and title: "". The code preserves the source role details. Do not invent a
-  positioning bullet or cite an achievement from another role
+  positioning bullet or cite an achievement from another role. This exception
+  applies only to roles with neither achievement evidence nor required bullet pins
 - non_requirement_reason is a required fallback classification. Choose pinned,
   positioning, or structure. When coverage_edge_ids is non-empty it is ignored;
   when coverage_edge_ids is empty it must truthfully classify the claim
@@ -1908,8 +1910,8 @@ WRITING STYLE:
 REQUIRED EXPERIENCE IDS:
 {json.dumps(required_experience_ids, ensure_ascii=False)}
 
-REQUIRED EXPERIENCE IDS WITHOUT ACHIEVEMENT EVIDENCE:
-{json.dumps(required_roles_without_evidence, ensure_ascii=False)}
+REQUIRED EXPERIENCE IDS ALLOWING EMPTY BULLETS:
+{json.dumps(required_roles_allowing_empty_bullets, ensure_ascii=False)}
 
 REQUIRED SKILL CATEGORY IDS:
 {json.dumps(required_skill_ids, ensure_ascii=False)}

--- a/workers/automation/src/jobctrl/domain/materials/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/materials/use_cases.py
@@ -168,6 +168,7 @@ from jobctrl.domain.profile.achievement_metrics import (
 from jobctrl.model_defaults import DEFAULT_PIPELINE_LLM_MODEL_SPEC
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.resume_profile import (
+    get_achievement_evidence,
     get_custom_tailoring_prompt,
     get_education_entries,
     get_experience_entries,
@@ -185,8 +186,8 @@ from jobctrl.resume_profile import (
 
 log = logging.getLogger(__name__)
 
-TAILORING_PROMPT_VERSION = "tailor.v6.minimal-achievement-set"
-TAILORING_SCHEMA_VERSION = "tailored-resume.v3"
+TAILORING_PROMPT_VERSION = "tailor.v8.summary-metric-grounding"
+TAILORING_SCHEMA_VERSION = "tailored-resume.v4"
 TAILORING_JUDGE_SCHEMA_VERSION = "tailor-judge.v2.final-semantic-fidelity"
 TAILORING_JUDGE_CRITERIA: tuple[str, ...] = (
     "relevance_to_job",
@@ -249,7 +250,7 @@ TAILORED_RESUME_RESPONSE_SCHEMA: dict[str, Any] = {
                     "title": {"type": "string"},
                     "bullets": {
                         "type": "array",
-                        "minItems": 1,
+                        "minItems": 0,
                         "items": {"type": "string"},
                     },
                 },
@@ -1007,10 +1008,12 @@ def _experience_bullet_curation_errors(
     bullet represents exactly one achievement. Target-covered and explicit
     pinned achievements may appear; a required role with neither gets exactly
     one evidence-backed positioning bullet so the role remains representable.
+    A required role with no achievement evidence retains only its fixed metadata.
     """
 
     mapping_tuple = tuple(mappings)
     evidence_by_id = tailoring_plan.evidence_by_id
+    evidence_entry_ids = {item.experience_entry_id for item in evidence_by_id.values()}
     pins = tailoring_plan.requirement_led_controls.required_content_pins
     required_roles = set(pins.experience_entry_ids)
     explicit_evidence_pins = set(tailoring_plan.required_evidence_ids)
@@ -1095,7 +1098,11 @@ def _experience_bullet_curation_errors(
                 for mapping in positioning
             )
         elif not covered_or_pinned:
-            if entry_id in required_roles and len(positioning) != 1:
+            if (
+                entry_id in required_roles
+                and entry_id in evidence_entry_ids
+                and len(positioning) != 1
+            ):
                 errors.append(
                     f"Required experience {entry_id} without target-covered or pinned "
                     "evidence must have exactly one positioning-only bullet."
@@ -1311,7 +1318,10 @@ _RETRY_GUIDANCE: dict[str, str] = {
     ),
     "validation_failed": (
         "Correct the schema and deterministic validation failures without adding "
-        "facts beyond canonical profile evidence."
+        "facts beyond canonical profile evidence. For summary years of experience "
+        "or other quantities, require support from the cited achievement evidence; "
+        "otherwise remove the quantity and retain only the supported qualitative "
+        "claim. Preserve verified pinned metrics."
     ),
 }
 
@@ -1690,6 +1700,12 @@ def build_master_tailor_prompt(
     require_resume_master(profile)
     resume = get_resume_master(profile)
     required_experience_ids = get_required_experience_entry_ids(profile)
+    evidence_entry_ids = {
+        item["experience_entry_id"] for item in get_achievement_evidence(profile)
+    }
+    required_roles_without_evidence = [
+        entry_id for entry_id in required_experience_ids if entry_id not in evidence_entry_ids
+    ]
     required_skill_ids = get_required_skill_category_ids(profile)
     all_experience_entries = get_experience_entries(profile)
     all_skill_categories = get_skill_categories(profile)
@@ -1790,6 +1806,10 @@ SOURCE OF TRUTH:
   in the TAILORING QUALITY PLAN are the only evidence for candidate claims.
 - A metric belongs only to the achievement evidence that contains it. Never use
   a number from one achievement to quantify another claim.
+- For a rewritten executive profile, use a metric only when its cited achievement
+  evidence supports that exact claim. If baseline years of experience or other
+  summary quantities lack that evidence, omit the quantity and use qualitative
+  wording. Do not infer tenure from employment dates.
 - TARGET JOB text is context only. Do NOT copy target-job technologies,
   systems, responsibilities, business claims, or phrases into the candidate's
   executive profile or bullets unless the same fact appears in the master
@@ -1808,7 +1828,7 @@ HARD RULES:
 - Do NOT add or remove skill categories
 - Do NOT rewrite historical experience titles or append job keywords to titles
 - Skill items must be exact strings from MASTER SKILL CATEGORIES; do NOT add job-only skills
-- Preserve every number exactly and bind it to the same achievement that supplied it
+- Preserve each retained metric exactly and bind it to the achievement that supplied it
 - Do NOT invent companies, roles, degrees, or certifications
 - Max {max_bullets} bullets per experience entry is a hard ceiling, never a target;
   requirement coverage and required bullets do not permit an overflow
@@ -1834,7 +1854,10 @@ HARD RULES:
 - Use each achievement evidence id in at most one experience bullet
 - If a required role has target-covered or explicitly pinned evidence, include
   only those bullets and no positioning-only filler. If it has neither, include
-  exactly one evidence-backed positioning bullet so the required role remains visible
+  exactly one positioning bullet citing an achievement from that role when one exists
+- For REQUIRED EXPERIENCE IDS WITHOUT ACHIEVEMENT EVIDENCE, return bullets: []
+  and title: "". The code preserves the source role details. Do not invent a
+  positioning bullet or cite an achievement from another role
 - non_requirement_reason is a required fallback classification. Choose pinned,
   positioning, or structure. When coverage_edge_ids is non-empty it is ignored;
   when coverage_edge_ids is empty it must truthfully classify the claim
@@ -1884,6 +1907,9 @@ WRITING STYLE:
 {quality_plan_block}
 REQUIRED EXPERIENCE IDS:
 {json.dumps(required_experience_ids, ensure_ascii=False)}
+
+REQUIRED EXPERIENCE IDS WITHOUT ACHIEVEMENT EVIDENCE:
+{json.dumps(required_roles_without_evidence, ensure_ascii=False)}
 
 REQUIRED SKILL CATEGORY IDS:
 {json.dumps(required_skill_ids, ensure_ascii=False)}

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -2132,6 +2132,45 @@ def test_tailor_use_case_does_not_promote_judge_feedback_into_retry_prompt(
     )
 
 
+@pytest.mark.parametrize("unrelated_citation", [False, True])
+def test_tailor_rewrites_uncitable_baseline_tenure_without_dropping_pinned_metrics(
+    tmp_path: Path, job: dict, unrelated_citation: bool,
+) -> None:
+    profile = _profile_dict()
+    baseline_summary = "Senior engineer with 37 years of experience."
+    profile["resume"]["executive_profile"]["baseline_text"] = baseline_summary
+    profile["resume"]["tailoring_rules"]["required_bullets_by_experience_id"] = {
+        "acme_swe": ["Cut latency 40%."],
+    }
+    snapshot = ProfileSnapshot.from_profile(Profile.from_dict(LOCAL_TENANT, profile))
+    bad = json.loads(_payload_with_bullet("Cut latency 40%.", summary=baseline_summary))
+    if unrelated_citation:
+        next(mapping for mapping in bad["generated_claim_mappings"]
+             if mapping["location"] == "executive_profile")["evidence_ids"] = ["ev_latency"]
+    llm = _ScriptedLlm([json.dumps(bad), _good_json_payload(), _judge_pass()])
+    outcome = TailorResumeUseCase(
+        repository=_FakeRepository(), llm=llm, validator=ContentValidator(),
+        assembler=ResumeAssembler(), analyze_use_case=_FakeAnalyzeUseCase(), max_retries=1,
+    ).execute(job=job, profile_snapshot=snapshot, tailored_dir=tmp_path)
+
+    assert outcome.status == "approved"
+    assert len(llm.calls) == 3
+    rejected = outcome.report["attempt_history"][0]["candidates"][0]
+    assert rejected["status"] == "failed_validation"
+    assert any("37 years" in error for error in rejected["validator"]["errors"])
+    first_system = llm.calls[0][0].content
+    retry_guidance = llm.calls[1][0].content.split("## CODE-OWNED RETRY REQUIREMENTS", 1)[1]
+    assert "Preserve every number exactly" not in first_system
+    assert "For a rewritten executive profile" in first_system
+    assert "years of experience" in retry_guidance
+    assert "cited achievement evidence" in retry_guidance
+    assert outcome.text_path is not None
+    rendered = Path(outcome.text_path).read_text()
+    assert "37 years" not in rendered
+    assert "Cut latency 40%." in rendered
+    assert "37 years" in snapshot.as_dict()["resume"]["executive_profile"]["baseline_text"]
+
+
 def test_tailor_use_case_judge_rejected_fails_quality_gate(
     tmp_path: Path, snapshot: ProfileSnapshot, job: dict
 ) -> None:
@@ -2610,7 +2649,7 @@ def test_tailor_use_case_persists_safe_provider_failures_without_calling_them_pa
         "inner_attempt": 4,
         "workflow_run_id": "temporal-run-builder-error",
         "durable_attempt": 2,
-        "schema_version": "tailored-resume.v3",
+        "schema_version": "tailored-resume.v4",
     }.items()
     assert provider_error["candidate_id"]
     assert provider_error["prompt_fingerprint"]

--- a/workers/automation/tests/test_requirement_led_tailoring.py
+++ b/workers/automation/tests/test_requirement_led_tailoring.py
@@ -24,6 +24,7 @@ from jobctrl.domain.materials.claim_grounding import (
     ground_claim_mappings,
 )
 from jobctrl.domain.materials.quality import build_tailoring_plan
+from jobctrl.domain.materials.services import ContentValidator
 from jobctrl.domain.materials.requirement_coverage import (
     AchievementNode,
     CoverageEdge,
@@ -553,6 +554,56 @@ def test_claim_mapping_gate_rejects_positioning_filler_when_role_has_job_evidenc
     errors = _claim_mapping_validation_errors(payload=payload, tailoring_plan=plan)
 
     assert any("positioning-only bullet" in error for error in errors)
+
+
+@pytest.mark.parametrize("has_evidence", (False, True))
+def test_required_role_can_have_no_bullets_only_without_achievement_evidence(
+    has_evidence: bool,
+) -> None:
+    profile = _profile()
+    if not has_evidence:
+        entry = profile["resume"]["experience_entries"][0]
+        entry["bullets"] = []
+        entry["achievement_evidence"] = []
+    plan = build_tailoring_plan(
+        profile, _senior_job(), employer_analysis=_employer_analysis("python")
+    )
+    payload = _mapped_payload(bullets=[], bullet_mappings=[])
+
+    fields = ContentValidator().validate_json_fields(payload, profile)
+    claims = _claim_mapping_validation_errors(payload=payload, tailoring_plan=plan)
+
+    assert fields.passed is not has_evidence
+    assert bool(claims) is has_evidence
+
+
+def test_required_role_without_evidence_rejects_a_generated_positioning_bullet() -> None:
+    profile = _profile()
+    entry = profile["resume"]["experience_entries"][0]
+    entry["bullets"] = []
+    entry["achievement_evidence"] = []
+    plan = build_tailoring_plan(
+        profile, _senior_job(), employer_analysis=_employer_analysis("python")
+    )
+    bullet = "Led an unsupported platform transformation."
+    payload = _mapped_payload(
+        bullets=[bullet],
+        bullet_mappings=[{
+            "claim_id": "unsupported",
+            "location": "experience.acme_swe.bullets[0]",
+            "text": bullet,
+            "claim_label": "positioning",
+            "coverage_edge_ids": [],
+            "requirement_ids": [],
+            "evidence_ids": [],
+            "non_requirement_reason": "positioning",
+            "review_required": False,
+        }],
+    )
+
+    errors = _claim_mapping_validation_errors(payload=payload, tailoring_plan=plan)
+
+    assert any("exactly one primary achievement" in error for error in errors)
 
 
 def test_claim_metric_must_be_supported_by_that_bullets_mapped_achievement() -> None:

--- a/workers/automation/tests/test_requirement_led_tailoring.py
+++ b/workers/automation/tests/test_requirement_led_tailoring.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from jobctrl.domain.identifiers import canonical_job_id
@@ -53,7 +55,10 @@ from jobctrl.domain.materials.requirement_coverage import (
 from jobctrl.domain.materials.use_cases import (
     _claim_mapping_validation_errors,
     _post_generation_fit_gate,
+    build_master_tailor_prompt,
 )
+from jobctrl.domain.profile.aggregate import Profile
+from jobctrl.domain.profile.snapshot import ProfileSnapshot
 from jobctrl.domain.scoring import (
     FitScore,
     RequirementFitAssessment,
@@ -575,6 +580,38 @@ def test_required_role_can_have_no_bullets_only_without_achievement_evidence(
 
     assert fields.passed is not has_evidence
     assert bool(claims) is has_evidence
+
+
+@pytest.mark.parametrize("has_evidence", (False, True))
+@pytest.mark.parametrize("has_pinned_bullet", (False, True))
+def test_prompt_empty_bullet_roles_agree_with_field_validation(
+    has_evidence: bool, has_pinned_bullet: bool,
+) -> None:
+    profile = _profile()
+    entry = profile["resume"]["experience_entries"][0]
+    if has_pinned_bullet:
+        profile["resume"]["tailoring_rules"]["required_bullets_by_experience_id"] = {
+            entry["id"]: [entry["bullets"][0]],
+        }
+    if not has_evidence:
+        entry["bullets"] = []
+        entry["achievement_evidence"] = []
+    snapshot = ProfileSnapshot.from_profile(Profile.from_dict(LOCAL_TENANT, profile))
+    prompt = build_master_tailor_prompt(snapshot)
+    empty_bullet_roles = json.loads(
+        prompt.split("REQUIRED EXPERIENCE IDS ALLOWING EMPTY BULLETS:\n")[1]
+        .split("\n\n", 1)[0]
+    )
+    fields = ContentValidator().validate_json_fields(
+        _mapped_payload(bullets=[], bullet_mappings=[]), snapshot.as_dict(),
+    )
+
+    assert fields.passed is (not has_evidence and not has_pinned_bullet)
+    assert (entry["id"] in empty_bullet_roles) is fields.passed
+    if has_pinned_bullet:
+        assert snapshot.as_dict()["resume"]["tailoring_rules"][
+            "required_bullets_by_experience_id"
+        ] == profile["resume"]["tailoring_rules"]["required_bullets_by_experience_id"]
 
 
 def test_required_role_without_evidence_rejects_a_generated_positioning_bullet() -> None:

--- a/workers/automation/tests/test_tailor_provenance_integration.py
+++ b/workers/automation/tests/test_tailor_provenance_integration.py
@@ -641,6 +641,49 @@ def test_accepted_resume_records_provenance_and_publishes_event(tmp_path: Path) 
     assert provenance_events[0].payload["artifact_id"] == saved.artifact_id
 
 
+def test_required_role_without_achievements_preserves_metadata_without_invented_bullets(
+    tmp_path: Path,
+) -> None:
+    profile = _profile_dict()
+    profile["resume"]["experience_entries"].append({
+        "id": "earlier_role",
+        "date_range": "2017-2019",
+        "title": "Software Engineer",
+        "company": "Earlier Employer",
+        "location": "Remote",
+        "bullets": [],
+        "achievement_evidence": [],
+    })
+    profile["resume"]["tailoring_rules"]["required_experience_entry_ids"].append("earlier_role")
+    snapshot = ProfileSnapshot.from_profile(Profile.from_dict(LOCAL_TENANT, profile))
+    payload = json.loads(
+        _payload("Owned the API and cut latency 40% with Python by replacing synchronous calls.")
+    )
+    payload["experience_updates"].append({"id": "earlier_role", "title": "", "bullets": []})
+    materials_repo = _FakeMaterialsRepo()
+    provenance_repo = _FakeProvenanceRepo()
+    publisher = _RecordingPublisher()
+    llm = _ScriptedLlm([json.dumps(payload), _judge_pass()])
+
+    outcome = _use_case(materials_repo, provenance_repo, llm, publisher).execute(
+        job=_job(), profile_snapshot=snapshot, tailored_dir=tmp_path
+    )
+
+    assert outcome.status == "approved"
+    assert outcome.materials is not None and outcome.materials.is_resume_approved
+    artifact = outcome.materials.tailored_resume
+    assert artifact is not None
+    text = Path(artifact.path).read_text()
+    assert "Earlier Employer" in text
+    assert "Software Engineer" in text
+    assert "2017-2019" in text
+    provenance = provenance_repo.load(LOCAL_TENANT, JOB_ID)
+    assert provenance is not None
+    experience_rows = [row for row in provenance.bullets if row.section == "experience"]
+    assert len(experience_rows) == 1
+    assert "latency" in experience_rows[0].generated_text
+
+
 def test_accepted_resume_updates_requirement_fit_artifact_coverage(tmp_path: Path) -> None:
     materials_repo = _FakeMaterialsRepo()
     provenance_repo = _FakeProvenanceRepo()


### PR DESCRIPTION
A required experience role without achievement evidence was forced to generate a positioning bullet, while summary rewriting was instructed to preserve unsupported baseline quantities. Retain such a role's canonical details with an empty bullet list, and allow unsupported summary quantities to become qualitative wording while preserving grounded metrics and required evidence.

Align response schema, prompt, deterministic curation, repair guidance, and evidence provenance. Add regressions for evidence-free required roles and summary grounding, and update canonical product documentation plus the cumulative recovery QA checklist.

Validation on cumulative head `a72c3078008482345c7ff14937cf8bc02511540d`:

- Ruff, API/web typechecks, all 828 API tests, 9 focused dashboard tests, 13 web type tests, production web build, docs build, and `git diff --check` pass. The fresh full Python run passed **3841 tests with 2 optional skips**.
- Independent cumulative review: **Gate: PASS**, no findings; 48 guarded Python cases, 4 API digest cases and all 9 dashboard cases passed.
- Independent cumulative product QA: **Gate: PASS**, no findings; 29 material-validation cases and 30 Temporal cases passed, with 19 real owned server lifecycles and balanced shutdowns. Three actual API surfaces and three desktop/mobile browser scenarios preserved canonical source data, failure/block information, readable labels and Inspect navigation; scoped accessibility, console and network checks passed.
- Prior SDK isolation and timeout/reservation gates were carried forward after source and dependency equality checks. The separate authenticated-provider/owner-extension operational requirement on #860 remains open.

These three PRs extend the existing unreleased stack. Owning contract and safety documentation accompanies the relevant phase; the final recovery PR carries the shared canonical product documentation and cumulative QA checklist.

This PR’s latest [Python CI](https://github.com/ebarti/JobCtrl/actions/runs/34125370619) and [TypeScript CI](https://github.com/ebarti/JobCtrl/actions/runs/34125370632) passed at its published head. All five TypeScript jobs passed, including E2E and Storybook; other applicable workflows passed and DCO was explicitly skipped. The final cumulative Python CI also passed lint, all 3841 tests (2 optional skips), and package builds on Python 3.11, 3.12 and 3.13.
