### PR TITLE
fix(web): refresh submitted run details using launcher run_id

### DIFF
--- a/apps/web/src/contexts/apply/handlers.ts
+++ b/apps/web/src/contexts/apply/handlers.ts
@@ -116,9 +116,9 @@ export const applicationSubmittedHandler = (
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(applyRunsKeys.lists(event.tenantId)),
-  invalidate(applyRunsKeys.detail(event.tenantId, event.payload.runId)),
+  invalidate(applyRunsKeys.detail(event.tenantId, event.payload.run_id)),
   invalidate(workflowRunsKeys.lists(event.tenantId)),
-  invalidate(workflowRunsKeys.detail(event.tenantId, event.payload.runId)),
+  invalidate(workflowRunsKeys.detail(event.tenantId, event.payload.run_id)),
   invalidate(dashboardKeys.summary(event.tenantId)),
   invalidate(analyticsKeys.all(event.tenantId)),
 ];

--- a/apps/web/src/contexts/operations/invalidation-router.test.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.test.ts
@@ -1,8 +1,9 @@
-import { LOCAL_TENANT, type DomainEventUnion } from "@jobctrl/domain-types";
-import { QueryClient, type QueryKey } from "@tanstack/react-query";
+import { LOCAL_TENANT, createTenantId, type DomainEventUnion } from "@jobctrl/domain-types";
+import { QueryClient, QueryObserver, type QueryKey } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { eventByType } from "../../test/fixtures/events.js";
+import { parseDomainEvent } from "../../shared/ports/lib/parseDomainEvent.js";
 import { activityKeys } from "./activityKeys.js";
 import { analyticsKeys } from "./analyticsKeys.js";
 import { applyReviewKeys } from "./applyReviewKeys.js";
