### PR TITLE
chore: adopt coordinated subagent workflow

### DIFF
--- a/.devflow/workflow.lock
+++ b/.devflow/workflow.lock
@@ -1,3 +1,3 @@
 schema_version = 1
-version = "0.3.0"
-revision = "61e6e7553cf549583dcb291a77abc10c0edd8a0b"
+version = "0.4.0"
+revision = "381b8b02923a09d2c23ec7690accdbedc7a00d98"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,14 +12,18 @@ pin in `.devflow/workflow.lock`. Use `scripts/devflow` wherever the skill says
 `devflow`. Once work is requested, run `scripts/devflow doctor --json`; continue
 recorded work with its existing ID. Historical attempts without a recorded user
 request need re-admission under the current request. Read only the selected
-role reference. Devflow owns intake, execution state, independent findings/gates,
-recovery and delivery; do not load a second lifecycle from legacy review/fix
+role and required subagent coordination references. The original conversation
+coordinates bounded implementation/repair and required independent review/QA
+subagents. Verify role identity and resolved model/effort before activation;
+the coordinator's active model does not set role policy. Devflow owns intake,
+execution state, independent findings/gates, recovery and delivery; do not load
+a second lifecycle from legacy review/fix
 skills. Missing installation or host capability is a diagnostic, never a passing
 gate. Setup and cutover limits: `docs/developer/workflow.md`.
 
 Public contributors and clients without the workflow host use `CONTRIBUTING.md`
 and the same product/check requirements. `CLAUDE.md` remains linked here; the
-native host-specific task bridge does not become a requirement to use JobCtrl.
+host-specific subagent bridge does not become a requirement to use JobCtrl.
 
 Use a dedicated task branch/worktree, preserve unrelated dirty work, and use
 Conventional Commits. Merge, release, deployment and external communication

--- a/docs/developer/workflow.md
+++ b/docs/developer/workflow.md
@@ -45,8 +45,8 @@ is sufficient authorization within its scope. Questions and requests for
 explanation do not create issues or start implementation. Respect requests for
 investigation only.
 
-Load the installed skill and only the current role reference; use `scripts/devflow`
-for its `devflow` commands. Capture each requested work item with
+Load the installed skill, current role and required subagent coordination reference;
+use `scripts/devflow` for its `devflow` commands. Capture each requested work item with
 `scripts/devflow backlog capture --request-file <json>
 --json`, reusing its existing issue or a stable work ID with a short public-safe
 outcome, acceptance and context. Follow-ups stay on that issue. Public issue
@@ -81,11 +81,43 @@ reject zero executed test cases, failures and skipped cases. Case counts do not
 measure individual assertion calls; independent QA must still prove meaningful
 behavior. The `diff` recipe compares committed changes with `origin/main`; a PR
 with a different base needs a matching focused recipe before admission. An unavailable browser or
-native task cannot stand in for passing product proof.
+subagent cannot stand in for passing product proof.
+
+## Coordinator And Role Assignments
+
+In devflow 0.4.0, the original user conversation coordinates the outcome.
+Implementation and repairs belong to a bounded `implementation_worker`; required
+review and QA use independent subagents with distinct verified identities.
+Review-only and delivery-only work enter at their actual phase without inventing
+implementation completion. Tier 0 skips independent gates according to the QA
+router. New work uses supported `agents` tools, without creating visible peer tasks.
+
+Role model/effort resolves from explicit user role/session overrides, configured
+role files, saved subagent defaults, then saved global defaults. The coordinator's
+active model overrides do not leak into roles. The package's subagent reference
+owns exact settings, startup evidence and native-tool arguments; do not duplicate
+that dispatch policy in JobCtrl or rewrite global role settings.
+
+The command sequence is `host assign`, then `host prepare` to journal action begin
+before native spawn, followed by `host record` and `host startup`. The bootstrap
+child only reports its own session metadata location and waits. The coordinator
+must verify the parent, canonical agent identity and actual model/effort before
+product activation. Missing or mismatched settings block activation; unknown
+service tier remains unknown. Session evidence stays private and uncommitted.
+
+`host activate` prepares the bounded follow-up; `host prepare` begins it before
+native dispatch, and `host record` stores actual inventory to mark it running.
+`candidate capture` uses the verified running implementation identity, then
+`host result` binds completion to that output candidate before verification.
+Review/QA use `gate record`. Reuse the same available roles for repairs. Changed
+policy or unavailability needs an explicitly recorded, observed replacement that
+preserves earlier identities and evidence. Reconcile an ambiguous spawn; inventory
+absence alone never authorizes a duplicate.
 
 ## Activation Boundaries
 
-Version 0.3.0 supports managed execution from agent-recorded user requests.
+Version 0.4.0 retains managed execution from agent-recorded user requests and
+adds verified subagent execution under the original coordinator.
 `doctor` reports the direct-request mode and checks the installed runtime, profile
 and tools. `READY` describes local runtime readiness; the separate `capabilities`
 report shows whether GitHub capture and other tool-dependent operations can run.
@@ -96,11 +128,14 @@ Issue events, labels and background activity cannot authorize new work.
 Read-only recovery and reconciliation of already dispatched actions remain
 available without restarting them.
 
-Visible owner/review/QA tasks use the native host bridge
-only with an explicit user launch instruction. Hosts without that capability
-cannot claim a devflow role gate; existing bootstrap review evidence must remain
-identified as bootstrap evidence. This adoption does not rewrite global role
-models or silently migrate existing work attempts.
+Hosts without the required subagent capability or observed startup settings cannot
+claim a devflow role gate; existing bootstrap review evidence remains identified
+as bootstrap evidence. Historical attempts without `execution_mode` remain
+`native_thread`, retaining their original control contract, receipts and evidence.
+The current runtime reads that history without relabeling it or delegating to an
+older release. Updating these maintainer instructions alone does not install or
+activate 0.4.0: the reviewed immutable repository pin and matching installed
+release must agree before execution.
 
 Automatic merge remains disabled until separately authorized target protection
 passes live conformance, including strict freshness, the required


### PR DESCRIPTION
Pin devflow 0.4.0 at `381b8b02923a09d2c23ec7690accdbedc7a00d98` and route maintainer work through the original conversation as coordinator, with bounded implementation, Review and QA subagents. Role settings and observed startup identity must match before product work; historical native-thread attempts keep their original evidence.

The shared implementation is [devflow #7](https://github.com/ebarti/devflow/pull/7). This PR contains the JobCtrl pin and owning maintainer documentation.

Validation:

- `node --test scripts/devflow.test.mjs`: 5 passed.
- `corepack pnpm docs:build`: passed, including internal links.
- `git diff --check`: passed.
- `scripts/devflow doctor --json`: READY with the exact 0.4.0 revision after managed installation.
- Shared runtime: 472 tests, Ruff and build passed; independent review/QA and actual native subagent canary passed through local delivery.

Installation changed the existing three managed workflow links. Model configuration, global instructions and unrelated dirty work were preserved. This PR does not claim new JobCtrl product-path or protected-merge validation; its executable change is the maintainer workflow pin.
