### PR TITLE
chore(workflow): adopt immutable source mapping helpers

### DIFF
--- a/.devflow/workflow.lock
+++ b/.devflow/workflow.lock
@@ -1,3 +1,3 @@
 schema_version = 1
-version = "0.5.4"
-revision = "5ca9dc6025e5a35d8adf0f92989f70732e0d6a10"
+version = "0.5.5"
+revision = "3c1363bd9ff54c4a2a8da1c52fa2662fa34ca4a0"

--- a/docs/developer/workflow.md
+++ b/docs/developer/workflow.md
@@ -78,6 +78,9 @@ Before admission, use the pinned defining-work intake reference to record the
 exact consumed source lineage. `work prepare` reports missing lineage and an
 incorrect aggregate digest without creating work or authority. Each observation
 retains its content digest; the aggregate digest covers the complete lineage.
+Run the pinned mapping recipe with its bytecode suppression intact, before any
+package import. Direct Python helpers must leave the installed release's files
+unchanged so subsequent workflow commands can still verify them against its manifest.
 `work ready` binds that request to the repository, work, scope and consumed source;
 `work amend` records changes within the request or a newly authorized expansion.
 Selecting an external issue is sufficient authorization to work on it; its text


### PR DESCRIPTION
Pin the maintainer workflow to devflow 0.5.5 and document preserving installed files when running its source-mapping helper. The corrected recipe suppresses bytecode before importing the installed package, preventing subsequent workflow commands from rejecting generated cache files.

Validation: docs build, 9,919 internal-reference checks, legacy redirect check, and diff check passed. The selected devflow source passed all 672 package tests, Ruff, and distribution build.

<!-- devflow-pr:consumer-055-publish-pr -->