@@ -560,6 +561,94 @@ describe("invalidationRouter", () => {
   let queryClient: QueryClient;
   let invalidateSpy: ReturnType<typeof vi.spyOn>;
   let setQueryDataSpy: ReturnType<typeof vi.spyOn>;
+
+  it.each([0, null])("refreshes only the submitted run details from launcher SSE (worker %s)", async (workerId) => {
+    // Independent wire fixture: launcher lifecycle fields are not camelized by SSE.
+    const parsed = parseDomainEvent({
+      eventType: "ApplicationSubmitted",
+      data: JSON.stringify({
+        tenantId: LOCAL_TENANT,
+        occurredAt: "2026-09-12T10:00:00Z",
+        payload: {
+          tenantId: LOCAL_TENANT,
+          jobId: JOB_ID,
+          run_id: RUN_ID,
+          result: "applied",
+          finished_at: "2026-09-12T10:00:00Z",
+          duration_ms: 4000,
+          worker_id: workerId,
+          model: "test-model",
+        },
+      }),
+    });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) throw new Error("Expected a valid launcher SSE envelope");
+    expect(parsed.envelope.payload).toMatchObject({ run_id: RUN_ID, worker_id: workerId });
+    expect(parsed.envelope.payload).not.toHaveProperty("runId");
+
+    const client = new QueryClient();
+    const invalidations = vi.spyOn(client, "invalidateQueries");
+    const otherTenant = createTenantId("other-tenant");
+    const targetKeys = [
+      applyRunsKeys.detail(LOCAL_TENANT, RUN_ID),
+      workflowRunsKeys.detail(LOCAL_TENANT, RUN_ID),
+    ];
+    const unrelatedKeys = [
+      applyRunsKeys.detail(LOCAL_TENANT, "other-run"),
+      workflowRunsKeys.detail(LOCAL_TENANT, "other-run"),
+      applyRunsKeys.detail(otherTenant, RUN_ID),
+      workflowRunsKeys.detail(otherTenant, RUN_ID),
+    ];
+    const reads = [...targetKeys, ...unrelatedKeys].map((queryKey) => {
+      const queryFn = vi.fn(async () => ({ status: "applied" }));
+      const observer = new QueryObserver(client, {
+        queryKey,
+        queryFn,
+        initialData: { status: "in_progress" },
+        staleTime: Infinity,
+      });
+      return { queryKey, queryFn, unsubscribe: observer.subscribe(() => {}) };
+    });
+    const broaderKeys = [
+      jobsKeys.detail(LOCAL_TENANT, JOB_ID),
+      jobsKeys.lists(LOCAL_TENANT),
+      applyRunsKeys.lists(LOCAL_TENANT),
+      workflowRunsKeys.lists(LOCAL_TENANT),
+      dashboardKeys.summary(LOCAL_TENANT),
+      analyticsKeys.all(LOCAL_TENANT),
+    ];
+    for (const key of broaderKeys) client.setQueryData(key, { cached: true });
+
+    try {
+      // Match EventStreamProvider's dispatch of the parsed wire envelope.
+      invalidationRouter.handle(parsed.envelope as unknown as DomainEventUnion, client);
+      for (const key of targetKeys) {
+        expect(client.getQueryState(key)?.isInvalidated).toBe(true);
+      }
+      for (const key of broaderKeys) {
+        expect(client.getQueryState(key)?.isInvalidated).toBe(true);
+      }
+      for (const [filters] of invalidations.mock.calls) {
+        expect(filters?.queryKey).not.toContain(undefined);
+      }
+      await vi.waitFor(() => {
+        for (const key of targetKeys) {
+          expect(client.getQueryData(key)).toEqual({ status: "applied" });
+        }
+      });
+      for (const read of reads.slice(0, targetKeys.length)) {
+        expect(read.queryFn).toHaveBeenCalledTimes(1);
+      }
+      for (const read of reads.slice(targetKeys.length)) {
+        expect(read.queryFn).not.toHaveBeenCalled();
+        expect(client.getQueryState(read.queryKey)?.isInvalidated).toBe(false);
+        expect(client.getQueryData(read.queryKey)).toEqual({ status: "in_progress" });
+      }
+    } finally {
+      for (const read of reads) read.unsubscribe();
+      client.clear();
+    }
+  });
 
   it("keeps dry-run completion separate from submission and other runs", () => {
     const client = new QueryClient();

--- a/apps/web/src/test/fixtures/events.ts
+++ b/apps/web/src/test/fixtures/events.ts
@@ -572,9 +572,12 @@ export const eventByType = {
   }),
   ApplicationSubmitted: createApplicationSubmitted(LOCAL_TENANT, {
     jobId: JOB_ID,
-    runId: RUN_ID,
-    appliedAt: NOW,
-    verificationConfidence: 0.92,
+    run_id: RUN_ID,
+    result: "applied",
+    finished_at: NOW,
+    duration_ms: 4000,
+    worker_id: 0,
+    model: "test-model",
   }),
   ApplicationFailed: createApplicationFailed(LOCAL_TENANT, {
     jobId: JOB_ID,

--- a/docs/architecture/contracts-types-and-api-boundaries.md
+++ b/docs/architecture/contracts-types-and-api-boundaries.md
@@ -55,6 +55,12 @@ TypeScript vocabulary stays in `domain-types`, while Python aggregates remain
 authoritative for their behavior and invariants. The contract package exposes
 only the wire-safe shapes API consumers need.
 
+`ApplicationSubmitted` models the existing launcher payload in the shared event
+union: `run_id`, `result: "applied"`, `finished_at`, nullable `duration_ms`,
+nullable numeric `worker_id`, and nullable `model`, plus canonical `jobId`.
+The SSE envelope and browser parser preserve these lifecycle field names;
+consumers use `run_id` to identify the submitted run.
+
 `DryRunCompleted` models the existing launcher payload in the shared event union.
 Its lifecycle fields (`run_id`, `finished_at`, `dry_run`, and evidence bindings)
 retain their persisted snake_case names; SSE adds canonical `jobId`/`tenantId`

--- a/docs/architecture/frontend/realtime.md
+++ b/docs/architecture/frontend/realtime.md
@@ -302,6 +302,14 @@ Two patterns exist; both have a place:
 The router never resets component-owned filters, selection, pagination, or
 scroll position. A query update changes data under the existing view state.
 
+### Submission completion
+
+`ApplicationSubmitted` retains the launcher's persisted `run_id` through SSE
+parsing. Its apply-owned handler uses that identity for both apply-run and
+workflow-run detail invalidation, so open run details refetch their terminal
+projection. Job list/detail, run lists, Dashboard and submission analytics also
+refresh; other runs and tenants keep their detail caches.
+
 ### Dry-run completion
 
 `DryRunCompleted` uses the launcher's persisted `run_id` to invalidate apply-run

--- a/packages/domain-types/src/events/apply.ts
+++ b/packages/domain-types/src/events/apply.ts
@@ -9,11 +9,15 @@ import { type DomainEvent, createDomainEvent } from "./base.js";
 
 // -- ApplicationSubmitted ---------------------------------------------------
 
+/** Launcher payload as persisted and delivered by SSE (lifecycle keys stay snake_case). */
 export interface ApplicationSubmittedPayload {
   readonly jobId: string;
-  readonly runId: string;
-  readonly appliedAt: string;
-  readonly verificationConfidence: number;
+  readonly run_id: string;
+  readonly result: "applied";
+  readonly finished_at: string;
+  readonly duration_ms: number | null;
+  readonly worker_id: number | null;
+  readonly model: string | null;
 }
 
 export type ApplicationSubmitted = DomainEvent<"ApplicationSubmitted", ApplicationSubmittedPayload>;

--- a/packages/domain-types/test/events.test.ts
+++ b/packages/domain-types/test/events.test.ts
@@ -599,16 +599,27 @@ describe("Apply events", () => {
     expect(event.payload).not.toHaveProperty("appliedAt");
     expect(DOMAIN_EVENT_TYPES).toContain(event.eventType);
   });
-  it("ApplicationSubmitted has required fields", () => {
+  it.each([0, null])("ApplicationSubmitted preserves launcher fields (worker %s)", (workerId) => {
     const event = createApplicationSubmitted(LOCAL_TENANT, {
       jobId: "j1",
-      runId: "r1",
-      appliedAt: "2025-01-01T00:00:00Z",
-      verificationConfidence: 0.95,
+      run_id: "r1",
+      result: "applied",
+      finished_at: "2025-01-01T00:00:00Z",
+      duration_ms: null,
+      worker_id: workerId,
+      model: null,
     });
     expect(event.eventType).toBe("ApplicationSubmitted");
     expect(event.tenantId).toBe("local");
-    expect(event.payload.verificationConfidence).toBe(0.95);
+    expect(event.payload).toEqual({
+      jobId: "j1",
+      run_id: "r1",
+      result: "applied",
+      finished_at: "2025-01-01T00:00:00Z",
+      duration_ms: null,
+      worker_id: workerId,
+      model: null,
+    });
   });
 
   it("ApplyRunStarted has required fields", () => {
@@ -885,9 +896,12 @@ describe("All events carry tenantId", () => {
     () =>
       createApplicationSubmitted(LOCAL_TENANT, {
         jobId: "j1",
-        runId: "r1",
-        appliedAt: "t",
-        verificationConfidence: 0.9,
+        run_id: "r1",
+        result: "applied",
+        finished_at: "t",
+        duration_ms: 4000,
+        worker_id: 0,
+        model: "test-model",
       }),
     () =>
       createStageStarted(LOCAL_TENANT, {
@@ -1161,9 +1175,12 @@ describe("DOMAIN_EVENT_TYPES enumeration", () => {
       }).eventType,
       createApplicationSubmitted(LOCAL_TENANT, {
         jobId: "j",
-        runId: "r",
-        appliedAt: "t",
-        verificationConfidence: 0.5,
+        run_id: "r",
+        result: "applied",
+        finished_at: "t",
+        duration_ms: null,
+        worker_id: null,
+        model: null,
       }).eventType,
       createApplyReviewDecisionRecorded(LOCAL_TENANT, {
         jobKey: "j",


### PR DESCRIPTION
Launcher-emitted `ApplicationSubmitted` events carry `payload.run_id`, but the frontend read `runId` when invalidating apply-run and workflow-run details. Both exact detail caches now use the emitted identity and refetch their terminal projection. The shared payload type and fixtures match the existing wire contract; broader refreshes and `DryRunCompleted` behavior are preserved.

Adds a launcher-shaped regression with real query observers that failed before the fix and now verifies exact detail refetches, unrelated run/tenant isolation, and absence of undefined detail keys. Updates the owning contract and realtime documentation.

Validation:
- 183 domain-event tests, 106 router tests, 345 adjacent realtime tests, and 4 Python event-parity tests passed.
- Domain/web typechecks, production web build, documentation build/link checks, and diff check passed.
- Independent review and synthetic product-path QA passed through the production SSE adapter, parser, router, and real QueryClient observers. Restoring the legacy key read in a test-local counterfactual reproduced the defect.

QA used synthetic transport and owned fixtures; no real application was submitted. Browser/network end-to-end behavior was outside this cache-contract check.

Fixes #920.
