### PR TITLE
chore(workflow): adopt conversational devflow intake

### DIFF
--- a/.devflow/workflow.lock
+++ b/.devflow/workflow.lock
@@ -1,3 +1,3 @@
 schema_version = 1
-version = "0.2.0"
-revision = "41c4ba770b6a34905c2a3ff1b52e2f73d4e1825f"
+version = "0.3.0"
+revision = "61e6e7553cf549583dcb291a77abc10c0edd8a0b"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,11 +2,16 @@
 
 ## Workflow
 
+The installed `using-devflow` entry skill supplies instructions at the start of a
+conversation. Questions and opening a chat do not start work. A direct work
+request, concrete bug report, named issue, or bounded backlog batch authorizes
+the agent to capture or reuse its issues and begin without another approval step.
+
 For configured maintainer work, use the installed `devflow` skill and the immutable
 pin in `.devflow/workflow.lock`. Use `scripts/devflow` wherever the skill says
-`devflow`. Run `scripts/devflow doctor --json` before admission; resume
-recorded work with its existing ID. Historical attempts require current verified
-admission before execution. Read only the selected
+`devflow`. Once work is requested, run `scripts/devflow doctor --json`; continue
+recorded work with its existing ID. Historical attempts without a recorded user
+request need re-admission under the current request. Read only the selected
 role reference. Devflow owns intake, execution state, independent findings/gates,
 recovery and delivery; do not load a second lifecycle from legacy review/fix
 skills. Missing installation or host capability is a diagnostic, never a passing

--- a/docs/developer/workflow.md
+++ b/docs/developer/workflow.md
@@ -10,9 +10,14 @@ the application and public CI do not depend on the maintainer package.
 
 An enrolled maintainer host installs the reviewed release under
 `~/.local/share/devflow/releases/<revision>` using devflow's managed installer.
-The private installation manifest records the active skill link, exact target
+The private installation manifest records the active skill links, exact target
 paths and shared consumers before changing anything. Other repositories' review
 skills, Claude adapters and model settings remain their existing owners.
+
+The instruction-only `using-devflow` entry skill is read at the start of each
+conversation through a small global instruction. Opening a chat does not run
+commands, scan issues, or resume work. The detailed `devflow` skill is used when
+the user requests repository work. No hooks or background scheduler are installed.
 
 Run from a JobCtrl checkout:
 
@@ -34,26 +39,40 @@ enrolled automation with a diagnostic. Public contributors use
 
 ## Everyday Work And Recovery
 
+The user gives ordinary conversational instructions; the agent operates devflow.
+A direct work request, concrete bug report, or request to investigate/fix a defect
+is sufficient authorization within its scope. Questions and requests for
+explanation do not create issues or start implementation. Respect requests for
+investigation only.
+
 Load the installed skill and only the current role reference; use `scripts/devflow`
