### PR TITLE
feat(profile): support experience bullet ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,9 @@ evidence, qualifications, and the complete capability matrix.
   URLs in Profile data.
   The Profile editor also owns resume experience order: move roles up or down,
   or apply the explicit newest-first sort, and the saved sequence is used by
-  baseline and tailored resumes.
+  baseline and tailored resumes. Within a role, move individual bullets up or
+  down to set their order; required selections and achievement evidence stay
+  attached to the same text when reordered.
 - Inspect the evidence map to see which profile achievements and skills are
   reused in generated materials, requirement-fit decisions, and recorded gaps.
   Job and artifact audit surfaces show those references as human-readable

--- a/apps/api/src/profile-store.ts
+++ b/apps/api/src/profile-store.ts
@@ -651,16 +651,55 @@ function achievementEvidenceForEntry(entry: Record<string, unknown>, entryId: st
   if (explicitEvidence.length === 0) {
     return derivedEvidence;
   }
-  if (explicitEvidence.every((evidence) => isMaterializedLegacyBulletEvidence(evidence, entryId))) {
-    return derivedEvidence;
-  }
-  const derivedById = new Map(derivedEvidence.map((evidence) => [text(evidence.id), evidence]));
-  return explicitEvidence.flatMap((evidence) => {
-    if (!isMaterializedLegacyBulletEvidence(evidence, entryId)) {
-      return [evidence];
+  const materialized = explicitEvidence.map((evidence) => isMaterializedLegacyBulletEvidence(evidence, entryId));
+  const allDerived = materialized.every(Boolean);
+  const available = new Set(derivedEvidence.map((_, index) => index));
+  const matched = new Map<number, number>();
+  // Claim unchanged occurrences before refreshing edited bullets. Position is
+  // only an allocation hint: a saved evidence ID already owns its source text.
+  // Authored records may share a source with derived records, so reserve their
+  // otherwise-unclaimed sources only after matching materialized occurrences.
+  const matchingOrder = explicitEvidence.map((_, index) => index)
+    .sort((left, right) => Number(materialized[right]) - Number(materialized[left]));
+  matchingOrder.forEach((index) => {
+    const evidence = explicitEvidence[index]!;
+    const bulletIndex = [...available].find((candidate) =>
+      text(derivedEvidence[candidate]!.source_text) === text(evidence.source_text).trim());
+    if (bulletIndex !== undefined) {
+      matched.set(index, bulletIndex);
+      available.delete(bulletIndex);
     }
-    const replacement = derivedById.get(text(evidence.id));
-    return replacement ? [replacement] : [];
+  });
+  explicitEvidence.forEach((evidence, index) => {
+    if (!materialized[index] || matched.has(index)) return;
+    const preferred = allDerived ? index : (legacyBulletEvidenceIndex(text(evidence.id), entryId) ?? 0) - 1;
+    const bulletIndex = available.has(preferred) ? preferred : available.values().next().value;
+    if (bulletIndex !== undefined) {
+      matched.set(index, bulletIndex);
+      available.delete(bulletIndex);
+    }
+  });
+  const replacements = new Map<number, Record<string, unknown>>();
+  const byBullet = new Map<number, Record<string, unknown>>();
+  for (const [index, bulletIndex] of matched) {
+    if (!materialized[index]) continue;
+    const replacement = { ...derivedEvidence[bulletIndex], id: text(explicitEvidence[index]!.id) };
+    replacements.set(index, replacement);
+    byBullet.set(bulletIndex, replacement);
+  }
+  if (!allDerived) {
+    return explicitEvidence.flatMap((evidence, index) =>
+      materialized[index] ? (replacements.has(index) ? [replacements.get(index)!] : []) : [evidence]);
+  }
+  const reservedIds = new Set(explicitEvidence.map((evidence) => text(evidence.id)));
+  return derivedEvidence.map((evidence, index) => {
+    const replacement = byBullet.get(index);
+    if (replacement) return replacement;
+    let suffix = index + 1;
+    while (reservedIds.has(legacyBulletEvidenceId(entryId, suffix))) suffix += 1;
+    const id = legacyBulletEvidenceId(entryId, suffix);
+    reservedIds.add(id);
+    return { ...evidence, id };
   });
 }
 
@@ -669,7 +708,7 @@ function legacyBulletAchievementEvidenceForEntry(
   entryId: string,
 ): Array<Record<string, unknown>> {
   const scope = legacyBulletEvidenceScope(entry);
-  return asTextArray(entry.bullets).map((bullet, index) => {
+  return asTextArray(entry.bullets).map((bullet) => bullet.trim()).filter(Boolean).map((bullet, index) => {
     const sourceText = bullet.trim();
     const normalized = legacyBulletEvidenceNormalizedText(entry, sourceText);
     return {

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -3169,6 +3169,7 @@ function profileEvidencePointers(db: SqliteDatabase, tenantId: string): ProfileE
       });
     }
   }
+  const canonicalEvidenceIds = new Set(pointers.map((pointer) => pointer.evidenceId));
   if (tableExists(db, "candidate_profile_experience_entries") && tableExists(db, "candidate_profile_experience_bullets")) {
     const rows = allRows<{
       entry_id: string;
@@ -3198,9 +3199,11 @@ function profileEvidencePointers(db: SqliteDatabase, tenantId: string): ProfileE
       const entryId = safeAuditText(bullet.entry_id, 160);
       const sourceText = safeAuditText(bullet.bullet_text, 1200);
       if (!entryId || !sourceText) continue;
+      const evidenceId = legacyBulletEvidenceId(entryId, Number(bullet.bullet_index ?? 0) + 1);
+      if (canonicalEvidenceIds.has(evidenceId)) continue;
       pointers.push({
         entryId,
-        evidenceId: legacyBulletEvidenceId(entryId, Number(bullet.bullet_index ?? 0) + 1),
+        evidenceId,
         sourceText,
         normalizedSourceText: normalizeEvidenceText(sourceText),
         senioritySignal: hasSenioritySignal([bullet.title, bullet.company, sourceText]),

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -2481,6 +2481,104 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     }
   });
 
+  it("keeps accepted artifact and requirement evidence bound to the same achievement after bullet sorting", async () => {
+    const { dbPath, cleanup } = withTempDb();
+    const sourceA = "Reduced incidents 40%.";
+    const sourceB = "Built APIs.";
+    const appOptions = { dbPath, configPath: path.join(path.dirname(dbPath), "config.json") };
+    try {
+      seedSchema(dbPath);
+      const app = buildApp(appOptions);
+      try {
+        const initial = await app.inject({
+          method: "PATCH", url: "/v1/profile", payload: { profile: {
+            personal: { full_name: "Sortable Evidence Candidate", email: "sort@example.com" },
+            resume: {
+              executive_profile: { baseline_text: "Platform engineer." },
+              experience_entries: [{ id: "role_1", title: "Engineer", company: "Acme", date_range: "2024-2025", bullets: [sourceA, sourceB] }],
+              education_entries: [], skill_categories: [], tailoring_rules: {},
+            },
+          } },
+        });
+        expect(initial.statusCode, initial.body).toBe(200);
+        const profile = initial.json().profile;
+        const evidenceId = profile.resume.experience_entries[0].achievement_evidence[0].id;
+        expect(evidenceId).toBe("role_1_bullet_1");
+
+        const db = new Database(dbPath);
+        try {
+          db.prepare(`INSERT INTO job_materials
+            (tenant_id, job_id, generation, status, created_at, updated_at)
+            VALUES ('local', ?, 1, 'complete', '2026-07-05T12:00:00Z', '2026-07-05T12:10:00Z')`).run(EVENT_JOB_ID);
+          db.prepare(`INSERT INTO job_materials_artifacts (
+            tenant_id, job_id, generation, artifact_type, artifact_id, status, path,
+            render_format, size_bytes, metadata_json, created_at
+          ) VALUES ('local', ?, 1, 'tailored_resume', 'sorted-resume', 'approved', '/tmp/synthetic-resume.txt', 'text', 12, ?, '2026-07-05T12:05:00Z')`).run(
+            EVENT_JOB_ID, JSON.stringify({ validation_mode: "normal", attempts: 1, quality_checks: { passed: true } }),
+          );
+          db.prepare(`INSERT INTO job_bullet_provenance (
+            tenant_id, job_id, generation, bullet_id, artifact_id, section, source_id,
+            evidence_ids_json, requirement_ids_json, matched_keywords_json, transform_type,
+            control, rationale, generated_text, position, created_at
+          ) VALUES ('local', ?, 1, 'experience:role_1#0', 'sorted-resume', 'experience', 'role_1', ?, '["req-reliability"]', '[]', 'reframe', 'rephrase_allowed', 'Used source achievement.', ?, 0, '2026-07-05T12:10:00Z')`).run(
+            EVENT_JOB_ID, JSON.stringify([evidenceId]), sourceA,
+          );
+          db.prepare(`INSERT INTO job_requirement_fit_reports (
+            tenant_id, job_id, score_version, employer_analysis_generation,
+            profile_snapshot_version, scoring_policy_version, formula_version,
+            resolved_fit_score, fit_band, confidence, summary_json, created_at
+          ) VALUES ('local', ?, 2, 1, 1, 1, 'v1', 8, 'strong', 'high', '{}', '2026-07-05T12:20:00Z')`).run(EVENT_JOB_ID);
+          db.prepare(`INSERT INTO job_requirement_fit_items (
+            tenant_id, job_id, score_version, requirement_id, requirement_text,
+            tier, weight, job_evidence_span, fit_json, contribution_json,
+            tailoring_json, artifact_coverage_json, position
+          ) VALUES ('local', ?, 2, 'req-reliability', 'Improve reliability', 'must_have', 1, 'reliability', ?, '{}', '{}', '{}', 0)`).run(
+            EVENT_JOB_ID, JSON.stringify({ kind: "matched", evidence_ids: [evidenceId], strength: "direct" }),
+          );
+        } finally {
+          db.close();
+        }
+
+        profile.resume.experience_entries[0].bullets = [sourceB, sourceA];
+        const reordered = await app.inject({ method: "PATCH", url: "/v1/profile", payload: { profile } });
+        expect(reordered.statusCode, reordered.body).toBe(200);
+        const nextProfile = reordered.json().profile;
+        nextProfile.personal.preferred_name = "Sort Candidate";
+        const savedAgain = await app.inject({ method: "PATCH", url: "/v1/profile", payload: { profile: nextProfile } });
+        expect(savedAgain.statusCode, savedAgain.body).toBe(200);
+      } finally {
+        await app.close();
+      }
+
+      const reopened = buildApp(appOptions);
+      try {
+        const loaded = await reopened.inject({ method: "GET", url: "/v1/profile" });
+        expect(loaded.statusCode, loaded.body).toBe(200);
+        expect(loaded.json().profile.resume.experience_entries[0].achievement_evidence).toEqual([
+          expect.objectContaining({ id: "role_1_bullet_2", source_text: sourceB, metrics: [] }),
+          expect.objectContaining({ id: "role_1_bullet_1", source_text: sourceA, metrics: ["40%"] }),
+        ]);
+        const artifact = await reopened.inject({ method: "GET", url: "/v1/artifacts/sorted-resume" });
+        expect(artifact.statusCode, artifact.body).toBe(200);
+        expect(artifact.json().tailoringExplanation.bulletProvenance).toMatchObject([
+          { evidenceIds: ["role_1_bullet_1"], sourceText: [sourceA], generatedText: sourceA },
+        ]);
+        const evidenceMap = await reopened.inject({ method: "GET", url: "/v1/evidence-map" });
+        expect(evidenceMap.statusCode, evidenceMap.body).toBe(200);
+        const achievement = evidenceMap.json().entries.find((entry: { evidenceId: string }) => entry.evidenceId === "role_1_bullet_1");
+        expect(achievement).toMatchObject({
+          title: sourceA, story: { action: sourceA, outcome: sourceA, metrics: ["40%"] },
+          resumeUsages: [{ artifactId: "sorted-resume", bulletId: "experience:role_1#0" }],
+          requirementUsages: [{ requirementId: "req-reliability", requirementFitKind: "matched" }],
+        });
+      } finally {
+        await reopened.close();
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
   it("excludes soft-deleted and hidden jobs from the career evidence map", async () => {
     // Regression for the R5 evidence-usage index: soft delete only writes a
     // jobctrl_deleted_jobs tombstone (and hide only writes jobctrl_hidden_jobs),

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -9632,6 +9632,76 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it.each([false, true])("preserves reordered bullet evidence occurrences across later saves (authored: %s)", async (withAuthored) => {
+    const app = buildApp(options);
+    try {
+      const profile = validProfileFixture("Sortable Bullet Candidate");
+      const entries = (profile.resume as Record<string, unknown>).experience_entries as Array<Record<string, unknown>>;
+      entries[0]!.bullets = ["Reduced incidents 40%.", "Built APIs.", "Reduced incidents 40%."];
+      const initial = await app.inject({ method: "PATCH", url: "/v1/profile", payload: { profile } });
+      expect(initial.statusCode, initial.body).toBe(200);
+      const materialized = initial.json().profile;
+      const entry = materialized.resume.experience_entries[0];
+      if (withAuthored) {
+        Object.assign(entry.achievement_evidence[1], { id: "authored_api", tags: ["authored"] });
+      }
+      const original = Object.fromEntries(entry.achievement_evidence.map((item: { id: string }) => [item.id, item]));
+      entry.bullets = [" ", " Built APIs. ", "Reduced incidents 40%.", "Reduced incidents 40%.", ""];
+      materialized.resume.tailoring_rules.required_bullets_by_experience_id = { role_1: ["Built APIs."] };
+      const reordered = await app.inject({ method: "PATCH", url: "/v1/profile", payload: { profile: materialized } });
+      expect(reordered.statusCode, reordered.body).toBe(200);
+      const nextProfile = reordered.json().profile;
+      nextProfile.personal.preferred_name = "Sort Candidate";
+      const savedAgain = await app.inject({ method: "PATCH", url: "/v1/profile", payload: { profile: nextProfile } });
+      expect(savedAgain.statusCode, savedAgain.body).toBe(200);
+      const loaded = await app.inject({ method: "GET", url: "/v1/profile" });
+      expect(loaded.statusCode, loaded.body).toBe(200);
+      const result = loaded.json().profile;
+      expect(Object.fromEntries(result.resume.experience_entries[0].achievement_evidence.map((item: { id: string }) => [item.id, item]))).toEqual(original);
+      expect(result.resume.tailoring_rules.required_bullets_by_experience_id).toEqual({ role_1: ["Built APIs."] });
+
+      result.resume.experience_entries[0].bullets = ["Built APIs.", "Reduced incidents 55%."];
+      const edited = await app.inject({ method: "PATCH", url: "/v1/profile", payload: { profile: result } });
+      expect(edited.statusCode, edited.body).toBe(200);
+      expect(edited.json().profile.resume_constraints.real_metrics).toEqual(["55%"]);
+      expect(edited.json().profile.resume.experience_entries[0].achievement_evidence).toHaveLength(2);
+      const apiId = withAuthored ? "authored_api" : "role_1_bullet_2";
+      expect(edited.json().profile.resume.experience_entries[0].achievement_evidence).toContainEqual(original[apiId]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it.each([false, true])("preserves authored and derived evidence sharing one sorted bullet (authored first: %s)", async (authoredFirst) => {
+    const app = buildApp(options);
+    try {
+      const profile = validProfileFixture("Shared Bullet Evidence Candidate");
+      const entries = (profile.resume as Record<string, unknown>).experience_entries as Array<Record<string, unknown>>;
+      entries[0]!.bullets = ["Reduced incidents 40%.", "Built APIs."];
+      const initial = await app.inject({ method: "PATCH", url: "/v1/profile", payload: { profile } });
+      expect(initial.statusCode, initial.body).toBe(200);
+      const materialized = initial.json().profile;
+      const entry = materialized.resume.experience_entries[0];
+      const authored = { ...entry.achievement_evidence[0], id: "authored_incidents", tags: ["authored"] };
+      const original = authoredFirst ? [authored, ...entry.achievement_evidence] : [...entry.achievement_evidence, authored];
+      entry.achievement_evidence = original;
+      entry.bullets.reverse();
+
+      const reordered = await app.inject({ method: "PATCH", url: "/v1/profile", payload: { profile: materialized } });
+      expect(reordered.statusCode, reordered.body).toBe(200);
+      expect(reordered.json().profile.resume.experience_entries[0].achievement_evidence).toEqual(original);
+      const nextProfile = reordered.json().profile;
+      nextProfile.personal.preferred_name = "Shared Candidate";
+      const savedAgain = await app.inject({ method: "PATCH", url: "/v1/profile", payload: { profile: nextProfile } });
+      expect(savedAgain.statusCode, savedAgain.body).toBe(200);
+      const loaded = await app.inject({ method: "GET", url: "/v1/profile" });
+      expect(loaded.statusCode, loaded.body).toBe(200);
+      expect(loaded.json().profile.resume.experience_entries[0].achievement_evidence).toEqual(original);
+    } finally {
+      await app.close();
+    }
+  });
+
   it("derives achievement metrics and preserves old flat values as unassigned legacy data", async () => {
     const app = buildApp(options);
     const profile = validProfileFixture("Scoped Metric Candidate");

--- a/apps/web/e2e/tests/profile-bullet-order.spec.ts
+++ b/apps/web/e2e/tests/profile-bullet-order.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from "@playwright/test";
+import { checkA11y, injectAxe } from "axe-playwright";
+
+const bullets = [
+  "Reduced deployment time 40%.",
+  "Led platform reliability work.",
+  "Mentored service owners.",
+] as const;
+
+test.skip(process.env["JOBCTRL_E2E_ISOLATED"] !== "1", "Requires the owned, no-subprocess API fixture");
+
+for (const viewport of ["desktop", "@mobile"]) {
+  test(`Profile bullet ordering preserves evidence and required status through autosave, reload, and preview ${viewport}`, async ({ page, baseURL }, testInfo) => {
+    const errors: string[] = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+    page.on("console", (message) => {
+      if (message.type() === "error") errors.push(message.text());
+    });
+    const originalResponse = await page.request.get("/v1/profile");
+    expect(originalResponse.ok()).toBe(true);
+    const original = await originalResponse.json();
+    const fixture = structuredClone(original.profile);
+    const entry = fixture.resume.experience_entries[0];
+    const entryId = entry.id;
+    const headers = { origin: new URL(baseURL!).origin, "sec-fetch-site": "same-origin" };
+    entry.bullets = bullets;
+    entry.achievement_evidence = [];
+    fixture.resume.tailoring_rules.required_bullets_by_experience_id[entryId] = [bullets[0]];
+    try {
+      const seededResponse = await page.request.patch("/v1/profile", { headers, data: { profile: fixture } });
+      expect(seededResponse.status(), await seededResponse.text()).toBe(200);
+      const seeded = await seededResponse.json();
+      const seededEntry = seeded.profile.resume.experience_entries[0];
+      const byId = (evidence: Array<{ id: string }>) => [...evidence].sort((left, right) => left.id.localeCompare(right.id));
+      const initialEvidence = byId(seededEntry.achievement_evidence);
+      expect(initialEvidence).toHaveLength(3);
+
+      await page.goto("/profile");
+      await expect(page).toHaveTitle(/JobCtrl.*Profile/);
+      await expect(page.getByRole("heading", { name: "Profile", exact: true })).toBeVisible();
+      await page.getByRole("button", { name: /^Experience entries\b/ }).click();
+      const experience = page.locator(".experience-repeat-section").first();
+      await expect(experience.getByRole("button", { name: "Move bullet 1 up", exact: true })).toBeDisabled();
+      await expect(experience.getByRole("button", { name: "Move bullet 3 down", exact: true })).toBeDisabled();
+      await experience.getByRole("button", { name: "Move bullet 3 up", exact: true }).click();
+      await experience.getByRole("button", { name: "Move bullet 1 down", exact: true }).click();
+      await expect(experience.getByRole("button", { name: "Move bullet 2 down", exact: true })).toBeFocused();
+      await page.keyboard.press("Enter");
+      await expect(experience.getByRole("textbox", { name: "Bullet 3", exact: true })).toBeFocused();
+
+      const reordered = [bullets[2], bullets[1], bullets[0]];
+      await expect.poll(async () => {
+        const response = await page.request.get("/v1/profile");
+        return (await response.json()).profile.resume.experience_entries[0].bullets;
+      }, { timeout: 15_000 }).toEqual(reordered);
+      await expect(page.getByRole("button", { name: "Save changes", exact: true })).toHaveCount(0);
+      const saved = await (await page.request.get("/v1/profile")).json();
+      expect(byId(saved.profile.resume.experience_entries[0].achievement_evidence)).toEqual(initialEvidence);
+      expect(saved.profile.resume.tailoring_rules.required_bullets_by_experience_id)
+        .toEqual(seeded.profile.resume.tailoring_rules.required_bullets_by_experience_id);
+      expect(saved.profile.resume.experience_entries.slice(1)).toEqual(seeded.profile.resume.experience_entries.slice(1));
+
+      await page.reload();
+      await page.getByRole("button", { name: /^Experience entries\b/ }).click();
+      for (const [index, bullet] of reordered.entries()) {
+        await expect(experience.getByRole("textbox", { name: `Bullet ${index + 1}`, exact: true })).toHaveValue(bullet);
+      }
+      await expect(experience.locator(".bullet-row").nth(2).getByRole("checkbox", { name: "Required", exact: true })).toBeChecked();
+      await expect(experience.locator(".bullet-row").nth(0).getByRole("checkbox", { name: "Required", exact: true })).not.toBeChecked();
+      await expect(page.locator("vite-error-overlay")).toHaveCount(0);
+      await injectAxe(page);
+      await checkA11y(page, ".profile-disclosure--experience .bullet-list", {
+        axeOptions: { runOnly: { type: "tag", values: ["wcag2a", "wcag2aa"] } },
+      });
+      await experience.locator(".bullet-list").screenshot({ path: testInfo.outputPath("bullet-order.png") });
+      expect(await experience.locator(".bullet-list").evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+
+      await page.getByRole("button", { name: "Resume editor", exact: true }).click();
+      await expect(page.locator(`.profile-resume-plate-editor [data-resume-profile-field^="experience:${entryId}:bullet:"]`))
+        .toHaveText(reordered, { timeout: 30_000 });
+      expect(errors).toEqual([]);
+    } finally {
+      const restored = await page.request.patch("/v1/profile", { headers, data: { profile: original.profile } });
+      expect(restored.status(), await restored.text()).toBe(200);
+    }
+  });
+}

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.test.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.test.tsx
@@ -428,6 +428,93 @@ describe("<StructuredProfileEditor>", () => {
     ).toEqual(["current", "recent", "older"]);
   });
 
+  it("moves bullets without changing text, evidence, required selections, or other profile data", async () => {
+    const user = userEvent.setup();
+    const initialProfile = structuredClone(sampleProfileResponse.profile) as JsonRecord;
+    const resume = initialProfile["resume"] as JsonRecord;
+    const entries = resume["experience_entries"] as JsonRecord[];
+    entries[0]!["bullets"] = ["  Repeated achievement.  ", "", "Reduced latency 40%.", "  Repeated achievement.  "];
+    entries[0]!["achievement_evidence"] = [{ id: "latency-proof", source_text: "Reduced latency 40%.", metrics: ["40%"], user_confirmed: true }];
+    entries[0]!["futureEntryData"] = { preserve: ["exactly", 7] };
+    (resume["tailoring_rules"] as JsonRecord)["required_bullets_by_experience_id"] = {
+      "exp-1": ["Reduced latency 40%."],
+    };
+    let latestProfile = JSON.stringify(initialProfile);
+    render(<StatefulEditor initialProfile={initialProfile} onLatestProfile={(value) => { latestProfile = value; }} />);
+    await user.click(screen.getByRole("button", { name: /Experience entries/ }));
+
+    expect(screen.getByRole("button", { name: "Move bullet 1 up" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Move bullet 4 down" })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Move bullet 3 up" }));
+    expect(screen.getByLabelText("Bullet 2")).toHaveValue("Reduced latency 40%.");
+    const movedRow = screen.getByLabelText("Bullet 2").closest(".bullet-row") as HTMLElement;
+    expect(within(movedRow).getByRole("checkbox", { name: "Required" })).toBeChecked();
+    expect(screen.getByRole("button", { name: "Move bullet 2 up" })).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+    expect(screen.getByLabelText("Bullet 1")).toHaveValue("Reduced latency 40%.");
+    expect(screen.getByLabelText("Bullet 1")).toHaveFocus();
+    await user.click(screen.getByRole("button", { name: "Move bullet 1 down" }));
+    expect(screen.getByRole("button", { name: "Move bullet 2 down" })).toHaveFocus();
+    await user.keyboard("{Enter}");
+    await user.keyboard("{Enter}");
+    expect(screen.getByLabelText("Bullet 4")).toHaveFocus();
+
+    const expected = structuredClone(initialProfile);
+    ((expected["resume"] as JsonRecord)["experience_entries"] as JsonRecord[])[0]!["bullets"] = [
+      "  Repeated achievement.  ", "", "  Repeated achievement.  ", "Reduced latency 40%.",
+    ];
+    expect(JSON.parse(latestProfile)).toEqual(expected);
+  });
+
+  it("keeps empty and single-bullet entries safe at both ordering boundaries", async () => {
+    const user = userEvent.setup();
+    const initialProfile = structuredClone(sampleProfileResponse.profile) as JsonRecord;
+    ((initialProfile["resume"] as JsonRecord)["experience_entries"] as JsonRecord[])[0]!["bullets"] = [];
+    const onLatestProfile = vi.fn();
+    render(<StatefulEditor initialProfile={initialProfile} onLatestProfile={onLatestProfile} />);
+    await user.click(screen.getByRole("button", { name: /Experience entries/ }));
+    expect(screen.queryByRole("button", { name: /Move bullet/ })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Add bullet" }));
+    expect(screen.getByLabelText("Bullet 1")).toHaveValue("");
+    expect(screen.getByRole("button", { name: "Move bullet 1 up" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Move bullet 1 down" })).toBeDisabled();
+    onLatestProfile.mockClear();
+    await user.click(screen.getByRole("button", { name: "Move bullet 1 up" }));
+    await user.click(screen.getByRole("button", { name: "Move bullet 1 down" }));
+    expect(onLatestProfile).not.toHaveBeenCalled();
+  });
+
+  it("keeps repeated keyboard moves inside the originating unsaved role", async () => {
+    const user = userEvent.setup();
+    let latestProfile = "";
+    const { container } = render(<StatefulEditor onLatestProfile={(value) => { latestProfile = value; }} />);
+    await user.click(screen.getByRole("button", { name: /Experience entries/ }));
+    await user.click(screen.getByRole("button", { name: "Add experience" }));
+    await user.click(screen.getByRole("button", { name: "Add experience" }));
+    const sections = [...container.querySelectorAll<HTMLElement>(".experience-repeat-section")];
+    const first = sections.at(-2)!;
+    const second = sections.at(-1)!;
+    for (const [section, prefix] of [[first, "A"], [second, "B"]] as const) {
+      await user.click(within(section).getByRole("button", { name: "Add bullet" }));
+      await user.click(within(section).getByRole("button", { name: "Add bullet" }));
+      for (let index = 0; index < 3; index += 1) {
+        fireEvent.change(within(section).getByRole("textbox", { name: `Bullet ${index + 1}` }), {
+          target: { value: `${prefix}${index + 1}` },
+        });
+      }
+    }
+
+    await user.click(within(first).getByRole("button", { name: "Move bullet 3 up" }));
+    expect(within(first).getByRole("button", { name: "Move bullet 2 up" })).toHaveFocus();
+    await user.keyboard("{Enter}");
+    expect(within(first).getByRole("textbox", { name: "Bullet 1" })).toHaveFocus();
+    const entries = JSON.parse(latestProfile).resume.experience_entries;
+    expect(entries.slice(-2).map((entry: { id: string }) => entry.id)).toEqual(["", ""]);
+    expect(entries.at(-2).bullets).toEqual(["A3", "A1", "A2"]);
+    expect(entries.at(-1).bullets).toEqual(["B1", "B2", "B3"]);
+  });
+
   it("renders bullet standards as a combined fixed set", () => {
     render(<StatefulEditor mode="preferences" />);
 

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -254,7 +254,7 @@ export function StructuredProfileEditor({
   onProfileChange,
   onStyleChange,
 }: StructuredProfileEditorProps) {
-  const focusTargetsRef = useRef(new Map<string, HTMLInputElement | HTMLSelectElement>());
+  const focusTargetsRef = useRef(new Map<string, HTMLElement>());
   const pendingFocusKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -273,7 +273,7 @@ export function StructuredProfileEditor({
     }
   }, [profile]);
 
-  const registerFocusTarget = (key: string) => (element: HTMLInputElement | HTMLSelectElement | null) => {
+  const registerFocusTarget = (key: string) => (element: HTMLElement | null) => {
     if (element) {
       focusTargetsRef.current.set(key, element);
     } else {
@@ -449,6 +449,22 @@ export function StructuredProfileEditor({
       const path = `resume.experience_entries.${entryIndex}.bullets`;
       setPathValue(draft, path, [...editableTextArrayAt(draft, path), ""]);
     });
+  };
+
+  const bulletFocusKey = (entryIndex: number, bulletIndex: number, control: "up" | "down" | "text") =>
+    JSON.stringify(["bullet", entryIndex, bulletIndex, control]);
+
+  const moveBullet = (entryIndex: number, bulletIndex: number, offset: -1 | 1) => {
+    const path = `resume.experience_entries.${entryIndex}.bullets`;
+    const bullets = editableTextArrayAt(profile, path);
+    const targetIndex = bulletIndex + offset;
+    if (targetIndex < 0 || targetIndex >= bullets.length) {
+      return;
+    }
+    const reachedEnd = offset === -1 ? targetIndex === 0 : targetIndex === bullets.length - 1;
+    focusAfterDraftUpdate(bulletFocusKey(entryIndex, targetIndex, reachedEnd ? "text" : offset === -1 ? "up" : "down"));
+    [bullets[bulletIndex], bullets[targetIndex]] = [bullets[targetIndex]!, bullets[bulletIndex]!];
+    updateProfilePath(path, bullets);
   };
 
   const removeBullet = (entryIndex: number, bulletIndex: number) => {
@@ -1650,6 +1666,7 @@ export function StructuredProfileEditor({
                               </div>
                               <Textarea
                                 aria-label={`Bullet ${bulletIndex + 1}`}
+                                ref={registerFocusTarget(bulletFocusKey(index, bulletIndex, "text"))}
                                 value={bullet}
                                 onChange={(event) =>
                                   updateProfilePath(
@@ -1658,17 +1675,47 @@ export function StructuredProfileEditor({
                                   )
                                 }
                               />
-                              <Button
-                                className="icon-button"
-                                aria-label={`Remove bullet ${bulletIndex + 1}`}
-                                size="icon"
-                                title="Remove bullet"
-                                type="button"
-                                variant="ghost"
-                                onClick={() => removeBullet(index, bulletIndex)}
+                              <div
+                                aria-label={`Actions for bullet ${bulletIndex + 1} in ${entryLabel}`}
+                                className="bullet-row-actions"
+                                role="group"
                               >
-                                <IconTrash size={14} aria-hidden="true" />
-                              </Button>
+                                <Button
+                                  aria-label={`Move bullet ${bulletIndex + 1} up`}
+                                  disabled={bulletIndex === 0}
+                                  onClick={() => moveBullet(index, bulletIndex, -1)}
+                                  ref={registerFocusTarget(bulletFocusKey(index, bulletIndex, "up"))}
+                                  size="icon"
+                                  title="Move bullet up"
+                                  type="button"
+                                  variant="outline"
+                                >
+                                  <IconArrowUp aria-hidden="true" data-icon="inline-start" />
+                                </Button>
+                                <Button
+                                  aria-label={`Move bullet ${bulletIndex + 1} down`}
+                                  disabled={bulletIndex === bullets.length - 1}
+                                  onClick={() => moveBullet(index, bulletIndex, 1)}
+                                  ref={registerFocusTarget(bulletFocusKey(index, bulletIndex, "down"))}
+                                  size="icon"
+                                  title="Move bullet down"
+                                  type="button"
+                                  variant="outline"
+                                >
+                                  <IconArrowDown aria-hidden="true" data-icon="inline-start" />
+                                </Button>
+                                <Button
+                                  className="icon-button"
+                                  aria-label={`Remove bullet ${bulletIndex + 1}`}
+                                  size="icon"
+                                  title="Remove bullet"
+                                  type="button"
+                                  variant="ghost"
+                                  onClick={() => removeBullet(index, bulletIndex)}
+                                >
+                                  <IconTrash size={14} aria-hidden="true" />
+                                </Button>
+                              </div>
                             </Field>
                           );
                         })}

--- a/apps/web/src/contexts/profile/forms/profile-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.test.tsx
@@ -175,6 +175,32 @@ describe("<ProfileForm>", () => {
     expect(initial).toEqual(original);
   });
 
+  it("keeps a moved bullet's Plate edits on the same source when saving the reordered profile", async () => {
+    const user = userEvent.setup();
+    let controller: ProfilePlateTextController | null = null;
+    const updateProfile = vi.fn(async (request) => ({
+      ...sampleProfileResponse, profile: JSON.parse(request.profileText),
+    }));
+    renderWithProviders(<ProfileForm initial={sampleProfileResponse} onPlateTextControllerChange={(value) => {
+      controller = value;
+    }} />, { ports: buildTestPorts({ api: { updateProfile } }), withRouter: true });
+    await openExperienceEntries(user);
+    await user.click(screen.getByRole("button", { name: "Move bullet 1 down" }));
+    expect(screen.getByLabelText("Bullet 1")).toHaveValue("Led the SRE org.");
+    expect(screen.getByLabelText("Bullet 2")).toHaveValue("Scaled the platform 10x.");
+    act(() => controller?.apply([{
+      semanticId: "experience:exp-1:bullet:1",
+      baselineTexts: ["Scaled the platform 10x."],
+      plateTexts: ["Scaled the platform 12x."],
+    }]));
+    expect(screen.getByLabelText("Bullet 1")).toHaveValue("Led the SRE org.");
+    expect(screen.getByLabelText("Bullet 2")).toHaveValue("Scaled the platform 12x.");
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => expect(updateProfile).toHaveBeenCalledTimes(1));
+    expect(JSON.parse(updateProfile.mock.calls[0]![0].profileText).resume.experience_entries[0].bullets)
+      .toEqual(["Led the SRE org.", "Scaled the platform 12x."]);
+  });
+
   it("preserves and surfaces a structural Profile conflict instead of overwriting it from Plate", async () => {
     const user = userEvent.setup();
     let plateController: ProfilePlateTextController | null = null;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -7843,9 +7843,18 @@ input[type="radio"] {
 .bullet-row-top {
   grid-area: meta;
   display: flex;
+  flex-wrap: wrap;
   min-width: 0;
   align-items: center;
   gap: 12px;
+}
+
+.bullet-row-actions {
+  grid-area: remove;
+  display: flex;
+  align-items: center;
+  align-self: start;
+  gap: 4px;
 }
 
 .bullet-label {

--- a/docs/architecture/read-model.md
+++ b/docs/architecture/read-model.md
@@ -219,6 +219,10 @@ clock; it never sends or acts.
 The evidence map derives from canonical profile evidence, requirement-fit,
 bullet-provenance, and coverage rows. It creates no second generation pipeline
 and uses conservative defaults for older databases missing optional metadata.
+Reordering profile bullets preserves canonical achievement IDs and their source
+associations. Material audit lookups prefer canonical evidence over positional
+compatibility pointers so an earlier usage link continues to identify the same
+achievement after reordering.
 
 Outcome conversion stores integer counts. The API derives rates and medians at
 read time using one minimum-sample threshold, so small groups keep counts but

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -168,6 +168,12 @@ Fields in composite lines must have individual source bindings; include a pipe
 inside an institution/location and a comma inside a single skill. Reorder roles
 before projecting a title and prove identity, not array position, owns the edit.
 A formatting-only change must not create a guessed profile-field edit.
+Move bullets up and down within a role using mouse and keyboard, including the
+first/last boundaries, then autosave and reload. Verify the baseline preview's
+order, required selections, metrics, and historical achievement links still
+refer to the same source text. Cover duplicate and blank draft bullets, mixed
+authored/derived evidence, another save after reordering, and desktop/mobile
+controls without overflow or accessibility regressions.
 Profile object-draft regression tests also verify unknown nested fields and raw
 numeric strings survive in the outgoing request. Backend schema normalization
 is unchanged. The isolated profile browser fixture uses real GET/PATCH and

--- a/docs/user/candidate-profile.md
+++ b/docs/user/candidate-profile.md
@@ -75,9 +75,12 @@ a presentation-only draft.
 The resume presentation follows the experience sequence saved in Profile. Each
 role has **Move up** and **Move down** controls for a custom sequence, and
 **Sort newest first** applies the date-based order explicitly, with current
-roles first. The reordered list follows the normal Profile save and autosave
-path. Roles without achievement bullets render compactly instead of reserving
-space for an empty bullet list. Education entries place the institution and
+roles first. Each bullet also has **Move up** and **Move down** controls within
+its role. Reordering preserves the bullet text, required selection, and the
+achievement identities used by existing evidence links. The reordered lists
+follow the normal Profile save and autosave path. Roles without achievement
+bullets render compactly instead of reserving space for an empty bullet list.
+Education entries place the institution and
 completion year on the first row and the degree directly underneath.
 
 The download is rendered from the document currently mounted in the browser,

--- a/workers/automation/src/jobctrl/resume_profile.py
+++ b/workers/automation/src/jobctrl/resume_profile.py
@@ -355,17 +355,55 @@ def _reconciled_achievement_evidence(entry: dict, entry_id: str, items: list[dic
     if not entry_id:
         return items
     derived_items = _legacy_bullet_achievement_evidence_for_entry(entry, entry_id)
-    if all(_is_materialized_legacy_bullet_evidence(item, entry_id) for item in items):
-        return derived_items
-    derived_by_id = {str(item["id"]): item for item in derived_items}
-    reconciled: list[dict] = []
-    for item in items:
-        if not _is_materialized_legacy_bullet_evidence(item, entry_id):
-            reconciled.append(item)
+    materialized = [_is_materialized_legacy_bullet_evidence(item, entry_id) for item in items]
+    all_derived = all(materialized)
+    available = dict.fromkeys(range(len(derived_items)))
+    matched: dict[int, int] = {}
+    # Match each unchanged occurrence first; persisted IDs own source text, not
+    # the current display position. Authored records may share a derived source,
+    # so reserve their otherwise-unclaimed sources after materialized matches.
+    for index in sorted(range(len(items)), key=lambda candidate: not materialized[candidate]):
+        item = items[index]
+        bullet_index = next(
+            (candidate for candidate in available if derived_items[candidate]["source_text"] == item["source_text"]),
+            None,
+        )
+        if bullet_index is not None:
+            matched[index] = bullet_index
+            del available[bullet_index]
+    for index, item in enumerate(items):
+        if not materialized[index] or index in matched:
             continue
-        replacement = derived_by_id.get(str(item["id"]))
-        if replacement is not None:
-            reconciled.append(replacement)
+        preferred = index if all_derived else (_legacy_bullet_evidence_index(item["id"], entry_id) or 0) - 1
+        bullet_index = preferred if preferred in available else next(iter(available), None)
+        if bullet_index is not None:
+            matched[index] = bullet_index
+            del available[bullet_index]
+    replacements: dict[int, dict] = {}
+    by_bullet: dict[int, dict] = {}
+    for index, bullet_index in matched.items():
+        if materialized[index]:
+            replacement = {**derived_items[bullet_index], "id": items[index]["id"]}
+            replacements[index] = replacement
+            by_bullet[bullet_index] = replacement
+    if not all_derived:
+        return [
+            replacements[index] if materialized[index] else item
+            for index, item in enumerate(items)
+            if not materialized[index] or index in replacements
+        ]
+    reserved_ids = {item["id"] for item in items}
+    reconciled: list[dict] = []
+    for index, item in enumerate(derived_items):
+        if index in by_bullet:
+            reconciled.append(by_bullet[index])
+            continue
+        suffix = index + 1
+        while legacy_bullet_evidence_id(entry_id, suffix) in reserved_ids:
+            suffix += 1
+        evidence_id = legacy_bullet_evidence_id(entry_id, suffix)
+        reserved_ids.add(evidence_id)
+        reconciled.append({**item, "id": evidence_id})
     return reconciled
 
 

--- a/workers/automation/tests/test_profile_aggregate.py
+++ b/workers/automation/tests/test_profile_aggregate.py
@@ -147,6 +147,54 @@ def test_get_achievement_evidence_rederives_materialized_legacy_bullets():
     assert evidence[0]["metrics"] == ["55%"]
 
 
+@pytest.mark.parametrize("with_authored", [False, True])
+def test_reordering_bullets_preserves_evidence_occurrences_and_refreshes_later_edits(with_authored):
+    profile = _valid_profile_dict()
+    entry = profile["resume"]["experience_entries"][0]
+    entry["bullets"] = ["Reduced incidents 40%.", "Built APIs.", "Reduced incidents 40%."]
+    entry["achievement_evidence"] = get_achievement_evidence(profile)
+    if with_authored:
+        entry["achievement_evidence"][1].update(id="authored_api", tags=["authored"])
+    original = {item["id"]: item for item in entry["achievement_evidence"]}
+    entry["bullets"] = [" ", "  Built APIs.  ", "Reduced incidents 40%.", "Reduced incidents 40%.", ""]
+
+    reordered = get_achievement_evidence(profile)
+
+    assert {item["id"]: item for item in reordered} == original
+    entry["achievement_evidence"] = reordered
+    profile["personal"]["preferred_name"] = "Jordan"
+    assert get_achievement_evidence(profile) == reordered
+
+    entry["bullets"] = ["Built APIs.", "Reduced incidents 55%.", "Reduced incidents 40%."]
+    updated = get_achievement_evidence(profile)
+    incidents = [item for item in updated if item["id"] != ("authored_api" if with_authored else "role_1_bullet_2")]
+    assert sorted(item["metrics"] for item in incidents) == [["40%"], ["55%"]]
+    assert len({item["id"] for item in updated}) == 3
+    entry["achievement_evidence"] = updated
+    entry["bullets"] = ["Built APIs.", "Reduced incidents 40%."]
+    assert all(item["metrics"] != ["55%"] for item in get_achievement_evidence(profile))
+
+
+@pytest.mark.parametrize("authored_first", [False, True])
+def test_reordering_preserves_authored_and_derived_evidence_sharing_one_bullet(authored_first):
+    profile = _valid_profile_dict()
+    entry = profile["resume"]["experience_entries"][0]
+    entry["bullets"] = ["Reduced incidents 40%.", "Built APIs."]
+    materialized = get_achievement_evidence(profile)
+    authored = {**materialized[0], "id": "authored_incidents", "tags": ["authored"]}
+    entry["achievement_evidence"] = (
+        [authored, *materialized] if authored_first else [*materialized, authored]
+    )
+    original = entry["achievement_evidence"]
+    entry["bullets"] = list(reversed(entry["bullets"]))
+
+    reordered = get_achievement_evidence(profile)
+
+    assert reordered == original
+    entry["achievement_evidence"] = reordered
+    assert get_achievement_evidence(profile) == original
+
+
 def test_from_dict_rejects_missing_resume_block():
     with pytest.raises(InvalidProfileError) as exc:
         Profile.from_dict(LOCAL_TENANT, {"personal": {"full_name": "X"}})

--- a/workers/automation/tests/test_sqlite_profile_repository.py
+++ b/workers/automation/tests/test_sqlite_profile_repository.py
@@ -248,6 +248,47 @@ def test_save_rederives_materialized_achievement_evidence_when_bullets_change(tm
     assert refreshed.resume_constraints.real_metrics == ("55%",)
 
 
+@pytest.mark.parametrize("with_authored", [False, True])
+def test_save_preserves_reordered_bullet_evidence_and_required_controls(tmp_path, with_authored):
+    repo, conn, _ = _new_repo(tmp_path)
+    raw = _valid_profile()
+    raw["resume"]["experience_entries"][0]["bullets"] = [
+        "Reduced incidents 40%.", "Built APIs.", "Reduced incidents 40%."
+    ]
+    repo.save(LOCAL_TENANT, Profile.from_dict(LOCAL_TENANT, raw))
+    loaded = repo.load(LOCAL_TENANT)
+    assert loaded is not None
+    updated = loaded.to_dict()
+    entry = updated["resume"]["experience_entries"][0]
+    if with_authored:
+        entry["achievement_evidence"][1].update(id="authored_api", tags=["authored"])
+    original = {item["id"]: item for item in entry["achievement_evidence"]}
+    entry["bullets"] = ["Built APIs.", "Reduced incidents 40%.", "Reduced incidents 40%."]
+
+    repo.save(LOCAL_TENANT, Profile.from_dict(LOCAL_TENANT, updated))
+    loaded = repo.load(LOCAL_TENANT)
+    assert loaded is not None
+    updated = loaded.to_dict()
+    updated["personal"]["preferred_name"] = "Jordan"
+    repo.save(LOCAL_TENANT, Profile.from_dict(LOCAL_TENANT, updated))
+    loaded = repo.load(LOCAL_TENANT)
+    assert loaded is not None
+    result = loaded.to_dict()
+    assert {item["id"]: item for item in result["resume"]["experience_entries"][0]["achievement_evidence"]} == original
+    assert result["resume"]["tailoring_rules"]["required_bullets_by_experience_id"] == {"role_1": ["Built APIs."]}
+    assert {
+        row["evidence_id"]: (row["source_text"], json.loads(row["metrics_json"]))
+        for row in conn.execute("SELECT evidence_id, source_text, metrics_json FROM candidate_profile_achievement_evidence")
+    } == {key: (item["source_text"], item["metrics"]) for key, item in original.items()}
+
+    # A later edit and deletion refresh only the changed achievement; the moved
+    # API bullet and remaining incident evidence keep their established IDs.
+    result["resume"]["experience_entries"][0]["bullets"] = ["Built APIs.", "Reduced incidents 55%."]
+    snapshot = repo.save(LOCAL_TENANT, Profile.from_dict(LOCAL_TENANT, result))
+    assert snapshot.as_dict()["resume_constraints"]["real_metrics"] == ["55%"]
+    assert conn.execute("SELECT COUNT(*) FROM candidate_profile_achievement_evidence").fetchone()[0] == 2
+
+
 def test_save_rederives_precanonical_materialized_evidence_when_bullet_changes(tmp_path):
     repo, conn, _ = _new_repo(tmp_path)
     raw = _valid_profile()


### PR DESCRIPTION
Profile data now supports moving individual experience bullets up or down within a role, with keyboard focus following the moved bullet. The order follows the existing save and autosave flow into the baseline resume editor.

Reordering preserves required selections and the IDs, source text, and metrics used by existing achievement evidence links. The API and worker reconcile unchanged bullet occurrences before refreshing edits; historical material lookups prefer canonical evidence over positional compatibility pointers. Regressions cover duplicate and blank drafts, mixed authored/derived evidence sharing a source, repeated saves, edits after reordering, and repeated keyboard moves across newly added roles that do not yet have saved IDs.

Stacked on #875 (`fix/public-fetch-recovery`). Updated the profile guide, README, read-model contract, and QA checklist.

Validation (Tier 3, dedicated task worktree):

- `env -u UV_EXCLUDE_NEWER_PACKAGE UV_EXCLUDE_NEWER=false corepack pnpm check` — passed.
- `env -u UV_EXCLUDE_NEWER_PACKAGE UV_EXCLUDE_NEWER=false corepack pnpm test` — passed, including 859 API tests, 3,908 Python tests, repository scripts, demo, extension, and launcher race tests. Two opt-in system-browser smoke tests were skipped.
- `corepack pnpm web:check` — passed; `corepack pnpm web:test` — 2,046 passed; `corepack pnpm web:test-d` — 13 passed; `corepack pnpm web:build` — passed.
- `corepack pnpm web:storybook:build` and `corepack pnpm web:storybook:test` — passed; 453 Storybook tests.
- `corepack pnpm docs:build` and `git diff --check` — passed.
- `corepack pnpm --filter @jobctrl/web exec playwright test --config=e2e/playwright.config.ts tests/profile-bullet-order.spec.ts` — 2 passed using isolated, owned synthetic fixtures and dynamically allocated ports. Desktop and mobile checks cover mouse/keyboard movement, autosave, reload, preview order, evidence preservation, required flags, overflow, and accessibility. Both screenshots were visually inspected.
- Independent review — PASS, no unresolved findings; 2,160 API persistence assertions, 2,160 Python evidence assertions, and the reproduced unsaved-role keyboard regression all passed.
- Independent QA — PASS, no findings; 4 desktop/mobile product tests preserved five historical achievement links through six API reorder cycles, two Python repository saves, and another API save. Repeated keyboard moves stayed within the originating unsaved role. Fixture teardown, database integrity, and foreign keys were clean.

Product QA used the real local API and SQLite with a deterministic preview fixture. The new browser spec requires `JOBCTRL_E2E_ISOLATED=1` and its owned fixture environment; it skips under the standard CI `web:e2e` invocation. The explicit desktop/mobile runs above provide that product-path proof. No user profile or live application submission was involved.
