### PR TITLE
test(apply-review): seed shipped-fit lifecycle audits

### DIFF
--- a/apps/api/test/qa-seed.ts
+++ b/apps/api/test/qa-seed.ts
@@ -39,6 +39,69 @@ export const QA_PLATFORM_JOB_ID = qaJobId(QA_PLATFORM_JOB_URL);
 export const QA_RISK_JOB_URL = "https://linkedin.com/jobs/view/qa-risk-manager";
 export const QA_RISK_JOB_ID = qaJobId(QA_RISK_JOB_URL);
 const QA_RESUME_TEMPLATE = "{{ personal_data }}\n\n{{ resume_body }}\n";
+const QA_SHIPPED_SUMMARY = "Owned platform reliability improvements for incident response.";
+
+export type QaShippedFitLifecycle = "post_voice_shipped" | "post_acceptance_audit";
+
+function shippedFitMetadata(lifecycle: QaShippedFitLifecycle): Record<string, unknown> {
+  return {
+    lifecycle,
+    fit_score: {
+      // r1 is the only must-have and supplies 0.9 of the total 1.6 weight.
+      score: lifecycle === "post_voice_shipped" ? 6 : 5,
+      must_have_coverage: lifecycle === "post_voice_shipped" ? 1 : 0.5,
+      covered_requirement_ids: ["r1"],
+      uncovered_requirement_ids: ["r2"],
+      claimed_only_requirement_ids: ["r2"],
+      // The historical post-acceptance audit did not record grounded coverage.
+      ...(lifecycle === "post_voice_shipped" ? { coverage_basis: "grounded_shipped_text_v1" } : {}),
+    },
+    passed: false,
+    gate_thresholds: { min_fit_score: 7, must_have_coverage: 0.8 },
+    warnings: lifecycle === "post_voice_shipped"
+      ? ["Shipped grounded must-have coverage 100% (fit 6/10) is below the revision gate (80% / 7)."]
+      : ["Recorded after acceptance; this audit did not influence the accepted resume."],
+  };
+}
+
+/** Switch only the owned seed's canonical final audit, retaining all other metadata. */
+export function seedQaShippedFitLifecycle(dbPath: string, lifecycle: QaShippedFitLifecycle): () => void {
+  const db = new Database(dbPath);
+  const originals: Array<{ table: string; rowid: number; metadata_json: string }> = [];
+  try {
+    db.transaction(() => {
+      for (const table of ["job_materials", "job_materials_artifacts"]) {
+        const rows = db.prepare(
+          `SELECT rowid, metadata_json FROM ${table} WHERE tenant_id = 'local' AND job_id = ? AND generation = 1`,
+        ).all(QA_PLATFORM_JOB_ID) as Array<{ rowid: number; metadata_json: string }>;
+        for (const row of rows) {
+          const metadata = JSON.parse(row.metadata_json) as Record<string, unknown>;
+          if (!metadata.post_generation_fit) continue;
+          originals.push({ table, ...row });
+          metadata.post_generation_fit_final = shippedFitMetadata(lifecycle);
+          db.prepare(`UPDATE ${table} SET metadata_json = ? WHERE rowid = ?`)
+            .run(JSON.stringify(metadata), row.rowid);
+        }
+      }
+      if (originals.length !== 3) throw new Error("Expected the seeded material and both resume artifacts.");
+    })();
+  } finally {
+    db.close();
+  }
+  return () => {
+    const restoreDb = new Database(dbPath);
+    try {
+      restoreDb.transaction(() => {
+        for (const row of originals) {
+          restoreDb.prepare(`UPDATE ${row.table} SET metadata_json = ? WHERE rowid = ?`)
+            .run(row.metadata_json, row.rowid);
+        }
+      })();
+    } finally {
+      restoreDb.close();
+    }
+  };
+}
 
 export function createQaPdfBytes(title: string): Buffer {
   const safeTitle = title
@@ -163,7 +226,7 @@ const QA_RESUME_HTML = `<!doctype html>
       <h1 data-resume-layout-target="personal:full_name" data-resume-line-number="1">John Doe</h1>
       <p data-resume-layout-target="personal:contact" data-resume-line-number="2">john.doe@example.com | Remote City</p>
       <h2>Profile</h2>
-      <p data-resume-layout-target="summary" data-resume-line-number="3">Platform and security engineering leader for QA validation.</p>
+      <p data-resume-layout-target="summary" data-resume-line-number="3">${QA_SHIPPED_SUMMARY}</p>
       <h2>Experience</h2>
       <p data-resume-layout-target="experience:qa_platform" data-resume-line-number="4"><strong>Director of Platform Engineering, QA Systems</strong></p>
       <ul>
@@ -224,8 +287,8 @@ export function seedQaDatabase(dbPath: string, options: QaSeedOptions = {}): voi
   const resumeHtml = path.join(artifactDir, "gitlab-platform-resume.html");
   const coverTxt = path.join(artifactDir, "gitlab-platform-cover.txt");
   const coverPdf = path.join(artifactDir, "gitlab-platform-cover.pdf");
-  fs.writeFileSync(resumeTxt, "QA tailored resume");
-  fs.writeFileSync(resumePdf, createQaPdfBytes("QA tailored resume"));
+  fs.writeFileSync(resumeTxt, QA_SHIPPED_SUMMARY);
+  fs.writeFileSync(resumePdf, createQaPdfBytes(QA_SHIPPED_SUMMARY));
   fs.writeFileSync(resumeHtml, QA_RESUME_HTML);
   fs.writeFileSync(coverTxt, "QA cover letter");
   fs.writeFileSync(coverPdf, createQaPdfBytes("QA cover letter"));
@@ -571,11 +634,13 @@ function requirementLedAuditMetadata(): Record<string, unknown> {
             requirement_id: "r1",
             text_excerpt: "Lead platform reliability improvements across critical services.",
             tier: "must_have",
+            weight: 0.9,
           },
           {
             requirement_id: "r2",
             text_excerpt: "Improve developer experience and incident-response practices.",
             tier: "nice_to_have",
+            weight: 0.7,
           },
         ],
       },
@@ -598,7 +663,7 @@ function requirementLedAuditMetadata(): Record<string, unknown> {
         section: "experience",
         label: "Director of Platform Engineering",
         source_text: ["FULL PROFILE SECRET source bullet"],
-        tailored_text: ["Owned platform reliability improvements for incident response."],
+        tailored_text: [QA_SHIPPED_SUMMARY],
         evidence_ids: ["ev-platform"],
         requirement_ids: ["r1"],
         coverage_edge_ids: ["edge-r1-ev-platform"],
@@ -639,6 +704,7 @@ function requirementLedAuditMetadata(): Record<string, unknown> {
         review_blockers: ["claim-draft: draft_requires_confirmation"],
       },
     },
+    post_generation_fit_final: shippedFitMetadata("post_voice_shipped"),
     bullet_limit_overflows: [
       {
         experience_entry_id: "qa_platform",
@@ -835,7 +901,7 @@ function insertBulletProvenance(db: Database.Database): void {
     "rephrased",
     "rephrase_allowed",
     "Reframed the bullet toward platform reliability.",
-    "Owned platform reliability improvements for incident response.",
+    QA_SHIPPED_SUMMARY,
     1,
     QA_NOW,
   );

--- a/apps/api/test/qa-workflow.test.ts
+++ b/apps/api/test/qa-workflow.test.ts
@@ -16,6 +16,7 @@ import {
   QA_PLATFORM_JOB_ID,
   QA_RISK_JOB_ID,
   removeQaWorkspace,
+  seedQaShippedFitLifecycle,
   type QaWorkspace,
 } from "./qa-seed.js";
 
@@ -55,6 +56,45 @@ afterEach(() => {
 });
 
 describe("seeded local QA workflow", () => {
+  it.each(["post_voice_shipped", "post_acceptance_audit"] as const)(
+    "projects canonical %s findings separately from the acceptance gate",
+    async (lifecycle) => {
+      if (lifecycle === "post_acceptance_audit") seedQaShippedFitLifecycle(workspace.dbPath, lifecycle);
+      const app = buildApp(options);
+      try {
+        const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
+        expect(response.statusCode, response.body).toBe(200);
+        const item = response.json().items.find((candidate: { jobKey: string }) => candidate.jobKey === QA_PLATFORM_JOB_ID);
+        const audit = item.materialsPreview.requirementLedAudit;
+        expect(audit.shippedFit).toEqual({
+          lifecycle,
+          score: lifecycle === "post_voice_shipped" ? 6 : 5,
+          mustHaveCoverage: lifecycle === "post_voice_shipped" ? 1 : 0.5,
+          claimedOnlyRequirementIds: ["r2"],
+          passed: false,
+          warnings: lifecycle === "post_voice_shipped"
+            ? ["Shipped grounded must-have coverage 100% (fit 6/10) is below the revision gate (80% / 7)."]
+            : ["Recorded after acceptance; this audit did not influence the accepted resume."],
+          coverageBasis: lifecycle === "post_voice_shipped" ? "grounded_shipped_text_v1" : "judge_claimed_legacy",
+        });
+        expect(audit.revision).toMatchObject({ score: 7, mustHaveCoverage: 0.5, reviewBlocked: true });
+        expect(audit.coveredRequirements).toMatchObject([{ id: "r1" }]);
+        expect(audit.uncoveredRequirements).toMatchObject([
+          { id: "r2", reason: "Adjacent developer-experience language needs review before approval." },
+        ]);
+        expect(audit.evidenceBackedClaims).toEqual(expect.arrayContaining([
+          expect.objectContaining({ evidenceIds: ["ev-platform"], requirementIds: ["r1"], claimLabels: ["evidence_reframed"] }),
+          expect.objectContaining({ evidenceIds: ["ev-incident"], requirementIds: ["r2"], reviewRequired: true }),
+        ]));
+        expect(response.body).not.toContain("RAW PROMPT SECRET");
+        expect(response.body).not.toContain("FULL PROFILE SECRET");
+        expect(response.body).not.toContain("/private/secret-resume.pdf");
+      } finally {
+        await app.close();
+      }
+    },
+  );
+
   it("soft deletes and restores all matching jobs without touching nonmatching rows", async () => {
     const app = buildApp(options);
 

--- a/apps/web/e2e/tests/outreach.spec.ts
+++ b/apps/web/e2e/tests/outreach.spec.ts
@@ -22,6 +22,24 @@ const SENSITIVE_VALUES = [
   "Hi Casey, I saw the platform role and wanted to introduce myself.",
 ];
 
+test.afterEach(() => {
+  const db = new Database(loadE2eDbPath());
+  try {
+    db.transaction(() => {
+      db.prepare(
+        "DELETE FROM application_outcomes WHERE tenant_id = 'local' AND outcome_id = 'outcome-e2e-outreach' AND job_id = ?",
+      ).run(QA_PLATFORM_JOB_ID);
+      // A later canonical metadata refresh must not inherit this fixture's
+      // applied status. Rebuild through the normal API from remaining facts.
+      db.prepare(
+        "DELETE FROM job_list_projections WHERE tenant_id = 'local' AND job_id = ?",
+      ).run(QA_PLATFORM_JOB_ID);
+    })();
+  } finally {
+    db.close();
+  }
+});
+
 function tableExists(db: Database.Database, table: string): boolean {
   const row = db
     .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")

--- a/apps/web/e2e/tests/shipped-fit-lifecycle.spec.ts
+++ b/apps/web/e2e/tests/shipped-fit-lifecycle.spec.ts
@@ -21,8 +21,9 @@ for (const lifecycle of ["post_voice_shipped", "post_acceptance_audit"] as const
       const response = await queueResponse;
       expect(response.status()).toBe(200);
       const queue = await response.json() as ApplyReviewQueueResponse;
-      const item = queue.items.find((candidate) => candidate.jobKey === QA_PLATFORM_JOB_ID)!;
-      const audit = item.materialsPreview.requirementLedAudit!;
+      const item = queue.items.find((candidate) => candidate.jobKey === QA_PLATFORM_JOB_ID);
+      expect(item, "The synthetic audit job must remain eligible after earlier browser fixtures").toBeDefined();
+      const audit = item!.materialsPreview.requirementLedAudit!;
       expect(audit.shippedFit).toMatchObject({
         lifecycle, score: lifecycle === "post_voice_shipped" ? 6 : 5,
         mustHaveCoverage: lifecycle === "post_voice_shipped" ? 1 : 0.5, passed: false,

--- a/apps/web/e2e/tests/shipped-fit-lifecycle.spec.ts
+++ b/apps/web/e2e/tests/shipped-fit-lifecycle.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+import type { ApplyReviewQueueResponse } from "@jobctrl/contracts";
+
+import { seedQaShippedFitLifecycle } from "../../../api/test/qa-seed.js";
+import { loadE2eDbPath, QA_PLATFORM_JOB_ID } from "../fixtures/e2e-state.js";
+
+// No route interception: canonical SQLite metadata flows through the real API.
+for (const lifecycle of ["post_voice_shipped", "post_acceptance_audit"] as const) {
+  test(`${lifecycle} labels final findings without rewriting the acceptance gate`, async ({ page }, testInfo) => {
+    const restore = seedQaShippedFitLifecycle(loadE2eDbPath(), lifecycle);
+    const errors: string[] = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+    page.on("console", (message) => {
+      if (message.type() === "error") errors.push(message.text());
+    });
+    try {
+      const queueResponse = page.waitForResponse((response) =>
+        new URL(response.url()).pathname === "/v1/apply/review-queue" && response.request().method() === "GET",
+      );
+      await page.goto(`/apply-review?jobKey=${encodeURIComponent(QA_PLATFORM_JOB_ID)}`);
+      const response = await queueResponse;
+      expect(response.status()).toBe(200);
+      const queue = await response.json() as ApplyReviewQueueResponse;
+      const item = queue.items.find((candidate) => candidate.jobKey === QA_PLATFORM_JOB_ID)!;
+      const audit = item.materialsPreview.requirementLedAudit!;
+      expect(audit.shippedFit).toMatchObject({
+        lifecycle, score: lifecycle === "post_voice_shipped" ? 6 : 5,
+        mustHaveCoverage: lifecycle === "post_voice_shipped" ? 1 : 0.5, passed: false,
+        claimedOnlyRequirementIds: ["r2"],
+        coverageBasis: lifecycle === "post_voice_shipped" ? "grounded_shipped_text_v1" : "judge_claimed_legacy",
+      });
+      expect(audit.revision).toMatchObject({ score: 7, mustHaveCoverage: 0.5, reviewBlocked: true });
+      expect(audit.coveredRequirements.map((requirement) => requirement.id)).toEqual(["r1"]);
+      expect(audit.uncoveredRequirements.map((requirement) => requirement.id)).toEqual(["r2"]);
+
+      await expect(page).toHaveURL(/\/apply-review\?jobKey=/);
+      await expect(page.getByRole("heading", { name: "Application review", exact: true })).toBeVisible();
+      const auditRegion = page.getByRole("region", { name: "Requirement-led tailoring audit" });
+      const shipped = auditRegion.locator(".apply-review-audit-shipped-fit");
+      await shipped.scrollIntoViewIfNeeded();
+      await expect(shipped).toContainText(lifecycle === "post_voice_shipped" ? "Shipped fit: 6/10" : "Shipped fit: 5/10");
+      await expect(shipped).toContainText(lifecycle === "post_voice_shipped" ? "Must-have coverage: 100%" : "Must-have coverage: 50%");
+      await expect(shipped).toContainText("below revision gate");
+      await expect(auditRegion).toContainText("Fit gate: 7/10");
+      await expect(auditRegion).toContainText("Gate-recorded coverage: 50%");
+      if (lifecycle === "post_voice_shipped") {
+        await expect(shipped).toContainText("Post-voice gate findings");
+        await expect(shipped).toContainText("grounded (shipped text)");
+        await expect(shipped).toContainText("Shipped grounded must-have coverage 100% (fit 6/10) is below the revision gate (80% / 7).");
+        await expect(shipped).not.toContainText("Post-acceptance audit findings");
+      } else {
+        await expect(shipped).toContainText("Post-acceptance audit findings");
+        await expect(shipped).toContainText("judge-claimed (legacy)");
+        await expect(shipped).toContainText("Recorded after acceptance; this audit did not influence the accepted resume.");
+        await expect(shipped).not.toContainText("Post-voice gate findings");
+        await expect(shipped).not.toContainText("grounded (shipped text)");
+      }
+      // Disclosing the real job-position panel preserves the same audit on reopen.
+      await page.getByRole("button", { name: "Collapse job position" }).click();
+      await expect(auditRegion).not.toBeVisible();
+      await page.getByRole("button", { name: "Expand job position" }).click();
+      await shipped.scrollIntoViewIfNeeded();
+      await expect(shipped).toBeVisible();
+      await expect(page.locator("vite-error-overlay")).toHaveCount(0);
+      expect(errors).toEqual([]);
+      await testInfo.attach(`${lifecycle}-audit`, { body: await auditRegion.screenshot(), contentType: "image/png" });
+    } finally {
+      restore();
+    }
+  });
+}

--- a/docs/developer/qa/frontend.md
+++ b/docs/developer/qa/frontend.md
@@ -21,6 +21,11 @@ browser behavior, and visual consistency catch different failures.
 - Type-level tests prove the public inferred shapes of read hooks and contracts.
 - Playwright uses a real API plus seeded SQLite fixtures to prove route and
   realtime behavior without a live worker or model.
+- `shipped-fit-lifecycle.spec.ts` reads canonical final-fit metadata through the
+  real review-queue API. It distinguishes post-voice gate findings from audits
+  recorded after acceptance, retains the original gate and provenance coverage,
+  and keeps historical judge-claimed coverage visibly separate from grounded
+  coverage. Its fixture restores the original metadata after each case.
 - Storybook proves state/variant rendering and shared accessibility behavior.
 
 ## Rhea And Base UI Contracts


### PR DESCRIPTION
The QA seed contained initial fit metadata but omitted the final audit consumed by Apply Review. Seed canonical post-voice and historical post-acceptance findings, and exercise their lifecycle labels through the real SQLite/API/browser path while preserving the original gate, provenance, and coverage basis.

Synthetic resume text now agrees with its recorded provenance. Grounded final coverage is 100% for the single covered must-have; the original judge-claimed gate remains 50%. Existing requirement-fit visual baselines remain unchanged.

The full browser suite exposed an existing Outreach fixture that left an application confirmation on the shared audit job. Clean up that exact synthetic outcome and invalidate its derived job row so later canonical metadata refreshes preserve review-queue eligibility. Other application confirmations remain authoritative.

Validation: 44 focused API tests; API/web type checks; web and docs builds; four lifecycle/visual browser tests; independent desktop/mobile light/dark checks covering exact fixture restoration, score sensitivity, missing-final fallback, and privacy masking. The repaired mixed sequence passes all five Outreach/lifecycle/downstream queue tests. Independent repair review, three browser cases, and an adversarial cleanup-preservation probe pass. An accidentally broadened local browser run exposed an unrelated isolated Browser settings typography assertion; the focused run passes.

Closes #892.
