### PR TITLE
chore: adopt retained workflow check evidence handoffs

### DIFF
--- a/.devflow/workflow.lock
+++ b/.devflow/workflow.lock
@@ -1,3 +1,3 @@
 schema_version = 1
-version = "0.5.0"
-revision = "1291aa7b57b5b7021d64c3631740cefd0f27128c"
+version = "0.5.1"
+revision = "df3ee4f285cc44acb851749a04e8df9cbb715457"

--- a/docs/developer/workflow.md
+++ b/docs/developer/workflow.md
@@ -20,12 +20,23 @@ coordinating, implementing, reviewing, verifying and delivering (each prefixed
 `devflow-`). A design-only conversation uses a method without creating work.
 The old `devflow` name forwards to the entry. No hooks or scheduler are installed.
 
-`skill list` reports the installed catalog. `skill resolve` with a JSON request
-such as `{"name":"devflow-coordinating"}` returns the selected release's file.
+`skill list` reports the installed catalog. Save a JSON request such as
+`{"name":"devflow-coordinating"}` in `skill.json`, then run
+`scripts/devflow skill resolve --request-file skill.json --json` to return the
+selected release's file. JSON input is not a positional argument.
 For continuation, include the existing `--work-id`; read that immutable path
 rather than substituting newer global skill text. Missing historical stages
 require compatible recovery or a recorded upgrade. `next` names each action's
 owning skill and the separate assigned role skill.
+
+Review/QA handoffs include each check's evidence ID, artifact hash and explicit
+private state root. Retained JSON lives at `<state-root>/artifacts/<hash>` and
+contains the command output and available JUnit report. Verify the hash and use
+the pinned verification skill's check-evidence reference when present. An older
+compatible pin can inspect the verified artifact with standard file/JSON tools
+while retaining its existing pin and activation. Paths in recorded argv
+describe past execution; a removed temporary report does not require rerunning a
+passing check when its retained evidence and candidate inputs match.
 
 Run from a JobCtrl checkout:
 


### PR DESCRIPTION
Upgrade the workflow pin to 0.5.1 and document the retained check-evidence handoff. Reviewers receive the evidence ID, artifact hash and explicit state root; an older compatible attempt can inspect its original artifact while retaining its existing pin and review activation. The skill-resolution example now uses the required JSON request file.

Validation: independent Tier 1 review passed; documentation build and link/redirect checks passed (9,917 references across 366 pages); git diff --check passed.

Source correction: ebarti/devflow#8.
