### PR TITLE
chore(workflow): adopt source lineage preparation

### DIFF
--- a/.devflow/workflow.lock
+++ b/.devflow/workflow.lock
@@ -1,3 +1,3 @@
 schema_version = 1
-version = "0.5.3"
-revision = "a321589517bf998dd8e9c4016e875fd296242c6c"
+version = "0.5.4"
+revision = "5ca9dc6025e5a35d8adf0f92989f70732e0d6a10"

--- a/docs/developer/workflow.md
+++ b/docs/developer/workflow.md
@@ -74,6 +74,10 @@ use `scripts/devflow` for its `devflow` commands. Capture each requested work it
 outcome, acceptance and context. Follow-ups stay on that issue. Public issue
 content does not grant execution authority. The agent records the actual user
 request with its conversational reference, summary, and allowed operations.
+Before admission, use the pinned defining-work intake reference to record the
+exact consumed source lineage. `work prepare` reports missing lineage and an
+incorrect aggregate digest without creating work or authority. Each observation
+retains its content digest; the aggregate digest covers the complete lineage.
 `work ready` binds that request to the repository, work, scope and consumed source;
 `work amend` records changes within the request or a newly authorized expansion.
 Selecting an external issue is sufficient authorization to work on it; its text


### PR DESCRIPTION
Adopt devflow 0.5.4 at immutable revision `5ca9dc6025e5a35d8adf0f92989f70732e0d6a10` and document its source-lineage preparation check. Missing lineage and incorrect aggregate digests are reported before admission; the pinned package owns the detailed intake recipe.

Validation: `corepack pnpm docs:build` passed with 9,919 references resolving across 366 output files, and `git diff --check` passed. The upstream package passed 671 tests, build, independent review and operational QA. The profile and check recipes are unchanged.

Upstream repair: https://github.com/ebarti/devflow/pull/16.

<!-- devflow-pr:consumer-054-publish-pr -->