### PR TITLE
perf(web): reconcile eligible realtime list updates

### DIFF
--- a/apps/web/e2e/tests/outreach.spec.ts
+++ b/apps/web/e2e/tests/outreach.spec.ts
@@ -22,6 +22,24 @@ const SENSITIVE_VALUES = [
   "Hi Casey, I saw the platform role and wanted to introduce myself.",
 ];
 
+test.afterEach(() => {
+  const db = new Database(loadE2eDbPath());
+  try {
+    db.transaction(() => {
+      db.prepare(
+        "DELETE FROM application_outcomes WHERE tenant_id = 'local' AND outcome_id = 'outcome-e2e-outreach' AND job_id = ?",
+      ).run(QA_PLATFORM_JOB_ID);
+      // A later canonical metadata refresh must not inherit this fixture's
+      // applied status. Rebuild through the normal API from remaining facts.
+      db.prepare(
+        "DELETE FROM job_list_projections WHERE tenant_id = 'local' AND job_id = ?",
+      ).run(QA_PLATFORM_JOB_ID);
+    })();
+  } finally {
+    db.close();
+  }
+});
+
 function tableExists(db: Database.Database, table: string): boolean {
   const row = db
     .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")

--- a/apps/web/e2e/tests/realtime-list-context.spec.ts
+++ b/apps/web/e2e/tests/realtime-list-context.spec.ts
@@ -8,8 +8,14 @@ const COMPANY = "Cache Context Labs";
 
 test("JobUpdated patches a filtered second page without losing selection, order or scroll", async ({
   page,
+  request,
 }, testInfo) => {
   const db = new Database(loadE2eDbPath());
+  db.pragma("foreign_keys = ON");
+  const seededJobIds: string[] = [];
+  const baselineResponse = await request.get("/v1/jobs");
+  expect(baselineResponse.ok()).toBe(true);
+  const baseline = await baselineResponse.json();
   const errors: string[] = [];
   const streamEvents: string[] = [];
   let listReads = 0;
@@ -46,6 +52,7 @@ test("JobUpdated patches a filtered second page without losing selection, order 
           Date.UTC(2026, 8, 12, 10, index),
         ).toISOString();
         insertJob.run(jobId, url, title, COMPANY, timestamp);
+        seededJobIds.push(jobId);
         insertEvent.run(
           jobId,
           "JobDiscovered",
@@ -161,7 +168,67 @@ test("JobUpdated patches a filtered second page without losing selection, order 
     expect(page.url()).toBe(urlBefore);
     expect(await page.evaluate(() => window.scrollY)).toBe(scrollBefore);
   } finally {
-    db.close();
-    // Playwright owns the page/context and closes the CDP session with it.
+    try {
+      // Other specs share this disposable workspace. Remove our canonical rows
+      // and derived rows, then replay the remaining canonical history so totals
+      // and dashboard activity no longer include the synthetic fixture.
+      await page.close();
+      db.transaction(() => {
+        for (const jobId of seededJobIds) {
+          for (const table of [
+            "job_events",
+            "job_list_projections",
+            "job_detail_projections",
+            "artifact_list_projections",
+            "jobs",
+          ]) {
+            db.prepare(
+              `DELETE FROM ${table} WHERE tenant_id = 'local' AND job_id = ?`,
+            ).run(jobId);
+          }
+        }
+        db.prepare(
+          "UPDATE event_watermarks SET last_event_id = 0 WHERE projection_name = ?",
+        ).run("typescript:operations_projections:local");
+      })();
+      const lastEvent = db
+        .prepare(
+          "SELECT COALESCE(MAX(event_id), 0) AS id FROM job_events WHERE tenant_id = 'local'",
+        )
+        .get() as { id: number };
+      await expect
+        .poll(async () => {
+          const response = await request.get("/v1/jobs");
+          expect(response.ok()).toBe(true);
+          const watermark = db
+            .prepare(
+              "SELECT last_event_id AS id FROM event_watermarks WHERE projection_name = ?",
+            )
+            .get("typescript:operations_projections:local") as { id: number };
+          return watermark.id;
+        })
+        .toBeGreaterThanOrEqual(lastEvent.id);
+      const restored = await (await request.get("/v1/jobs")).json();
+      expect(restored.pagination.total).toBe(baseline.pagination.total);
+      expect(
+        restored.items.map((item: { jobKey: string }) => item.jobKey),
+      ).toEqual(baseline.items.map((item: { jobKey: string }) => item.jobKey));
+      for (const table of [
+        "jobs",
+        "job_events",
+        "job_list_projections",
+        "job_detail_projections",
+        "artifact_list_projections",
+      ]) {
+        const remaining = db
+          .prepare(
+            `SELECT COUNT(*) AS count FROM ${table} WHERE tenant_id = 'local' AND job_id IN (${seededJobIds.map(() => "?").join(",")})`,
+          )
+          .get(...seededJobIds) as { count: number };
+        expect(remaining.count).toBe(0);
+      }
+    } finally {
+      db.close();
+    }
   }
 });

--- a/apps/web/e2e/tests/realtime-list-context.spec.ts
+++ b/apps/web/e2e/tests/realtime-list-context.spec.ts
@@ -1,0 +1,167 @@
+import { expect, test } from "@playwright/test";
+import Database from "better-sqlite3";
+import { createHash } from "node:crypto";
+import { loadE2eDbPath } from "../fixtures/e2e-state.js";
+
+const PREFIX = "qa-cache-890-";
+const COMPANY = "Cache Context Labs";
+
+test("JobUpdated patches a filtered second page without losing selection, order or scroll", async ({
+  page,
+}, testInfo) => {
+  const db = new Database(loadE2eDbPath());
+  const errors: string[] = [];
+  const streamEvents: string[] = [];
+  let listReads = 0;
+  let connections = 0;
+  page.on("pageerror", (error) => errors.push(error.message));
+  page.on("request", (request) => {
+    const pathname = new URL(request.url()).pathname;
+    if (pathname === "/v1/jobs") listReads += 1;
+    if (pathname === "/v1/events/stream") connections += 1;
+  });
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("Network.enable");
+  cdp.on("Network.eventSourceMessageReceived", (event) =>
+    streamEvents.push(event.eventName),
+  );
+  try {
+    // This database belongs to the guarded, disposable E2E workspace. Populate
+    // enough canonical jobs for a real second page and a nonzero scroll offset.
+    const insertJob = db.prepare(`INSERT INTO jobs
+      (tenant_id, job_id, url, title, company, site, discovered_at)
+      VALUES ('local', ?, ?, ?, ?, 'cache-890', ?)`);
+    const insertEvent = db.prepare(`INSERT INTO job_events
+      (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json)
+      VALUES ('local', ?, 1, 'discover', ?, 'info', ?, ?, ?)`);
+    db.transaction(() => {
+      for (let index = 0; index < 60; index += 1) {
+        const digest = createHash("sha256")
+          .update(`${PREFIX}${index}`)
+          .digest("hex");
+        const jobId = `${digest.slice(0, 8)}-${digest.slice(8, 12)}-4${digest.slice(13, 16)}-8${digest.slice(17, 20)}-${digest.slice(20, 32)}`;
+        const title = `Cache Engineer ${String(index).padStart(3, "0")}`;
+        const url = `https://example.com/${jobId}`;
+        const timestamp = new Date(
+          Date.UTC(2026, 8, 12, 10, index),
+        ).toISOString();
+        insertJob.run(jobId, url, title, COMPANY, timestamp);
+        insertEvent.run(
+          jobId,
+          "JobDiscovered",
+          "Synthetic cache regression job",
+          timestamp,
+          JSON.stringify({
+            jobId,
+            postingUrl: url,
+            source: "cache-890",
+            employer: COMPANY,
+            metadata: {},
+            discoveredAt: timestamp,
+          }),
+        );
+      }
+    })();
+
+    const initialResponse = page.waitForResponse(
+      (response) => new URL(response.url()).pathname === "/v1/jobs",
+    );
+    await page.goto(
+      "/jobs?discoveredSince=2026-09-12T10%3A00%3A00.000Z&page=2&pageSize=20&sort=discovered_at&dir=desc",
+    );
+    const response = await initialResponse;
+    expect(response.ok(), await response.text()).toBe(true);
+    const initial = (await response.json()) as {
+      items: Array<{ jobKey: string; title: string }>;
+      pagination: { page: number; total: number };
+    };
+    expect(initial.pagination).toMatchObject({ page: 2, total: 60 });
+    await expect(page.locator(".connection-pill")).toContainText("Live", {
+      timeout: 30_000,
+    });
+    const target = initial.items[8]!;
+    const selected = page.getByRole("checkbox", {
+      name: `Select ${target.title}`,
+      exact: true,
+    });
+    await selected.click();
+    await expect(selected).toBeChecked();
+    await expect(page.getByText("1 selected", { exact: true })).toBeVisible();
+    await page.evaluate(() => window.scrollTo(0, 350));
+    const scrollBefore = await page.evaluate(() => window.scrollY);
+    expect(scrollBefore).toBeGreaterThan(0);
+    const urlBefore = page.url();
+    const labelsBefore = await page
+      .locator("[role='checkbox'][aria-label^='Select Cache Engineer']")
+      .evaluateAll((elements) =>
+        elements.map((element) => element.getAttribute("aria-label")),
+      );
+    const readsBefore = listReads;
+    const connectionsBefore = connections;
+    const title = "Cache Engineer updated";
+    const occurredAt = new Date().toISOString();
+    // Persist the same canonical field written by discovery, then emit only
+    // JobUpdated. No navigation, focus or manual refresh drives the new label.
+    db.transaction(() => {
+      db.prepare(
+        "UPDATE jobs SET title = ? WHERE tenant_id = 'local' AND job_id = ?",
+      ).run(title, target.jobKey);
+      insertEvent.run(
+        target.jobKey,
+        "JobUpdated",
+        "Synthetic title update",
+        occurredAt,
+        JSON.stringify({ jobId: target.jobKey, changedFields: { title } }),
+      );
+    })();
+    const updated = page.getByRole("checkbox", {
+      name: `Select ${title}`,
+      exact: true,
+    });
+    await expect(updated).toBeChecked({ timeout: 5000 });
+    await expect.poll(() => streamEvents.includes("JobUpdated")).toBe(true);
+    expect(listReads).toBe(readsBefore);
+    expect(connections).toBe(connectionsBefore);
+    expect(page.url()).toBe(urlBefore);
+    expect(await page.evaluate(() => window.scrollY)).toBe(scrollBefore);
+    const labelsAfter = await page
+      .locator("[role='checkbox'][aria-label^='Select Cache Engineer']")
+      .evaluateAll((elements) =>
+        elements.map((element) => element.getAttribute("aria-label")),
+      );
+    expect(labelsAfter).toEqual(
+      labelsBefore.map((label) =>
+        label === `Select ${target.title}` ? `Select ${title}` : label,
+      ),
+    );
+    expect(errors).toEqual([]);
+    await expect(page.locator("vite-error-overlay")).toHaveCount(0);
+    await page.screenshot({
+      path: testInfo.outputPath("realtime-context.png"),
+    });
+    await testInfo.attach("realtime-context", {
+      path: testInfo.outputPath("realtime-context.png"),
+      contentType: "image/png",
+    });
+
+    // An event with unknown derived fields must still refetch this exact page.
+    const refreshed = page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === "/v1/jobs" && response.ok(),
+    );
+    insertEvent.run(
+      target.jobKey,
+      "JobUpdated",
+      "Synthetic unknown update",
+      new Date().toISOString(),
+      JSON.stringify({ jobId: target.jobKey, changedFields: { metadata: {} } }),
+    );
+    expect((await refreshed).ok()).toBe(true);
+    await expect(updated).toBeChecked();
+    expect(page.url()).toBe(urlBefore);
+    expect(await page.evaluate(() => window.scrollY)).toBe(scrollBefore);
+  } finally {
+    db.close();
+    // Playwright owns the page/context and closes the CDP session with it.
+  }
+});

--- a/apps/web/src/contexts/discovery/handlers.ts
+++ b/apps/web/src/contexts/discovery/handlers.ts
@@ -23,8 +23,15 @@ import type {
 import { dashboardKeys } from "../operations/dashboardKeys.js";
 import { digestKeys } from "../operations/digestKeys.js";
 import { discoveryKeys } from "./queryKeys.js";
-import { invalidate, type InvalidationItem } from "../operations/invalidation-router.js";
+import {
+  invalidate,
+  patchQuery,
+  reconcileQuery,
+  type InvalidationItem,
+} from "../operations/invalidation-router.js";
 import { jobsKeys } from "../operations/jobsKeys.js";
+import { patchDashboardJobLabels, reconcileJobUpdatedPage } from "../operations/realtimePatches.js";
+import type { JobsListInput } from "../operations/types.js";
 
 export const jobDiscoveredHandler = (event: JobDiscovered): readonly InvalidationItem[] => [
   invalidate(jobsKeys.lists(event.tenantId)),
@@ -36,7 +43,11 @@ export const jobDiscoveredHandler = (event: JobDiscovered): readonly Invalidatio
 ];
 
 export const jobUpdatedHandler = (event: JobUpdated): readonly InvalidationItem[] => [
-  invalidate(jobsKeys.lists(event.tenantId)),
+  reconcileQuery(jobsKeys.lists(event.tenantId), (current, key) =>
+    reconcileJobUpdatedPage(current, key[4] as JobsListInput, event.payload)),
+  patchQuery(dashboardKeys.summary(event.tenantId), (current) => patchDashboardJobLabels(current, event.payload)),
+  // Labels are exact; activity insertion and aggregate/projection changes are not.
+  invalidate(dashboardKeys.summary(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
 ];
 

--- a/apps/web/src/contexts/enrichment/handlers.ts
+++ b/apps/web/src/contexts/enrichment/handlers.ts
@@ -13,10 +13,12 @@ import { discoveryKeys } from "../discovery/queryKeys.js";
 import {
   invalidate,
   patchQuery,
+  reconcileQuery,
   type InvalidationItem,
 } from "../operations/invalidation-router.js";
 import { jobsKeys } from "../operations/jobsKeys.js";
-import { patchJobActiveState } from "../operations/realtimePatches.js";
+import { patchJobActiveState, reconcileJobActiveStatePage } from "../operations/realtimePatches.js";
+import type { JobsListInput } from "../operations/types.js";
 
 export const jobEnrichedHandler = (event: JobEnriched): readonly InvalidationItem[] => [
   invalidate(jobsKeys.lists(event.tenantId)),
@@ -67,13 +69,13 @@ export const postingContentSnapshotFailedHandler = (
 export const jobActiveStateChangedHandler = (
   event: JobActiveStateChanged,
 ): readonly InvalidationItem[] => [
-  // Active state is exact on an open detail. List membership can cross the
-  // active/closed filters, so list reconciliation remains bounded by tenant.
+  // Patch eligible pages; reconcile active/closed membership changes on the server.
   patchQuery(
     jobsKeys.detail(event.tenantId, event.payload.jobId),
     (current) => patchJobActiveState(current, event.payload),
   ),
-  invalidate(jobsKeys.lists(event.tenantId)),
+  reconcileQuery(jobsKeys.lists(event.tenantId), (current, key) =>
+    reconcileJobActiveStatePage(current, key[4] as JobsListInput, event.payload)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(discoveryKeys.sourceQuality(event.tenantId)),
   invalidate(dashboardKeys.summary(event.tenantId)),

--- a/apps/web/src/contexts/materials/handlers.ts
+++ b/apps/web/src/contexts/materials/handlers.ts
@@ -23,17 +23,19 @@ import { dashboardKeys } from "../operations/dashboardKeys.js";
 import {
   invalidate,
   patchQuery,
+  reconcileQuery,
   type InvalidationItem,
 } from "../operations/invalidation-router.js";
 import { jobsKeys } from "../operations/jobsKeys.js";
-import { patchResumeApproved } from "../operations/realtimePatches.js";
+import { patchResumeApproved, reconcileResumeApprovedPage } from "../operations/realtimePatches.js";
 import { profileKeys } from "../profile/queryKeys.js";
+import type { ArtifactsListInput } from "../operations/types.js";
 
 export const resumeApprovedHandler = (
   event: ResumeApproved,
 ): readonly InvalidationItem[] => [
-  // Patch only already-registered detail rows. This event does not carry the
-  // complete artifact summary needed to insert or refilter an artifact page.
+  // Patch already-registered rows. Approval can also register PDFs and suppress
+  // older artifacts, so every artifact page still needs canonical reconciliation.
   patchQuery(
     jobsKeys.detail(event.tenantId, event.payload.jobId),
     (current) => patchResumeApproved(current, event.payload),
@@ -44,7 +46,11 @@ export const resumeApprovedHandler = (
   ),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(jobsKeys.lists(event.tenantId)),
-  invalidate(artifactsKeys.lists(event.tenantId)),
+  reconcileQuery(
+    artifactsKeys.lists(event.tenantId),
+    (current, key) => reconcileResumeApprovedPage(current, key[4] as ArtifactsListInput, event.payload),
+    { invalidateAfterPatch: true },
+  ),
   invalidate(dashboardKeys.summary(event.tenantId)),
 ];
 

--- a/apps/web/src/contexts/operations/invalidation-router.test.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.test.ts
@@ -36,7 +36,7 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
     dashboardKeys.summary(LOCAL_TENANT),
     digestKeys.all(LOCAL_TENANT),
   ],
-  JobUpdated: [jobsKeys.lists(LOCAL_TENANT), jobsKeys.detail(LOCAL_TENANT, JOB_ID)],
+  JobUpdated: [dashboardKeys.summary(LOCAL_TENANT), jobsKeys.detail(LOCAL_TENANT, JOB_ID)],
   JobDeleted: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
@@ -146,7 +146,6 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
     discoveryKeys.sourceQuality(LOCAL_TENANT),
   ],
   JobActiveStateChanged: [
-    jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     discoveryKeys.sourceQuality(LOCAL_TENANT),
     dashboardKeys.summary(LOCAL_TENANT),
@@ -182,7 +181,6 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
   ResumeApproved: [
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     jobsKeys.lists(LOCAL_TENANT),
-    artifactsKeys.lists(LOCAL_TENANT),
     dashboardKeys.summary(LOCAL_TENANT),
   ],
   ResumeFailed: [

--- a/apps/web/src/contexts/operations/invalidation-router.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.ts
@@ -134,6 +134,12 @@ export type InvalidationItem =
       readonly updater: (current: unknown) => unknown;
     }
   | {
+      readonly kind: "reconcile-query";
+      readonly queryKey: QueryKey;
+      readonly invalidateAfterPatch: boolean;
+      readonly updater: (current: unknown, queryKey: QueryKey) => unknown;
+    }
+  | {
       readonly kind: "apply-run-event-append";
       readonly tenantId: TenantId;
       readonly runId: string;
@@ -158,6 +164,19 @@ export const patchQuery = (
   queryKey,
   exact,
   updater,
+});
+
+// Returning undefined means the event cannot truthfully reconcile this query.
+// Only existing queries are inspected; fallback invalidation is exact per page.
+export const reconcileQuery = (
+  queryKey: QueryKey,
+  updater: (current: unknown, queryKey: QueryKey) => unknown,
+  options: { readonly invalidateAfterPatch?: boolean } = {},
+): InvalidationItem => ({
+  kind: "reconcile-query",
+  queryKey,
+  updater,
+  invalidateAfterPatch: options.invalidateAfterPatch ?? false,
 });
 
 export const patchApplyRunEvent = (
@@ -310,6 +329,25 @@ export const invalidationRouter: InvalidationRouter = {
           { queryKey: item.queryKey, exact: item.exact },
           item.updater,
         );
+        continue;
+      }
+      if (item.kind === "reconcile-query") {
+        for (const query of queryClient.getQueryCache().findAll({ queryKey: item.queryKey })) {
+          const current = query.state.data;
+          // Reconcile explicit invalidation and responses in flight on the server.
+          const next = query.state.isInvalidated || query.state.fetchStatus === "fetching"
+            ? undefined
+            : item.updater(current, query.queryKey);
+          if (next !== undefined && next !== current) {
+            // A partial event patch does not refresh unrelated fields.
+            queryClient.setQueryData(query.queryKey, next, {
+              updatedAt: query.state.dataUpdatedAt,
+            });
+          }
+          if (next === undefined || item.invalidateAfterPatch) {
+            void queryClient.invalidateQueries({ queryKey: query.queryKey, exact: true });
+          }
+        }
         continue;
       }
       // High-frequency `ApplyRunEventRecorded` events patch the apply-run

--- a/apps/web/src/contexts/operations/realtimeListPatches.test.ts
+++ b/apps/web/src/contexts/operations/realtimeListPatches.test.ts
@@ -1,0 +1,334 @@
+import {
+  LOCAL_TENANT,
+  createJobActiveStateChanged,
+  createJobUpdated,
+  createResumeApproved,
+  createPdfRendered,
+  type TenantId,
+} from "@jobctrl/domain-types";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import {
+  makeJobsPage,
+  makeArtifactsPage,
+  sampleJob,
+  sampleSecondaryJob,
+  sampleDraftResumeArtifact,
+  sampleDashboardSummary,
+} from "../../test/fixtures/projections.js";
+import { jobsKeys } from "./jobsKeys.js";
+import { artifactsKeys } from "./artifactsKeys.js";
+import { dashboardKeys } from "./dashboardKeys.js";
+import { invalidationRouter } from "./invalidation-router.js";
+import type { ArtifactsListInput, JobsListInput } from "./types.js";
+
+const OTHER = "other" as TenantId;
+const approval = createResumeApproved(LOCAL_TENANT, {
+  jobId: sampleDraftResumeArtifact.jobKey,
+  artifactId: sampleDraftResumeArtifact.artifactId,
+  generation: 2,
+  approvedAt: "2026-09-12T10:00:00Z",
+});
+const availability = (
+  activeState: "closed" | "active" | "expired",
+  previousState: "active" | "closed" = "active",
+) =>
+  createJobActiveStateChanged(LOCAL_TENANT, {
+    jobId: sampleJob.jobKey,
+    activeState,
+    previousState,
+    verificationMethod: "snapshot",
+    verifiedAt: "2026-09-12T10:00:00Z",
+  });
+
+// Exercise the router against real QueryClient cache entries, including pages
+// not containing the changed row and other tenants with identical identifiers.
+describe("event-specific list reconciliation", () => {
+  it("patches eligible job pages without changing filters, pagination, row order or unrelated references", () => {
+    const client = new QueryClient();
+    const input: JobsListInput = {
+      page: 3,
+      pageSize: 20,
+      sort: "fit_score",
+      dir: "asc",
+      source: "lever",
+      normalizedScoreKeyword: "platform",
+      stages: ["score", "tailor"],
+    };
+    const key = jobsKeys.list(LOCAL_TENANT, input);
+    const page = makeJobsPage([sampleSecondaryJob, sampleJob]);
+    page.pagination = { page: 3, pageSize: 20, total: 70, pages: 4 };
+    const otherKey = jobsKeys.list(OTHER, input);
+    client.setQueryData(key, page);
+    client.setQueryData(otherKey, page);
+    invalidationRouter.handle(
+      createJobUpdated(LOCAL_TENANT, {
+        jobId: sampleJob.jobKey,
+        changedFields: { title: "New title", company: "  New employer  " },
+      }),
+      client,
+    );
+    const next = client.getQueryData<typeof page>(key)!;
+    expect(next.items.map((row) => row.jobKey)).toEqual(
+      page.items.map((row) => row.jobKey),
+    );
+    expect(next.items[1]).toMatchObject({
+      title: "New title",
+      company: "New employer",
+    });
+    expect(next.items[0]).toBe(page.items[0]);
+    expect(next.pagination).toBe(page.pagination);
+    expect(next.sort).toBe(page.sort);
+    expect(next.filter).toBe(page.filter);
+    expect(client.getQueryState(key)?.isInvalidated).toBe(false);
+    expect(client.getQueryData(otherKey)).toBe(page);
+    expect(client.getQueryState(otherKey)?.isInvalidated).toBe(false);
+    client.clear();
+  });
+
+  it.each<JobsListInput>([
+    { q: "new" },
+    { sort: "title" },
+    { sort: "company" },
+    { company: "new" },
+  ])(
+    "invalidates a display edit when membership/order is unknown: %j",
+    (input) => {
+      const client = new QueryClient();
+      const key = jobsKeys.list(LOCAL_TENANT, input);
+      const page = makeJobsPage([sampleSecondaryJob]);
+      client.setQueryData(key, page);
+      invalidationRouter.handle(
+        createJobUpdated(LOCAL_TENANT, {
+          jobId: sampleJob.jobKey,
+          changedFields: { title: "New title", company: "New employer" },
+        }),
+        client,
+      );
+      expect(client.getQueryData(key)).toBe(page);
+      expect(client.getQueryState(key)?.isInvalidated).toBe(true);
+      client.clear();
+    },
+  );
+
+  it("retains fallback for unknown fields and malformed values, without partially applying known fields", () => {
+    for (const changedFields of [
+      { title: "New", location: "Berlin" },
+      { title: 3 },
+      {},
+    ]) {
+      const client = new QueryClient();
+      const key = jobsKeys.list(LOCAL_TENANT, {});
+      const page = makeJobsPage();
+      client.setQueryData(key, page);
+      invalidationRouter.handle(
+        createJobUpdated(LOCAL_TENANT, {
+          jobId: sampleJob.jobKey,
+          changedFields,
+        }),
+        client,
+      );
+      expect(client.getQueryData(key)).toBe(page);
+      expect(client.getQueryState(key)?.isInvalidated).toBe(true);
+      client.clear();
+    }
+  });
+
+  it("patches all/deleted/hidden queues but invalidates active and closed queue boundaries", () => {
+    const client = new QueryClient();
+    const inputs: JobsListInput[] = [
+      {},
+      { deleted: "closed" },
+      { deleted: "all", q: "engineer" },
+      { deleted: "hidden" },
+      { deleted: "deleted", page: 3 },
+    ];
+    const page = makeJobsPage();
+    for (const input of inputs)
+      client.setQueryData(jobsKeys.list(LOCAL_TENANT, input), page);
+    invalidationRouter.handle(availability("closed"), client);
+    for (const [index, input] of inputs.entries()) {
+      const key = jobsKeys.list(LOCAL_TENANT, input);
+      expect(client.getQueryState(key)?.isInvalidated).toBe(index < 2);
+      expect(client.getQueryData<typeof page>(key)?.items[0]?.activeState).toBe(
+        index < 2 ? sampleJob.activeState : "closed",
+      );
+    }
+    client.clear();
+  });
+
+  it("keeps same-class transitions in their active/closed pages and handles duplicate events", () => {
+    const client = new QueryClient();
+    const key = jobsKeys.list(LOCAL_TENANT, { deleted: "closed" });
+    client.setQueryData(
+      key,
+      makeJobsPage([{ ...sampleJob, activeState: "closed" }]),
+    );
+    invalidationRouter.handle(availability("expired", "closed"), client);
+    invalidationRouter.handle(availability("expired", "closed"), client);
+    expect(
+      client.getQueryData<ReturnType<typeof makeJobsPage>>(key)?.items[0]
+        ?.activeState,
+    ).toBe("expired");
+    expect(client.getQueryState(key)?.isInvalidated).toBe(false);
+    client.clear();
+  });
+
+  it("patches an existing artifact but reconciles registration and suppression side effects", () => {
+    const client = new QueryClient();
+    const input: ArtifactsListInput = {
+      page: 2,
+      type: "resume",
+      sort: "created_at",
+      dir: "asc",
+    };
+    const key = artifactsKeys.list(LOCAL_TENANT, input);
+    const otherKey = artifactsKeys.list(OTHER, input);
+    const page = makeArtifactsPage([sampleDraftResumeArtifact]);
+    client.setQueryData(key, page);
+    client.setQueryData(otherKey, page);
+    invalidationRouter.handle(approval, client);
+    const next = client.getQueryData<typeof page>(key)!;
+    expect(next.items[0]?.status).toBe("approved");
+    expect(next.pagination).toBe(page.pagination);
+    expect(next.sort).toBe(page.sort);
+    expect(client.getQueryState(key)?.isInvalidated).toBe(true);
+    expect(client.getQueryData(otherKey)).toBe(page);
+    client.clear();
+  });
+
+  it("invalidates each approval-sensitive page once without a second family-wide refetch", () => {
+    const client = new QueryClient();
+    const key = artifactsKeys.list(LOCAL_TENANT, { status: "candidate" });
+    client.setQueryData(key, makeArtifactsPage([sampleDraftResumeArtifact]));
+    const invalidations = vi.spyOn(client, "invalidateQueries");
+    invalidationRouter.handle(approval, client);
+    const artifactInvalidations = invalidations.mock.calls.filter(([filters]) => filters?.queryKey?.[2] === "artifacts");
+    expect(artifactInvalidations).toHaveLength(1);
+    expect(artifactInvalidations[0]?.[0]).toEqual({ queryKey: key, exact: true });
+    client.clear();
+  });
+
+  it.each<ArtifactsListInput>([
+    { status: "candidate" },
+    { status: "approved" },
+    { q: "approved" },
+    { sort: "status" },
+  ])("invalidates approval-sensitive artifact pages: %j", (input) => {
+    const client = new QueryClient();
+    const key = artifactsKeys.list(LOCAL_TENANT, input);
+    const page = makeArtifactsPage([sampleDraftResumeArtifact]);
+    client.setQueryData(key, page);
+    invalidationRouter.handle(approval, client);
+    expect(client.getQueryData(key)).toBe(page);
+    expect(client.getQueryState(key)?.isInvalidated).toBe(true);
+    client.clear();
+  });
+
+  it("does not invent missing artifacts or unsuppress rows without reconciling totals", () => {
+    for (const rows of [
+      [],
+      [{ ...sampleDraftResumeArtifact, status: "suppressed" }],
+    ]) {
+      const client = new QueryClient();
+      const key = artifactsKeys.list(LOCAL_TENANT, { page: 3 });
+      const page = makeArtifactsPage(rows);
+      client.setQueryData(key, page);
+      invalidationRouter.handle(approval, client);
+      expect(client.getQueryData(key)).toBe(page);
+      expect(client.getQueryState(key)?.isInvalidated).toBe(true);
+      client.clear();
+    }
+  });
+
+  it("preserves page age so partial patches cannot suppress a stale remount fetch", async () => {
+    const client = new QueryClient();
+    const key = jobsKeys.list(LOCAL_TENANT, {});
+    const page = makeJobsPage();
+    const updatedAt = Date.now() - 60_000;
+    client.setQueryData(key, page, { updatedAt });
+    invalidationRouter.handle(
+      createJobUpdated(LOCAL_TENANT, {
+        jobId: sampleJob.jobKey,
+        changedFields: { title: "Changed" },
+      }),
+      client,
+    );
+    expect(client.getQueryState(key)?.dataUpdatedAt).toBe(updatedAt);
+    const canonical = makeJobsPage([
+      { ...sampleJob, title: "Changed", fitScore: 10 },
+    ]);
+    const queryFn = vi.fn(async () => canonical);
+    const observer = new QueryObserver(client, {
+      queryKey: key,
+      queryFn,
+      staleTime: 30_000,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    await vi.waitFor(() => expect(queryFn).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(client.getQueryData(key)).toEqual(canonical));
+    unsubscribe();
+    client.clear();
+  });
+
+  it("preserves invalidation from an earlier event instead of declaring a partial patch fresh", async () => {
+    const client = new QueryClient();
+    const key = jobsKeys.list(LOCAL_TENANT, { deleted: "all" });
+    const page = makeJobsPage();
+    client.setQueryData(key, page);
+    await client.invalidateQueries({ queryKey: key });
+    invalidationRouter.handle(availability("closed"), client);
+    expect(client.getQueryData(key)).toBe(page);
+    expect(client.getQueryState(key)?.isInvalidated).toBe(true);
+    client.clear();
+  });
+
+  it("keeps PDF rendering bounded invalidation because no path, size or complete artifact is carried", () => {
+    const client = new QueryClient();
+    const key = artifactsKeys.list(LOCAL_TENANT, {});
+    client.setQueryData(key, makeArtifactsPage());
+    client.setQueryData(artifactsKeys.list(OTHER, {}), makeArtifactsPage());
+    invalidationRouter.handle(
+      createPdfRendered(LOCAL_TENANT, {
+        jobId: sampleJob.jobKey,
+        artifactId: "new",
+        artifactType: "resume",
+        renderedAt: "2026-09-12T10:00:00Z",
+      }),
+      client,
+    );
+    expect(client.getQueryState(key)?.isInvalidated).toBe(true);
+    expect(
+      client.getQueryState(artifactsKeys.list(OTHER, {}))?.isInvalidated,
+    ).toBe(false);
+    client.clear();
+  });
+
+  it("patches existing dashboard job labels while retaining canonical activity/aggregate refresh", () => {
+    const client = new QueryClient();
+    const key = dashboardKeys.summary(LOCAL_TENANT);
+    const summary = {
+      ...sampleDashboardSummary,
+      activity: [
+        { ...sampleDashboardSummary.activity[0]!, jobKey: sampleJob.jobKey },
+      ],
+    };
+    client.setQueryData(key, summary);
+    client.setQueryData(dashboardKeys.summary(OTHER), summary);
+    invalidationRouter.handle(
+      createJobUpdated(LOCAL_TENANT, {
+        jobId: sampleJob.jobKey,
+        changedFields: { title: "Changed" },
+      }),
+      client,
+    );
+    const next = client.getQueryData<typeof summary>(key)!;
+    expect(next.activity[0]?.title).toBe("Changed");
+    expect(next.totals).toBe(summary.totals);
+    expect(next.applyRuns).toBe(summary.applyRuns);
+    expect(next.activity).toHaveLength(summary.activity.length);
+    expect(client.getQueryState(key)?.isInvalidated).toBe(true);
+    expect(client.getQueryData(dashboardKeys.summary(OTHER))).toBe(summary);
+    client.clear();
+  });
+});

--- a/apps/web/src/contexts/operations/realtimePatches.test.ts
+++ b/apps/web/src/contexts/operations/realtimePatches.test.ts
@@ -144,7 +144,7 @@ describe("realtime cache patches", () => {
     expect(
       queryClient.getQueryData<ReturnType<typeof makeJobsPage>>(jobsListKey)?.items[0]
         ?.activeState,
-    ).toBe("active");
+    ).toBe("closed");
     expect(
       queryClient.getQueryData<ReturnType<typeof makeJobDetail>>(
         jobsKeys.detail(LOCAL_TENANT, sampleJob.jobKey),

--- a/apps/web/src/contexts/operations/realtimePatches.ts
+++ b/apps/web/src/contexts/operations/realtimePatches.ts
@@ -1,4 +1,7 @@
 import type {
+  JobActiveStateChanged,
+  JobUpdated,
+  ResumeApproved,
   WorkflowCanceled,
   WorkflowCompleted,
   WorkflowFailed,
@@ -8,6 +11,10 @@ import type {
 } from "@jobctrl/domain-types";
 
 import type {
+  ArtifactsListInput,
+  DashboardSummary,
+  JobsListInput,
+  PaginatedResponse,
   ArtifactDetail,
   ArtifactSummary,
   JobDetail,
@@ -196,5 +203,94 @@ export function patchWorkflowRunDetail(
     errorCode: event.payload.errorCode || null,
     errorMessage: event.payload.errorMessage || null,
     retryable: event.eventType === "WorkflowFailed" ? event.payload.retryable : false,
+  };
+}
+
+function isPage<T>(current: unknown): current is PaginatedResponse<T> {
+  return isRecord(current) && Array.isArray(current.items)
+    && isRecord(current.pagination) && isRecord(current.sort) && isRecord(current.filter);
+}
+
+const CLOSED_STATES = new Set(["closed", "expired", "removed", "location_incompatible"]);
+const ACTIVE_STATES = new Set(["unknown", "active", ...CLOSED_STATES]);
+
+export function reconcileJobActiveStatePage(
+  current: unknown,
+  input: JobsListInput,
+  payload: JobActiveStateChanged["payload"],
+): unknown {
+  if (!isPage<JobSummary>(current) || !ACTIVE_STATES.has(payload.activeState)
+    || !ACTIVE_STATES.has(payload.previousState)) return undefined;
+  const queue = input.deleted ?? "active";
+  if ((queue === "active" || queue === "closed")
+    && CLOSED_STATES.has(payload.previousState) !== CLOSED_STATES.has(payload.activeState)) {
+    return undefined;
+  }
+  return patchPageRows(current, (job) => job.jobKey === payload.jobId
+    ? { ...job, activeState: payload.activeState } : job);
+}
+
+// Match the canonical jobs -> job_list_projections -> summary mapping.
+// Other changed fields can affect derived labels, ranking or eligibility.
+function jobDisplayPatch(payload: JobUpdated["payload"]): Partial<JobSummary> | undefined {
+  if (!isRecord(payload.changedFields) || Object.keys(payload.changedFields).length === 0) return undefined;
+  const patch: Partial<JobSummary> = {};
+  for (const [field, value] of Object.entries(payload.changedFields)) {
+    if (typeof value !== "string") return undefined;
+    if (field === "title") patch.title = value || "Untitled";
+    else if (field === "company") patch.company = value.trim() || "Unknown company";
+    else return undefined;
+  }
+  return patch;
+}
+
+function patchPageRows<T>(page: PaginatedResponse<T>, patch: (row: T) => T): PaginatedResponse<T> {
+  let changed = false;
+  const items = page.items.map((row) => {
+    const next = patch(row);
+    changed ||= next !== row;
+    return next;
+  });
+  return changed ? { ...page, items } : page;
+}
+
+export function reconcileJobUpdatedPage(
+  current: unknown,
+  input: JobsListInput,
+  payload: JobUpdated["payload"],
+): unknown {
+  const patch = jobDisplayPatch(payload);
+  if (!isPage<JobSummary>(current) || !patch || input.q
+    || (patch.title !== undefined && input.sort === "title")
+    || (patch.company !== undefined && (input.sort === "company" || input.company))) return undefined;
+  return patchPageRows(current, (job) => job.jobKey === payload.jobId ? { ...job, ...patch } : job);
+}
+
+export function reconcileResumeApprovedPage(
+  current: unknown,
+  input: ArtifactsListInput,
+  payload: ResumeApproved["payload"],
+): unknown {
+  if (!isPage<ArtifactSummary>(current) || input.q || input.status || input.sort === "status") return undefined;
+  const artifact = current.items.find((row) => row.artifactId === payload.artifactId
+    && row.jobKey === payload.jobId);
+  // Approval can register a newly generated artifact or unsuppress one. Neither
+  // page membership, total nor boundary can be reconstructed from this event.
+  if (!artifact || !["candidate", "approved"].includes(artifact.status)) return undefined;
+  return patchPageRows(current, (row) => row === artifact ? approveArtifact(row, payload.artifactId) : row);
+}
+
+export function patchDashboardJobLabels(current: unknown, payload: JobUpdated["payload"]): unknown {
+  const patch = jobDisplayPatch(payload);
+  if (!patch || !isRecord(current) || !isRecord(current.work)
+    || !Array.isArray(current.work.stuckItems) || !Array.isArray(current.activity)
+  ) return current;
+  const summary = current as unknown as DashboardSummary;
+  const patchRow = <T extends { jobKey: string | null }>(row: T): T =>
+    row.jobKey === payload.jobId ? { ...row, ...patch } : row;
+  return {
+    ...summary,
+    work: { ...summary.work, stuckItems: summary.work.stuckItems.map(patchRow) },
+    activity: summary.activity.map(patchRow),
   };
 }

--- a/docs/architecture/frontend/realtime.md
+++ b/docs/architecture/frontend/realtime.md
@@ -204,21 +204,15 @@ patch instructions. The router lives in
 registered aggregate-owned handler:
 
 ```ts
-export const jobActiveStateChangedHandler = (event) => [
-  patchQuery(jobsKeys.detail(event.tenantId, event.payload.jobId),
-    (current) => patchJobActiveState(current, event.payload)),
-  invalidate(jobsKeys.lists(event.tenantId)),
-  invalidate(dashboardKeys.summary(event.tenantId)),
+export const jobUpdatedHandler = (event) => [
+  reconcileQuery(jobsKeys.lists(event.tenantId), (current, key) =>
+    reconcileJobUpdatedPage(current, key[4], event.payload)),
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
 ];
 
-export const resumeApprovedHandler = (event) => [
-  patchQuery(jobsKeys.detail(event.tenantId, event.payload.jobId),
-    (current) => patchResumeApproved(current, event.payload)),
-  patchQuery(artifactsKeys.detail(event.tenantId, event.payload.artifactId),
-    (current) => patchResumeApproved(current, event.payload)),
-  invalidate(jobsKeys.lists(event.tenantId)),
-  invalidate(artifactsKeys.lists(event.tenantId)),
-];
+// reconcileQuery inspects existing tenant-scoped pages. Its updater returns
+// undefined when membership/order cannot be determined, causing exact-page
+// invalidation. Eligible pages update without refetching or replacing metadata.
 
 // Workflow lifecycle handlers patch the existing detail, then invalidate the
 // list/dashboard reads whose membership or aggregation may have changed.
@@ -228,7 +222,7 @@ export const resumeApprovedHandler = (event) => [
 In practice the per-event handler functions are authored in each aggregate
 context's `handlers.ts` (seven files: `discovery`, `enrichment`, `profile`,
 `scoring`, `materials`, `apply`, `pipeline`) and registered centrally in
-`invalidation-router.ts`, which exports `invalidate`, `patchQuery`,
+`invalidation-router.ts`, which exports `invalidate`, `patchQuery`, `reconcileQuery`,
 `patchApplyRunEvent`, and `useInvalidationRouter`. The illustration above
 inlines representative handlers for
 clarity; Operations itself has no `handlers.ts`.
@@ -287,11 +281,25 @@ Two patterns exist; both have a place:
 
 **Exact patch rules:**
 
-- `JobActiveStateChanged` patches an open job detail immediately; job lists and
-  Dashboard invalidate because active-state filters and aggregates can change.
-- `ResumeApproved` changes status only on an artifact already present in an
-  open job/artifact detail. It never creates a missing artifact; list pages
-  invalidate so persisted registration and filtering remain authoritative.
+- `JobUpdated` patches existing job-list title/company labels only when the
+  query's search, company filter and sort do not depend on those changed fields.
+  Unknown fields or malformed values retain exact-page invalidation. Dashboard
+  activity and stuck-work labels update immediately; its bundled activity,
+  aggregates and runtime data still require a bounded summary refresh. Apply-run
+  labels remain owned by their separately refreshed server projection.
+- `JobActiveStateChanged` patches job pages when the active/closed queue boundary
+  does not change, or when the query is for all, deleted or hidden jobs. A change
+  between active and closed classes invalidates active/closed pages, including
+  pages without the job, because page boundaries and totals can move.
+- `ResumeApproved` changes status on an artifact already present in a detail or
+  an eligible unfiltered, non-status-sorted artifact page. Artifact pages still
+  invalidate: approval can also register a PDF and suppress an older generation.
+  Status/search-filtered pages, missing artifacts and suppressed rows wait for
+  the canonical response. `PdfRendered` lacks the path/size/status needed to
+  patch a complete artifact, so bounded invalidation remains necessary.
+- List reconciliation never creates missing query entries, invents rows, alters
+  pagination totals or reorders a partial page. Already-invalidated or fetching
+  queries retain exact invalidation instead of making a partial update fresh.
 - `Workflow*` lifecycle events patch the matching run detail by exact workflow
   identity and append a deduplicated timeline entry. Run lists, Dashboard, and
   operations invalidate because status membership and aggregation can change.


### PR DESCRIPTION
## Summary

- Patch eligible job-list title/company and availability updates in place, preserving tenant scope, ordering, filters, pagination and cache age. Reconcile each affected page when the event cannot determine membership or ordering.
- Update known artifact approval status and dashboard job labels immediately while retaining canonical refreshes for PDF registration, older-artifact suppression, activity and aggregate data.
- Add event-specific cache coverage and a real SSE browser regression that preserves second-page selection and scroll, avoids eligible list refetches, and exercises fallback reconciliation.

Closes #890.

## Validation

- Web type check; 2,098 full web tests, followed by 333 focused tests covering the final freshness and single-invalidation repairs; 13 public type tests.
- Production web build and documentation build. All applicable remote checks passed; final remote E2E reported 95 passed, 1 passed on retry, and 10 skipped (the retry was an existing profile layout assertion).
- Full Chromium and mobile browser suite: 96 passed, 10 skipped. Independent review and browser QA passed, including the realtime regression followed by the affected downstream scenarios.
- Browser fixtures restore their owned rows and canonical projections; the Outreach fixture removes its synthetic application confirmation after use. Initial fixture/type-check and browser integration failures were repaired and rerun. No application submissions or real user data were used.

## Checklist

- [x] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`).
- [x] I ran the relevant local checks and listed them above. CI follows workflow events/path filters on individual PRs; external fork runs require maintainer approval.
- [x] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.