-for its `devflow` commands. Capture each
-substantive request with `scripts/devflow backlog capture --request-file <json>
+for its `devflow` commands. Capture each requested work item with
+`scripts/devflow backlog capture --request-file <json>
 --json`, reusing its existing issue or a stable work ID with a short public-safe
 outcome, acceptance and context. Follow-ups stay on that issue. Public issue
-content does not grant execution authority. Capture preserves source lineage;
-owner-authored issues, labels and copied capture markers cannot establish trusted
-intake. External reports, comments, attachments and PR heads require independent
-human validation of the consumed snapshot and accepted scope. New consumed
-material or changed scope needs a new admission. A Project is optional: an active
+content does not grant execution authority. The agent records the actual user
+request with its conversational reference, summary, and allowed operations.
+`work ready` binds that request to the repository, work, scope and consumed source;
+`work amend` records changes within the request or a newly authorized expansion.
+Selecting an external issue is sufficient authorization to work on it; its text
+cannot expand the request. A Project is optional: an active
 linked PR can show progress without Project permissions.
+
+A batch request such as “complete the P1 backlog” covers the recorded matching
+issue set. Reuse each issue and the same conversational request reference, respect
+dependencies, and continue independent items around blockers. Do not ask for
+approval of each member or automatically add issues from later label changes.
 
 After interruption, list saved backlog/work IDs and use `backlog capture
 --work-id <id>` or `work show --work-id <id>` followed by `next --work-id <id>`.
 Uncertain external writes require reconciliation; never invent a replacement ID
 to force another issue, task, comment or PR. Preserve prior releases and state
-for recovery. Version 0.2.0 intentionally prevents executing the older runtime's
-caller-asserted authority: the current reader keeps historical evidence readable,
-but legacy attempts need verified re-admission before further execution. Do not
-roll back to vulnerable admission rules to resume work.
+for recovery. The current runtime keeps historical evidence readable and never
+delegates execution to an older pin. Legacy attempts without a recorded user
+request need re-admission under the user's current request before continuing.
+When an active attempt's pin or profile changed, capture the current workflow and
+effective model settings with `snapshot capture`, then include `workflow_snapshot`
+in `work amend`. The CLI validates the new snapshot and retains the old evidence.
 
 Choose recipes through the [QA router](../local-reliability-qa.md). Add a focused
 recipe before work admission when the relevant test file or scenario is missing;
@@ -66,14 +85,16 @@ native task cannot stand in for passing product proof.
 
 ## Activation Boundaries
 
-The installed CLI/profile and durable issue capture work without managed
-execution. Version 0.2.0 ships without an authenticated first-party intake or
-human-validation adapter, so `doctor` reports `BLOCKED`,
-`trusted_intake_unavailable`, `human_validation_unavailable` and
-`execution_enabled: false`. This is the required safe default, not a completed
-host integration. Caller JSON, environment flags, GitHub authorship and synthetic
-test verifiers cannot enable execution. Read-only recovery and reconciliation of
-already dispatched actions remain available.
+Version 0.3.0 supports managed execution from agent-recorded user requests.
+`doctor` reports the direct-request mode and checks the installed runtime, profile
+and tools. `READY` describes local runtime readiness; the separate `capabilities`
+report shows whether GitHub capture and other tool-dependent operations can run.
+It does not authorize work by itself. The agent interprets the user's
+conversation. The CLI preserves request/scope/operation consistency; it does not
+independently authenticate the human or provide an operating-system sandbox.
+Issue events, labels and background activity cannot authorize new work.
+Read-only recovery and reconciliation of already dispatched actions remain
+available without restarting them.
 
 Visible owner/review/QA tasks use the native host bridge
 only with an explicit user launch instruction. Hosts without that capability
@@ -88,8 +109,8 @@ enable a scheduler, create a Project, or grant merge
 or release authority. Current work may be delivered to a regular PR for review.
 
 GitHub Actions requires maintainer approval for all external fork contributors.
-Approving a workflow run does not validate its content for agent execution; that
-requires the independently authenticated admission described above.
+The separate CI approval policy remains effective for external contributions and
+their updates. CI approval does not replace the user's request for agent work.
 
 See the [cutover accounting](workflow-cutover.md) for removed process owners,
 retained product checks and the historical backlog dispositions.


### PR DESCRIPTION
Pin maintainer workflows to devflow 0.3.0 at `61e6e7553cf549583dcb291a77abc10c0edd8a0b`, so a normal work request can enter managed execution without the unavailable 0.2 host verifier.

The owning instructions now cover concrete bug reports, named issues, bounded backlog batches, ordinary questions, and validated recovery after a pin/profile upgrade. A small global instruction loads the installed entry skill; the agent operates the tool. Startup hooks and automatic backlog work are excluded.

Upstream implementation: https://github.com/ebarti/devflow/pull/5
Canonical request: https://github.com/ebarti/devflow/issues/4

Validation:

- `node --test scripts/devflow.test.mjs`: 5 passed.
- `corepack pnpm docs:build`: passed, including 9,917 internal references across 366 emitted files and the install/redirect checks.
- `git diff --check`: passed.
- Actual `scripts/devflow doctor --json` against the installed pinned release: READY, execution enabled, valid profile, and all reported tool capabilities available.
- Independent review/QA passed on the upstream behavior; final consumer pin and installation review passed with no unresolved findings.
- Upstream validation includes 400 passing regressions, real installed CLI lifecycle/recovery checks, and six fresh agent conversation-routing cases.

The local reviewed installation is active. This PR updates the repository pin when merged; merge and release authority remain scoped to the user's request.
