### PR TITLE
refactor(storage): remove legacy application URL authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,15 +624,15 @@ This writes `~/.jobctrl/backups/jobctrl-<timestamp>.db` via SQLite
 `VACUUM INTO` and never deletes anything (`--output <path>` to choose a
 target).
 
-The native exact-v9 update performs its own paired migration safeguard. It
-stops JobCtrl and backs up both `jobctrl.db` and bundled Temporal state. An
-admitted v6 installation is quiesced and transformed through a private exact-v7
-and then exact-v8 intermediate before v9 is sealed; an exact-v7 installation
-starts at the private v8 step, while an exact-v8 installation receives only
-the additive optional position-summary column. Intermediates are never
-installed. Any failed build, verification, activation, or readiness check
-restores the previous pair. The API and worker run exact v9 only; there is no
-mixed-version, dual-write, or permanent fallback runtime.
+The native exact-v10 update performs its own paired migration safeguard. It
+stops JobCtrl and backs up both `jobctrl.db` and bundled Temporal state. Admitted
+v6/v7/v8 sources pass through private intermediate schemas; exact v9 transfers
+application URLs directly into canonical enrichment and lookup aliases before
+removing the legacy job column. Existing canonical targets win, and legacy-only
+values remain usable. Intermediates are never installed. Any failed build,
+verification, activation, or readiness check restores the previous pair. The
+API and worker run exact v10 only; there is no mixed-version or dual-write runtime.
+See the [storage contract](docs/architecture/storage.md) for preservation rules.
 
 <details>
 <summary><b>Restore steps</b></summary>

--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -926,9 +926,10 @@ function applyTargetUrl(row: ReviewQueueRow): string | null {
 function currentApplicationUrl(db: SqliteDatabase, jobId: JobId): string | null {
   const row = getRow<{ application_url: string | null; url: string }>(
     db,
-    `SELECT application_url, url
-       FROM jobs
-      WHERE tenant_id = ? AND job_id = ?`,
+    `SELECT e.application_url, j.url
+       FROM jobs j LEFT JOIN job_enrichments e
+         ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id
+      WHERE j.tenant_id = ? AND j.job_id = ?`,
     [DEFAULT_TENANT, jobId],
   );
   return cleanBlockerText(row?.application_url ?? null) || cleanBlockerText(row?.url ?? null) || null;

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import Database from "better-sqlite3";
 
-import { EXACT_V9_SCHEMA_MANIFEST, hasExactV9SchemaManifest } from "./schema-manifest.js";
+import { EXACT_V10_SCHEMA_MANIFEST, hasExactV10SchemaManifest } from "./schema-manifest.js";
 
 export type SqliteDatabase = Database.Database;
 export type SqliteValue = string | number | bigint | null;
@@ -11,7 +11,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only admits the exact
 // migrated schema shape. Bump both constants together whenever the schema
 // shape changes.
-export const SUPPORTED_SCHEMA_VERSION = EXACT_V9_SCHEMA_MANIFEST.version;
+export const SUPPORTED_SCHEMA_VERSION = EXACT_V10_SCHEMA_MANIFEST.version;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {
@@ -28,7 +28,7 @@ export class IncompatibleSchemaVersionError extends Error {
 export class IncompatibleSchemaManifestError extends Error {
   constructor() {
     super(
-      "JobCtrl database schema does not match the exact v9 manifest; restore "
+      "JobCtrl database schema does not match the exact v10 manifest; restore "
         + "a compatible backup or complete the documented stopped-runtime migration.",
     );
     this.name = "IncompatibleSchemaManifestError";
@@ -38,13 +38,13 @@ export class IncompatibleSchemaManifestError extends Error {
 function assertExactSchemaVersion(db: SqliteDatabase): void {
   // The API never writes ``user_version`` — the Python worker owns stamping so
   // the schema marker has a single writer. Stopped-runtime migration is the
-  // only upgrade path; runtime admission accepts only the completed v9 shape.
+  // only upgrade path; runtime admission accepts only the completed v10 shape.
   const current = db.pragma("user_version", { simple: true }) as number;
   if (current !== SUPPORTED_SCHEMA_VERSION) {
     db.close();
     throw new IncompatibleSchemaVersionError(current);
   }
-  if (!hasExactV9SchemaManifest(db)) {
+  if (!hasExactV10SchemaManifest(db)) {
     db.close();
     throw new IncompatibleSchemaManifestError();
   }

--- a/apps/api/src/job-locators.ts
+++ b/apps/api/src/job-locators.ts
@@ -1,0 +1,30 @@
+import type { SqliteDatabase } from "./db.js";
+
+export type LocatedJob = { jobId: string; jobUrl: string };
+
+/** Posting identity wins; a shared application endpoint cannot select a job. */
+export function resolveJobLocator(db: SqliteDatabase, tenantId: string, locator: string): LocatedJob | null {
+  const posting = db.prepare(`
+    SELECT job_id, url FROM jobs j
+    WHERE tenant_id = ? AND (job_id = ? OR url = ? OR EXISTS (
+      SELECT 1 FROM job_locators l WHERE l.tenant_id = j.tenant_id
+        AND l.job_id = j.job_id AND l.locator_value = ?
+    )) LIMIT 2
+  `).all(tenantId, locator, locator, locator) as Array<{ job_id: string; url: string }>;
+  if (posting.length > 0) return uniqueJob(posting);
+  const application = db.prepare(`
+    SELECT job_id, url FROM jobs j
+    WHERE tenant_id = ? AND (EXISTS (
+      SELECT 1 FROM job_enrichments e WHERE e.tenant_id = j.tenant_id
+        AND e.job_id = j.job_id AND e.application_url = ?
+    ) OR EXISTS (
+      SELECT 1 FROM job_application_locators l WHERE l.tenant_id = j.tenant_id
+        AND l.job_id = j.job_id AND l.application_url = ?
+    )) LIMIT 2
+  `).all(tenantId, locator, locator) as Array<{ job_id: string; url: string }>;
+  return uniqueJob(application);
+}
+
+function uniqueJob(rows: Array<{ job_id: string; url: string }>): LocatedJob | null {
+  return rows.length === 1 ? { jobId: rows[0]!.job_id, jobUrl: rows[0]!.url } : null;
+}

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -781,6 +781,11 @@ function runRefreshPassInTransaction(db: SqliteDatabase, tenantId: string): bool
       if (job.job_id) dirtyJobs.add(job.job_id);
     }
   }
+  // Migration preserves projection rows and cursors; reconcile canonical target
+  // changes even when no new domain event follows the stopped-runtime cutover.
+  for (const jobId of staleApplicationUrlProjectionJobs(db, tenantId)) {
+    dirtyJobs.add(jobId);
+  }
   for (const jobId of staleDeletedProjectionJobs(db, tenantId)) {
     dirtyJobs.add(jobId);
   }
@@ -2279,7 +2284,7 @@ function loadEnrichment(db: SqliteDatabase, tenantId: string, jobId: string): En
   if (!row) return empty;
   return {
     fullDescription: row.full_description,
-    applicationUrl: row.application_url,
+    applicationUrl: row.application_url || null,
     enrichedAt: row.enriched_at,
     currentStatus: row.current_status,
   };
@@ -2338,6 +2343,15 @@ function loadDeletedAt(db: SqliteDatabase, tenantId: string, jobId: string): str
     [tenantId, jobId],
   );
   return row ? nullableString(row.deleted_at) : null;
+}
+
+function staleApplicationUrlProjectionJobs(db: SqliteDatabase, tenantId: string): string[] {
+  return allRows<{ job_id: string }>(db, `
+    SELECT p.job_id FROM job_list_projections p
+    JOIN jobs j ON j.tenant_id = p.tenant_id AND j.job_id = p.job_id
+    LEFT JOIN job_enrichments e ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id
+    WHERE p.tenant_id = ? AND p.application_url IS NOT NULLIF(e.application_url, '')
+  `, [tenantId]).map((row) => row.job_id);
 }
 
 function staleDeletedProjectionJobs(db: SqliteDatabase, tenantId: string): string[] {
@@ -2703,7 +2717,7 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobId: stri
 
   const title = stringField(job.title) || "Untitled";
   const site = stringField(job.site);
-  const applicationUrl = enrichment.applicationUrl ?? nullableString(job.application_url);
+  const applicationUrl = enrichment.applicationUrl;
   const employer = stringField(job.company).trim() || "Unknown company";
 
   const firstActionable =

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -1,3 +1,4 @@
+import { resolveJobLocator } from "./job-locators.js";
 /**
  * TS read-model — projection-backed (Phase 9 / S-33).
  *
@@ -2394,32 +2395,12 @@ function findJobListRow(db: SqliteDatabase, jobKey: string): JobListProjectionRo
     [DEFAULT_TENANT, jobKey],
   );
   if (direct) return direct;
-  // URLs remain locators; canonical job ids remain the relation key.
-  return (
-    getRow<JobListProjectionRow>(
-      db,
-      `SELECT ${jobProjectionSelect()}
-         FROM job_list_projections
-        WHERE job_list_projections.tenant_id = ?
-          AND (
-            job_list_projections.application_url = ?
-            OR EXISTS (
-              SELECT 1 FROM jobs j
-               WHERE j.tenant_id = job_list_projections.tenant_id
-                 AND j.job_id = job_list_projections.job_id
-                 AND (j.url = ? OR j.application_url = ?)
-            )
-            OR EXISTS (
-              SELECT 1 FROM job_locators l
-               WHERE l.tenant_id = job_list_projections.tenant_id
-                 AND l.job_id = job_list_projections.job_id
-                 AND l.locator_value = ?
-            )
-          )
-        LIMIT 1`,
-      [DEFAULT_TENANT, jobKey, jobKey, jobKey, jobKey],
-    ) ?? null
-  );
+  const identity = resolveJobLocator(db, DEFAULT_TENANT, jobKey);
+  return identity ? getRow<JobListProjectionRow>(
+    db,
+    `SELECT ${jobProjectionSelect()} FROM job_list_projections WHERE tenant_id = ? AND job_id = ?`,
+    [DEFAULT_TENANT, identity.jobId],
+  ) ?? null : null;
 }
 
 export function listArtifacts(db: SqliteDatabase, query: ArtifactListQuery): PaginatedResponse<ArtifactSummary> {

--- a/apps/api/src/repeat-application.ts
+++ b/apps/api/src/repeat-application.ts
@@ -312,7 +312,7 @@ function jobIdentity(db: SqliteDatabase, jobId: string): JobIdentityRow | null {
   return getRow<JobIdentityRow>(
     db,
     `SELECT j.job_id, j.url, j.title, ${company} AS company,
-            COALESCE(${enrichment} j.application_url, j.url) AS application_url
+            ${enrichment ? `COALESCE(${enrichment} j.url)` : "j.url"} AS application_url
        FROM jobs j WHERE j.tenant_id = ? AND j.job_id = ?`,
     params,
   ) ?? null;

--- a/apps/api/src/resume-templates.ts
+++ b/apps/api/src/resume-templates.ts
@@ -591,16 +591,23 @@ function sensitiveFactSentinels(db: SqliteDatabase): string[] {
   for (const value of Object.values(profile ?? {})) addSensitiveFact(facts, value);
   const jobs = allRows<Record<string, unknown>>(
     db,
-    `SELECT title, company, application_url
-       FROM jobs
-      WHERE tenant_id = ?
-      ORDER BY discovered_at DESC
+    `SELECT j.title, j.company, e.application_url
+       FROM jobs j LEFT JOIN job_enrichments e
+         ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id
+      WHERE j.tenant_id = ?
+      ORDER BY j.discovered_at DESC
       LIMIT 25`,
     [DEFAULT_TENANT],
   );
   for (const job of jobs) {
     for (const value of Object.values(job)) addSensitiveFact(facts, value);
   }
+  const aliases = allRows<{ application_url: string }>(db,
+    `SELECT application_url FROM job_application_locators
+      WHERE tenant_id = ? AND job_id IN (
+        SELECT job_id FROM jobs WHERE tenant_id = ? ORDER BY discovered_at DESC LIMIT 25
+      )`, [DEFAULT_TENANT, DEFAULT_TENANT]);
+  for (const alias of aliases) addSensitiveFact(facts, alias.application_url);
   return [...facts];
 }
 

--- a/apps/api/src/schema-manifest.ts
+++ b/apps/api/src/schema-manifest.ts
@@ -33,6 +33,13 @@ export const EXACT_V9_SCHEMA_MANIFEST: SchemaManifest = {
   fingerprint: "ee90d737238c162f34d69f5becf01f15897d4bbeb2c4b2c51d41526ec6343621",
 };
 
+export const EXACT_V10_SCHEMA_MANIFEST: SchemaManifest = {
+  version: 10,
+  objectCount: 274,
+  tableCount: 118,
+  fingerprint: "d5c1676fff6e81c987055bf4db6d725c582c74b834f4bf92c9eef3f5980f3641",
+};
+
 type SqliteMasterRow = [type: string, name: string, tableName: string, sql: string];
 
 type SqliteMasterQueryRow = {
@@ -107,6 +114,10 @@ export function hasExactV8SchemaManifest(db: Pick<Database.Database, "prepare">)
 
 export function hasExactV9SchemaManifest(db: Pick<Database.Database, "prepare">): boolean {
   return hasExactSchemaManifest(db, EXACT_V9_SCHEMA_MANIFEST);
+}
+
+export function hasExactV10SchemaManifest(db: Pick<Database.Database, "prepare">): boolean {
+  return hasExactSchemaManifest(db, EXACT_V10_SCHEMA_MANIFEST);
 }
 
 function hasExactSchemaManifest(

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -1,3 +1,4 @@
+import { resolveJobLocator } from "./job-locators.js";
 import crypto from "node:crypto";
 
 import type {
@@ -147,27 +148,7 @@ function resolveJobIdentity(
   tenantId: string,
   jobLocator: string,
 ): ResolvedJobIdentity | null {
-  const row = getRow<{ job_id?: string; url?: string }>(
-    db,
-    `SELECT job_id, url
-       FROM jobs
-      WHERE tenant_id = ?
-        AND (
-          job_id = ?
-          OR url = ?
-          OR application_url = ?
-          OR EXISTS (
-            SELECT 1
-              FROM job_locators
-             WHERE job_locators.tenant_id = jobs.tenant_id
-               AND job_locators.job_id = jobs.job_id
-               AND job_locators.locator_value = ?
-          )
-        )
-      LIMIT 1`,
-    [tenantId, jobLocator, jobLocator, jobLocator, jobLocator],
-  );
-  return row?.job_id && row.url ? { jobId: row.job_id, jobUrl: row.url } : null;
+  return resolveJobLocator(db, tenantId, jobLocator);
 }
 
 export function resetJobStage(
@@ -875,6 +856,16 @@ function purgeJobRows(db: SqliteDatabase, tenantId: string, jobId: string): void
     [tenantId, jobId, jobId],
   );
   for (const locatorValue of locatorValues) {
+    // An application form can belong to several jobs. Retain another job's
+    // duplicate-rejection evidence when a shared locator survives this purge.
+    if (getRow(db, `SELECT 1 FROM jobs j WHERE j.tenant_id = ? AND j.job_id != ? AND (
+      j.url = ? OR EXISTS (SELECT 1 FROM job_enrichments e WHERE e.tenant_id = j.tenant_id
+        AND e.job_id = j.job_id AND e.application_url = ?)
+      OR EXISTS (SELECT 1 FROM job_application_locators a WHERE a.tenant_id = j.tenant_id
+        AND a.job_id = j.job_id AND a.application_url = ?)
+      OR EXISTS (SELECT 1 FROM job_locators l WHERE l.tenant_id = j.tenant_id
+        AND l.job_id = j.job_id AND l.locator_value = ?)
+    ) LIMIT 1`, [tenantId, jobId, locatorValue, locatorValue, locatorValue, locatorValue])) continue;
     deleteExactV7Rows(
       db,
       "job_rejected_duplicate_links",
@@ -892,11 +883,18 @@ function jobLocatorValues(db: SqliteDatabase, tenantId: string, jobId: string): 
   const values = new Set<string>();
   const job = getRow<{ url: string | null; application_url: string | null }>(
     db,
-    "SELECT url, application_url FROM jobs WHERE tenant_id = ? AND job_id = ?",
+    "SELECT j.url, e.application_url FROM jobs j LEFT JOIN job_enrichments e ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id WHERE j.tenant_id = ? AND j.job_id = ?",
     [tenantId, jobId],
   );
   for (const value of [job?.url, job?.application_url]) {
     if (value?.trim()) values.add(value);
+  }
+  for (const row of allRows<{ application_url: string }>(
+    db,
+    "SELECT application_url FROM job_application_locators WHERE tenant_id = ? AND job_id = ?",
+    [tenantId, jobId],
+  )) {
+    if (row.application_url.trim()) values.add(row.application_url);
   }
   for (const row of allRows<{ locator_value: string }>(
     db,

--- a/apps/api/test/application-feedback-v7.test.ts
+++ b/apps/api/test/application-feedback-v7.test.ts
@@ -1,3 +1,4 @@
+import { seedApplicationUrl } from "./seed-enrichment.js";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -21,7 +22,7 @@ import {
   recordManualApplicationOutcome,
 } from "../src/application-feedback.js";
 import { InputError } from "../src/write-model.js";
-import { hasExactV9SchemaManifest } from "../src/schema-manifest.js";
+import { hasExactV10SchemaManifest } from "../src/schema-manifest.js";
 import { initializeExactV7Database } from "./v7-schema.js";
 
 const JOB_ID = "00000000-0000-4000-8000-000000000071";
@@ -49,9 +50,10 @@ function seededDatabase(): Database.Database {
 
   for (const tenantId of ["local", OTHER_TENANT]) {
     db.prepare(
-      `INSERT INTO jobs (tenant_id, job_id, url, title, company, discovered_at, application_url)
-       VALUES (?, ?, ?, 'Feedback Engineer', 'Example', '2026-07-31T12:00:00Z', ?)`,
-    ).run(tenantId, JOB_ID, `${JOB_URL}/${tenantId}`, JOB_URL);
+      `INSERT INTO jobs (tenant_id, job_id, url, title, company, discovered_at)
+       VALUES (?, ?, ?, 'Feedback Engineer', 'Example', '2026-07-31T12:00:00Z')`,
+    ).run(tenantId, JOB_ID, `${JOB_URL}/${tenantId}`);
+    seedApplicationUrl(db, tenantId, JOB_ID, JOB_URL);
     db.prepare(
       `INSERT INTO job_list_projections (
          tenant_id, job_id, title, employer, source, application_url, fit_score,
@@ -143,11 +145,11 @@ describe("application feedback exact v7 identity", () => {
 
   it("does not mutate the exact-v7 schema and refuses an invalid job id", () => {
     const db = seededDatabase();
-    expect(hasExactV9SchemaManifest(db)).toBe(true);
+    expect(hasExactV10SchemaManifest(db)).toBe(true);
 
     expect(() =>
       recordManualApplicationOutcome(db, "not-a-canonical-job-id", { kind: "interview" }),
     ).toThrow(InputError);
-    expect(hasExactV9SchemaManifest(db)).toBe(true);
+    expect(hasExactV10SchemaManifest(db)).toBe(true);
   });
 });

--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -1,3 +1,4 @@
+import { seedApplicationUrl } from "./seed-enrichment.js";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
@@ -549,7 +550,7 @@ describe("application feedback API", () => {
 
   it("uses the posting URL as the review apply target when direct application URL is missing", async () => {
     const db = new Database(options.dbPath);
-    db.prepare("UPDATE jobs SET application_url = NULL WHERE url = ?").run(READY_JOB);
+    db.prepare("UPDATE job_enrichments SET application_url = NULL WHERE job_id = (SELECT job_id FROM jobs WHERE url = ?)").run(READY_JOB);
     db.close();
     const app = buildApp(options);
 
@@ -1559,6 +1560,8 @@ describe("application feedback API", () => {
 
   it("rejects submit approval when the displayed review binding is stale", async () => {
     const db = new Database(options.dbPath);
+    db.prepare("INSERT INTO job_application_locators VALUES ('local', ?, ?)")
+      .run(READY_JOB_ID, "https://example.com/old-apply");
     db.prepare(
       "INSERT INTO candidate_profiles (tenant_id, profile_id, version, updated_at) VALUES ('local', 'default', ?, ?)",
     ).run(7, NOW);
@@ -1598,9 +1601,10 @@ describe("application feedback API", () => {
     expect(staleProfile.statusCode, staleProfile.body).toBe(409);
     expect(staleProfile.json()).toMatchObject({ ok: false, error: "approval_stale_profile" });
 
+    // A retained locator finds the job but cannot authorize its retired target.
     const staleUrl = await app.inject({
       method: "POST",
-      url: `/v1/jobs/${readyKey}/apply-review/decision`,
+      url: `/v1/jobs/${encodeURIComponent("https://example.com/old-apply")}/apply-review/decision`,
       payload: {
         decision: "approve_submit",
         materialsGeneration: 1,
@@ -2477,10 +2481,10 @@ function insertJob(
 ): void {
   db.prepare(
     `INSERT INTO jobs (
-       tenant_id, job_id, url, title, site, strategy, location, salary, discovered_at, application_url,
+       tenant_id, job_id, url, title, site, strategy, location, salary, discovered_at,
        description, full_description, detail_scraped_at, fit_score, score_reasoning,
        scored_at, tailored_resume_path, tailored_at, apply_status, applied_at
-     ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+     ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     job.jobId,
     job.url,
@@ -2490,7 +2494,6 @@ function insertJob(
     "Remote",
     "",
     NOW,
-    job.url,
     "Short description",
     "Full description",
     NOW,
@@ -2502,6 +2505,7 @@ function insertJob(
     job.appliedAt ? "applied" : null,
     job.appliedAt ?? null,
   );
+  seedApplicationUrl(db, "local", job.jobId, job.url);
   for (const stage of ["discover", "enrich", "score", "tailor", "cover"]) {
     insertStage(db, job.jobId, stage, "succeeded");
   }

--- a/apps/api/test/application-url-authority.test.ts
+++ b/apps/api/test/application-url-authority.test.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import Database from "better-sqlite3";
+import { describe, expect, it } from "vitest";
+import { refreshProjections } from "../src/projections.js";
+import { resolveJobId } from "../src/write-model.js";
+import { EXACT_V10_SCHEMA_MANIFEST, schemaManifest } from "../src/schema-manifest.js";
+
+const fixture = JSON.parse(fs.readFileSync(new URL(
+  "../../../packages/domain-types/test/fixtures/application_url_authority.json", import.meta.url,
+), "utf8")) as { cases: Array<{
+  name: string; jobId: string; legacy: string | null;
+  enrichment: { applicationUrl: string | null; status: string } | null; expected: string | null;
+}> };
+
+function sql(version: number): string {
+  return fs.readFileSync(new URL(
+    `../../../workers/automation/src/jobctrl/infrastructure/migrations/schema_v${version}.sql`, import.meta.url,
+  ), "utf8");
+}
+
+function migratedDatabase(): Database.Database {
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  for (const version of [7, 8, 9]) db.exec(sql(version));
+  for (const tenant of ["local", "other"]) {
+    for (const row of fixture.cases) {
+      db.prepare(`INSERT INTO jobs (tenant_id, job_id, url, application_url, title, discovered_at)
+        VALUES (?, ?, ?, ?, ?, '2026-08-01T00:00:00Z')`).run(
+        tenant, row.jobId, `https://jobs.example.test/${row.name}`, row.legacy, row.name,
+      );
+      if (row.enrichment) db.prepare(`INSERT INTO job_enrichments (
+        tenant_id, job_id, current_status, application_url, updated_at
+      ) VALUES (?, ?, ?, ?, '2026-08-01T00:00:00Z')`).run(
+        tenant, row.jobId, row.enrichment.status, row.enrichment.applicationUrl,
+      );
+    }
+  }
+  // Existing exact-v9 projections may already have consumed every event.
+  db.prepare(`INSERT INTO job_list_projections (tenant_id, job_id, application_url)
+    VALUES ('local', ?, '')`).run(fixture.cases[2]!.jobId);
+  db.exec(sql(10));
+  db.pragma("user_version = 10");
+  return db;
+}
+
+describe("canonical application URL authority", () => {
+  it("matches the Python migration/projection fixture and never projects lookup aliases", () => {
+    const db = migratedDatabase();
+    try {
+      expect(schemaManifest(db, 10)).toEqual(EXACT_V10_SCHEMA_MANIFEST);
+      refreshProjections(db, "local");
+      expect(db.prepare("SELECT COUNT(*) AS n FROM job_list_projections WHERE tenant_id = 'other'").get()).toEqual({ n: 0 });
+      for (const row of fixture.cases) {
+        expect(db.prepare("SELECT application_url FROM job_list_projections WHERE tenant_id = 'local' AND job_id = ?").get(row.jobId))
+          .toEqual({ application_url: row.expected });
+        for (const url of [row.legacy, row.enrichment?.applicationUrl].filter(Boolean)) {
+          expect(resolveJobId(db, "local", url!)).toBe(row.jobId);
+          expect(resolveJobId(db, "other", url!)).toBe(row.jobId);
+        }
+      }
+      const conflict = fixture.cases[1]!;
+      db.prepare("UPDATE job_enrichments SET application_url = NULL WHERE tenant_id = 'local' AND job_id = ?").run(conflict.jobId);
+      refreshProjections(db, "local");
+      expect(db.prepare("SELECT application_url FROM job_list_projections WHERE tenant_id = 'local' AND job_id = ?").get(conflict.jobId))
+        .toEqual({ application_url: null });
+      expect(resolveJobId(db, "local", conflict.legacy!)).toBe(conflict.jobId);
+      const settled = db.prepare("SELECT total_changes() AS changes").get();
+      refreshProjections(db, "local");
+      expect(db.prepare("SELECT total_changes() AS changes").get()).toEqual(settled);
+      expect(db.pragma("foreign_key_check")).toEqual([]);
+    } finally { db.close(); }
+  });
+
+  it("refuses shared application endpoints and gives posting identity priority", () => {
+    const db = migratedDatabase();
+    try {
+      const first = fixture.cases[0]!;
+      const second = fixture.cases[1]!;
+      const shared = "https://apply.example.test/shared";
+      const insert = db.prepare("INSERT INTO job_application_locators VALUES (?, ?, ?)");
+      insert.run("local", first.jobId, shared);
+      insert.run("local", second.jobId, shared);
+      insert.run("other", first.jobId, shared);
+      expect(resolveJobId(db, "local", shared)).toBeNull();
+      expect(resolveJobId(db, "other", shared)).toBe(first.jobId);
+      insert.run("local", second.jobId, `https://jobs.example.test/${first.name}`);
+      expect(resolveJobId(db, "local", `https://jobs.example.test/${first.name}`)).toBe(first.jobId);
+      db.prepare("DELETE FROM jobs WHERE tenant_id = 'local' AND job_id = ?").run(first.jobId);
+      expect(resolveJobId(db, "local", shared)).toBe(second.jobId);
+      expect(resolveJobId(db, "other", shared)).toBe(first.jobId);
+      expect(db.pragma("foreign_key_check")).toEqual([]);
+    } finally { db.close(); }
+  });
+});

--- a/apps/api/test/audit-projection-parity.test.ts
+++ b/apps/api/test/audit-projection-parity.test.ts
@@ -1,3 +1,4 @@
+import { seedApplicationUrl } from "./seed-enrichment.js";
 /**
  * Cross-runtime projection parity for the read-model projections (AUDIT-02).
  *
@@ -192,10 +193,10 @@ function seedRows(dbPath: string): void {
   db.prepare(
     `INSERT INTO jobs (
        tenant_id, job_id, url, title, company, site, strategy, location, salary, description,
-       full_description, application_url, apply_status, applied_at,
+       full_description, apply_status, applied_at,
        score_reasoning, discovered_at
      ) VALUES ('local', @job_id, @url, @title, @company, @site, @strategy, @location, @salary, @description,
-       @full_description, @application_url, @apply_status, @applied_at,
+       @full_description, @apply_status, @applied_at,
        @score_reasoning, @discovered_at)`,
   ).run({
     job_id: jobId,
@@ -208,12 +209,13 @@ function seedRows(dbPath: string): void {
     salary: fixture.job.salary,
     description: fixture.job.description,
     full_description: fixture.job.fullDescription,
-    application_url: fixture.job.applicationUrl,
     apply_status: fixture.job.applyStatus,
     applied_at: fixture.job.appliedAt,
     score_reasoning: fixture.job.scoreReasoning,
     discovered_at: fixture.job.discoveredAt,
   });
+
+  seedApplicationUrl(db, "local", jobId, fixture.job.applicationUrl);
 
   const insertScore = db.prepare(
     `INSERT INTO job_scores (

--- a/apps/api/test/digest.test.ts
+++ b/apps/api/test/digest.test.ts
@@ -1,3 +1,4 @@
+import { seedApplicationUrl } from "./seed-enrichment.js";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -312,9 +313,9 @@ function seedJobs(db: Database.Database, tempDir: string): void {
   const insertJob = db.prepare(
     `INSERT INTO jobs (
        tenant_id, job_id, url, title, company, site, strategy, location, salary, discovered_at,
-       application_url, description, full_description, detail_scraped_at,
+       description, full_description, detail_scraped_at,
        detail_error, fit_score, score_reasoning, scored_at, tailored_resume_path
-     ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+     ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
   const insertScore = db.prepare(
     `INSERT INTO job_scores (
@@ -335,7 +336,6 @@ function seedJobs(db: Database.Database, tempDir: string): void {
       "Remote",
       "",
       job.discoveredAt,
-      job.applicationUrl,
       "Digest fixture description.",
       "Digest fixture full description.",
       job.discoveredAt,
@@ -345,6 +345,7 @@ function seedJobs(db: Database.Database, tempDir: string): void {
       job.scoredAt,
       null,
     );
+    seedApplicationUrl(db, "local", jobId, job.applicationUrl);
     const eligibilityStatus = job.eligibilityStatus ?? "eligible";
     const scoreBreakdown = {
       technical_fit: job.fitScore,

--- a/apps/api/test/exact-v7-projections.test.ts
+++ b/apps/api/test/exact-v7-projections.test.ts
@@ -6,7 +6,7 @@ import Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { refreshProjections } from "../src/projections.js";
-import { EXACT_V9_SCHEMA_MANIFEST, schemaManifest } from "../src/schema-manifest.js";
+import { EXACT_V10_SCHEMA_MANIFEST, schemaManifest } from "../src/schema-manifest.js";
 import { initializeExactV7Database } from "./v7-schema.js";
 
 const JOB_ID = "00000000-0000-4000-8000-000000000071";
@@ -28,8 +28,8 @@ describe("exact-v7 projection refresh", () => {
     initializeExactV7Database(dbPath);
     const db = new Database(dbPath);
     db.pragma("foreign_keys = ON");
-    const before = schemaManifest(db, EXACT_V9_SCHEMA_MANIFEST.version);
-    expect(before).toEqual(EXACT_V9_SCHEMA_MANIFEST);
+    const before = schemaManifest(db, EXACT_V10_SCHEMA_MANIFEST.version);
+    expect(before).toEqual(EXACT_V10_SCHEMA_MANIFEST);
 
     const insertJob = db.prepare(
       `INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at)
@@ -86,7 +86,7 @@ describe("exact-v7 projection refresh", () => {
         .prepare("SELECT title FROM job_list_projections WHERE tenant_id = ? AND job_id = ?")
         .get("other", JOB_ID),
     ).toEqual({ title: "Other title" });
-    expect(schemaManifest(db, EXACT_V9_SCHEMA_MANIFEST.version)).toEqual(before);
+    expect(schemaManifest(db, EXACT_V10_SCHEMA_MANIFEST.version)).toEqual(before);
     db.close();
   });
 

--- a/apps/api/test/job-id-resolution.test.ts
+++ b/apps/api/test/job-id-resolution.test.ts
@@ -1,3 +1,4 @@
+import { seedApplicationUrl } from "./seed-enrichment.js";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -19,11 +20,14 @@ describe("canonical job identity resolution", () => {
     initializeExactV7Database(dbPath);
     const db = new Database(dbPath);
     const insert = db.prepare(
-      `INSERT INTO jobs (tenant_id, job_id, url, application_url)
-       VALUES (?, ?, ?, ?)`,
+      `INSERT INTO jobs (tenant_id, job_id, url)
+       VALUES (?, ?, ?)`,
     );
-    insert.run("local", LOCAL_JOB_ID, SHARED_POSTING_URL, `${SHARED_POSTING_URL}/apply`);
-    insert.run("other", OTHER_JOB_ID, SHARED_POSTING_URL, `${SHARED_POSTING_URL}/apply`);
+    insert.run("local", LOCAL_JOB_ID, SHARED_POSTING_URL);
+    insert.run("other", OTHER_JOB_ID, SHARED_POSTING_URL);
+
+    seedApplicationUrl(db, "local", LOCAL_JOB_ID, `${SHARED_POSTING_URL}/apply`);
+    seedApplicationUrl(db, "other", OTHER_JOB_ID, `${SHARED_POSTING_URL}/apply`);
 
     expect(resolveJobId(db, "local", LOCAL_JOB_ID)).toBe(LOCAL_JOB_ID);
     expect(resolveJobId(db, "local", SHARED_POSTING_URL)).toBe(LOCAL_JOB_ID);

--- a/apps/api/test/market-compensation-estimates.test.ts
+++ b/apps/api/test/market-compensation-estimates.test.ts
@@ -49,7 +49,8 @@ function seedDatabase(dbPath: string): void {
     "Short description",
     "Full private description that must never appear",
   );
-  db.prepare("UPDATE jobs SET application_url = ? WHERE tenant_id = 'local' AND job_id = ?").run(
+  db.prepare(`INSERT INTO job_enrichments (application_url, job_id, tenant_id, current_status, updated_at)
+    VALUES (?, ?, 'local', 'pending', '2026-08-01T00:00:00Z')`).run(
     ESTIMATED_APPLICATION_URL,
     ESTIMATED_JOB_ID,
   );

--- a/apps/api/test/permanent-delete-v7.test.ts
+++ b/apps/api/test/permanent-delete-v7.test.ts
@@ -1,3 +1,4 @@
+import { seedApplicationUrl } from "./seed-enrichment.js";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -7,7 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { openDatabase } from "../src/db.js";
 import { rebuildTenantDeleteProjections } from "../src/projections.js";
-import { schemaManifest, EXACT_V9_SCHEMA_MANIFEST } from "../src/schema-manifest.js";
+import { schemaManifest, EXACT_V10_SCHEMA_MANIFEST } from "../src/schema-manifest.js";
 import { permanentlyDeleteJob } from "../src/write-model.js";
 import { initializeExactV7Database } from "./v7-schema.js";
 
@@ -38,9 +39,10 @@ function exactDatabase(): Database.Database {
 
 function insertJob(db: Database.Database, tenantId: string, jobId: string, url: string): void {
   db.prepare(
-    `INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at, application_url)
-     VALUES (?, ?, ?, ?, 'Example', 'example', ?, ?)`,
-  ).run(tenantId, jobId, url, `Job ${jobId.slice(-3)}`, NOW, `${url}/apply`);
+    `INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at)
+     VALUES (?, ?, ?, ?, 'Example', 'example', ?)`,
+  ).run(tenantId, jobId, url, `Job ${jobId.slice(-3)}`, NOW);
+  seedApplicationUrl(db, tenantId, jobId, `${url}/apply`);
 }
 
 function countRows(db: Database.Database, tableName: string, whereSql: string, params: unknown[] = []): number {
@@ -265,7 +267,13 @@ describe("exact-v7 permanent job deletion", () => {
   it("purges only the local Job aggregate, preserves independent history, and permits rediscovery", () => {
     const db = exactDatabase();
     seedExactV7DeleteGraph(db);
-    const manifestBefore = schemaManifest(db, EXACT_V9_SCHEMA_MANIFEST.version);
+    const sharedApplication = "https://apply.example.test/shared-form";
+    db.prepare("INSERT INTO job_application_locators VALUES ('local', ?, ?)").run(JOB_ID, sharedApplication);
+    db.prepare("INSERT INTO job_application_locators VALUES ('local', ?, ?)").run(ANCHOR_JOB_ID, sharedApplication);
+    db.prepare(`INSERT INTO job_rejected_duplicate_links (
+      tenant_id, owner_job_id, candidate_url, reason, rejected_at
+    ) VALUES ('local', ?, ?, 'shared form belongs to surviving job', ?)`).run(ANCHOR_JOB_ID, sharedApplication, NOW);
+    const manifestBefore = schemaManifest(db, EXACT_V10_SCHEMA_MANIFEST.version);
     const otherJobsBefore = rowSnapshot(db, "jobs", "tenant_id = ? AND job_id = ?", [OTHER_TENANT, JOB_ID]);
     const otherLocatorsBefore = rowSnapshot(db, "job_locators", "tenant_id = ? AND job_id = ?", [OTHER_TENANT, JOB_ID]);
     const otherEvidenceBefore = rowSnapshot(db, "evidence_usage_projections", "tenant_id = ?", [OTHER_TENANT]);
@@ -273,6 +281,9 @@ describe("exact-v7 permanent job deletion", () => {
 
     expect(db.pragma("foreign_keys", { simple: true })).toBe(1);
     expect(permanentlyDeleteJob(db, JOB_URL)).toEqual({ ok: true, count: 1, jobKeys: [JOB_ID] });
+    expect(countRows(db, "job_rejected_duplicate_links", "tenant_id = ? AND candidate_url = ?", ["local", sharedApplication])).toBe(1);
+    expect(db.prepare("SELECT job_id FROM job_application_locators WHERE application_url = ?").all(sharedApplication))
+      .toEqual([{ job_id: ANCHOR_JOB_ID }]);
 
     for (const tableName of [
       "jobs",
@@ -368,7 +379,7 @@ describe("exact-v7 permanent job deletion", () => {
       ]);
     }
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
-    expect(schemaManifest(db, EXACT_V9_SCHEMA_MANIFEST.version)).toEqual(manifestBefore);
+    expect(schemaManifest(db, EXACT_V10_SCHEMA_MANIFEST.version)).toEqual(manifestBefore);
 
     expect(rowSnapshot(db, "jobs", "tenant_id = ? AND job_id = ?", [OTHER_TENANT, JOB_ID])).toEqual(otherJobsBefore);
     expect(rowSnapshot(db, "job_locators", "tenant_id = ? AND job_id = ?", [OTHER_TENANT, JOB_ID])).toEqual(otherLocatorsBefore);

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -1,3 +1,4 @@
+import { seedApplicationUrl } from "./seed-enrichment.js";
 /**
  * PR 4 of the Temporal stack: the TS API reads ``apply_run_projections``
  * directly. The bespoke ``apply_runs`` / ``apply_run_events`` tables
@@ -44,8 +45,8 @@ function seedSchema(dbPath: string): void {
   seedBuiltInResumeTemplate(db);
   db.prepare(
     `INSERT INTO jobs (
-       tenant_id, job_id, url, title, site, fit_score, score_reasoning, application_url
-     ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?)`,
+       tenant_id, job_id, url, title, site, fit_score, score_reasoning
+     ) VALUES ('local', ?, ?, ?, ?, ?, ?)`,
   ).run(
     EVENT_JOB_ID,
     EVENT_JOB_URL,
@@ -53,8 +54,8 @@ function seedSchema(dbPath: string): void {
     "ExampleCo",
     9,
     "Legacy reasoning kept for old callers.",
-    "https://example.com/apply/event",
   );
+  seedApplicationUrl(db, "local", EVENT_JOB_ID, "https://example.com/apply/event");
   db.prepare(
     "INSERT INTO job_scores (tenant_id, job_id, version, fit_score, breakdown_json, keywords_json, scored_at) VALUES ('local', ?, ?, ?, ?, ?, ?)",
   ).run(

--- a/apps/api/test/qa-seed.ts
+++ b/apps/api/test/qa-seed.ts
@@ -1,3 +1,4 @@
+import { seedApplicationUrl } from "./seed-enrichment.js";
 import fs from "node:fs";
 import { createHash } from "node:crypto";
 import os from "node:os";
@@ -1921,10 +1922,10 @@ function seedWorkerHeartbeat(db: Database.Database, dbPath: string): void {
 function insertJob(db: Database.Database, job: QaJobSeed): void {
   db.prepare(
     `INSERT INTO jobs (
-      url, tenant_id, job_id, title, company, site, strategy, location, salary, discovered_at, application_url,
+      url, tenant_id, job_id, title, company, site, strategy, location, salary, discovered_at,
       description, full_description, detail_scraped_at, fit_score, score_reasoning,
       scored_at, tailored_resume_path, tailored_at
-    ) VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES (?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     job.url,
     qaJobId(job.url),
@@ -1935,7 +1936,6 @@ function insertJob(db: Database.Database, job: QaJobSeed): void {
     job.location ?? "Remote",
     "",
     QA_NOW,
-    job.applicationUrl ?? job.url,
     job.description ?? "QA job description",
     job.fullDescription ?? job.description ?? "QA job description",
     QA_NOW,
@@ -1945,6 +1945,7 @@ function insertJob(db: Database.Database, job: QaJobSeed): void {
     null,
     null,
   );
+  seedApplicationUrl(db, "local", qaJobId(job.url), job.applicationUrl ?? job.url);
 }
 
 function qaJobId(jobUrl: string): string {

--- a/apps/api/test/read-model-v7.test.ts
+++ b/apps/api/test/read-model-v7.test.ts
@@ -1,3 +1,4 @@
+import { seedApplicationUrl } from "./seed-enrichment.js";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -15,7 +16,7 @@ import {
   listScoringKeywords,
 } from "../src/read-model.js";
 import { BUILT_IN_RESUME_TEMPLATE_THEME } from "../src/resume-templates.js";
-import { EXACT_V9_SCHEMA_MANIFEST, schemaManifest } from "../src/schema-manifest.js";
+import { EXACT_V10_SCHEMA_MANIFEST, schemaManifest } from "../src/schema-manifest.js";
 import { hideJob, restoreJob, softDeleteJob, unhideJob } from "../src/write-model.js";
 import { initializeExactV7Database } from "./v7-schema.js";
 
@@ -128,9 +129,10 @@ function insertJob(
   applicationUrl: string,
 ): void {
   db.prepare(
-    `INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at, application_url)
-     VALUES (?, ?, ?, ?, 'Example', 'example', ?, ?)`,
-  ).run(tenantId, jobId, url, title, NOW, applicationUrl);
+    `INSERT INTO jobs (tenant_id, job_id, url, title, company, site, discovered_at)
+     VALUES (?, ?, ?, ?, 'Example', 'example', ?)`,
+  ).run(tenantId, jobId, url, title, NOW);
+  seedApplicationUrl(db, tenantId, jobId, applicationUrl);
   db.prepare(
     `INSERT INTO job_events (
        tenant_id, job_id, identity_version, stage, event_type, occurred_at
@@ -238,7 +240,7 @@ describe("exact-v7 read model job ids", () => {
 
   it("keeps same-UUID tenants isolated while preserving URL locators and material/template state", () => {
     const db = seededDatabase();
-    const before = schemaManifest(db, EXACT_V9_SCHEMA_MANIFEST.version);
+    const before = schemaManifest(db, EXACT_V10_SCHEMA_MANIFEST.version);
 
     const jobs = listJobs(db, activeJobQuery);
     const detail = getJobDetail(db, JOB_ID);
@@ -260,7 +262,7 @@ describe("exact-v7 read model job ids", () => {
     expect(detail?.job.resumeTemplate).toEqual(expect.any(Object));
     expect(detail?.stages.find((stage) => stage.stage === "score")).toMatchObject({ retryable: false });
     expect(dashboard.totals.jobs).toBe(1);
-    expect(schemaManifest(db, EXACT_V9_SCHEMA_MANIFEST.version)).toEqual(before);
+    expect(schemaManifest(db, EXACT_V10_SCHEMA_MANIFEST.version)).toEqual(before);
   });
 
   it("projects attempt exhaustion as a retryable failure reason", () => {

--- a/apps/api/test/repeat-application.test.ts
+++ b/apps/api/test/repeat-application.test.ts
@@ -46,9 +46,9 @@ function jobIdFor(url: string): string {
 
 function insertJob(url: string, title: string, company: string): void {
   db.prepare(
-    `INSERT INTO jobs (tenant_id, job_id, url, title, company, application_url, discovered_at)
-     VALUES ('local', ?, ?, ?, ?, ?, ?)`,
-  ).run(jobIdFor(url), url, title, company, `${url}/apply`, NOW);
+    `INSERT INTO jobs (tenant_id, job_id, url, title, company, discovered_at)
+     VALUES ('local', ?, ?, ?, ?, ?)`,
+  ).run(jobIdFor(url), url, title, company, NOW);
   db.prepare(
     `INSERT INTO job_enrichments
        (tenant_id, job_id, current_status, application_url, updated_at)

--- a/apps/api/test/resume-templates.test.ts
+++ b/apps/api/test/resume-templates.test.ts
@@ -126,6 +126,12 @@ describe("resume template service", () => {
   });
 
   it("rejects template payloads that contain profile or job facts", async () => {
+    const retainedUrl = "https://apply.example.test/private-retired-target";
+    db.prepare("INSERT INTO job_application_locators VALUES ('local', ?, ?)").run(JOB_ID, retainedUrl);
+    expect(() => createResumeTemplateVersion(db, {
+      displayName: retainedUrl, theme: BUILT_IN_RESUME_TEMPLATE_THEME, layout: {},
+    })).toThrow("profile or job facts");
+
     expect(() =>
       createResumeTemplateVersion(db, {
         displayName: "Jordan Candidate",
@@ -419,11 +425,13 @@ function seedDatabase(database: Database.Database): void {
       url TEXT NOT NULL,
       title TEXT,
       company TEXT,
-      application_url TEXT,
       discovered_at TEXT,
       PRIMARY KEY (tenant_id, job_id),
       UNIQUE (tenant_id, url)
     );
+    CREATE TABLE job_enrichments (tenant_id TEXT, job_id TEXT, application_url TEXT,
+      PRIMARY KEY (tenant_id, job_id));
+    CREATE TABLE job_application_locators (tenant_id TEXT, job_id TEXT, application_url TEXT);
     CREATE TABLE candidate_profiles (
       tenant_id TEXT NOT NULL,
       profile_id TEXT NOT NULL,
@@ -564,19 +572,23 @@ function seedDatabase(database: Database.Database): void {
   database.pragma("foreign_keys = ON");
   database
     .prepare(
-      "INSERT INTO jobs (tenant_id, job_id, url, title, company, application_url, discovered_at) VALUES ('local', ?, ?, ?, ?, ?, ?)",
+      "INSERT INTO jobs (tenant_id, job_id, url, title, company, discovered_at) VALUES ('local', ?, ?, ?, ?, ?)",
     )
-    .run(JOB_ID, JOB_URL, "Senior Platform Engineer", "Globex Infrastructure", "https://apply.example.com/globex", NOW);
+    .run(JOB_ID, JOB_URL, "Senior Platform Engineer", "Globex Infrastructure", NOW);
   database
     .prepare(
-      "INSERT INTO jobs (tenant_id, job_id, url, title, company, application_url, discovered_at) VALUES ('local', ?, ?, ?, ?, ?, ?)",
+      "INSERT INTO jobs (tenant_id, job_id, url, title, company, discovered_at) VALUES ('local', ?, ?, ?, ?, ?)",
     )
-    .run(UUID_SHAPED_URL_OWNER_JOB_ID, UUID_SHAPED_URL, "URL-shaped locator", "Example", "https://apply.example.com/uuid", NOW);
+    .run(UUID_SHAPED_URL_OWNER_JOB_ID, UUID_SHAPED_URL, "URL-shaped locator", "Example", NOW);
   database
     .prepare(
-      "INSERT INTO jobs (tenant_id, job_id, url, title, company, application_url, discovered_at) VALUES ('other', ?, ?, ?, ?, ?, ?)",
+      "INSERT INTO jobs (tenant_id, job_id, url, title, company, discovered_at) VALUES ('other', ?, ?, ?, ?, ?)",
     )
-    .run(JOB_ID, "https://other.example/jobs/template-engineer", "Other tenant job", "Other", "https://other.example/apply", NOW);
+    .run(JOB_ID, "https://other.example/jobs/template-engineer", "Other tenant job", "Other", NOW);
+  const insertApplication = database.prepare("INSERT INTO job_enrichments VALUES (?, ?, ?)");
+  insertApplication.run("local", JOB_ID, "https://apply.example.com/globex");
+  insertApplication.run("local", UUID_SHAPED_URL_OWNER_JOB_ID, "https://apply.example.com/uuid");
+  insertApplication.run("other", JOB_ID, "https://other.example/apply");
   database
     .prepare(
       `INSERT INTO candidate_profiles (

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -18,6 +18,7 @@ import {
   EXACT_V7_SCHEMA_MANIFEST,
   EXACT_V8_SCHEMA_MANIFEST,
   EXACT_V9_SCHEMA_MANIFEST,
+  EXACT_V10_SCHEMA_MANIFEST,
   hasExactV8SchemaManifest,
   hasExactV9SchemaManifest,
   schemaManifest,
@@ -32,7 +33,7 @@ function makeDbWithUserVersion(userVersion: number): { dbPath: string; cleanup: 
   return { dbPath, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
 }
 
-function makeExactV9Database(): { dbPath: string; cleanup: () => void } {
+function makeExactV10Database(): { dbPath: string; cleanup: () => void } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-api-exact-v9-"));
   const dbPath = path.join(dir, "jobs.db");
   const migrations = path.resolve(
@@ -43,6 +44,7 @@ function makeExactV9Database(): { dbPath: string; cleanup: () => void } {
   db.exec(fs.readFileSync(path.join(migrations, "schema_v7.sql"), "utf8"));
   db.exec(fs.readFileSync(path.join(migrations, "schema_v8.sql"), "utf8"));
   db.exec(fs.readFileSync(path.join(migrations, "schema_v9.sql"), "utf8"));
+  db.exec(fs.readFileSync(path.join(migrations, "schema_v10.sql"), "utf8"));
   db.pragma(`user_version = ${SUPPORTED_SCHEMA_VERSION}`);
   db.close();
   return { dbPath, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
@@ -58,7 +60,7 @@ function tableColumns(db: Database.Database, tableName: string): string[] {
 }
 
 describe("schema version guard at DB open", () => {
-  it.each([0, 6, 7, 8, 10])("refuses schema version %i before runtime writes", (userVersion) => {
+  it.each([0, 6, 7, 8, 9, 11])("refuses schema version %i before runtime writes", (userVersion) => {
     const { dbPath, cleanup } = makeDbWithUserVersion(userVersion);
     try {
       const token = "job" + "ctl";
@@ -87,8 +89,8 @@ describe("schema version guard at DB open", () => {
     }
   });
 
-  it("opens the exact v9 schema", () => {
-    const { dbPath, cleanup } = makeExactV9Database();
+  it("opens the exact v10 schema", () => {
+    const { dbPath, cleanup } = makeExactV10Database();
     try {
       openDatabase(dbPath).close();
       openReadOnlyDatabase(dbPath).close();
@@ -97,7 +99,7 @@ describe("schema version guard at DB open", () => {
     }
   });
 
-  it("rejects a merely stamped v9 database before runtime writes", () => {
+  it("rejects a merely stamped v10 database before runtime writes", () => {
     const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION);
     try {
       expect(() => openDatabase(dbPath)).toThrow(IncompatibleSchemaManifestError);
@@ -114,7 +116,7 @@ describe("schema version guard at DB open", () => {
     }
   });
 
-  it("rejects a malformed v9 database without running legacy tombstone migration", () => {
+  it("rejects a malformed v10 database without running legacy tombstone migration", () => {
     const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION);
     try {
       const token = "job" + "ctl";
@@ -173,10 +175,17 @@ describe("schema version guard at DB open", () => {
     expect(pythonManifest).toContain("version=9,");
     expect(pythonManifest).toContain(`fingerprint="${EXACT_V9_SCHEMA_MANIFEST.fingerprint}",`);
     expect(EXACT_V9_SCHEMA_MANIFEST).toEqual({
-      version: SUPPORTED_SCHEMA_VERSION,
+      version: 9,
       objectCount: 272,
       tableCount: 117,
       fingerprint: "ee90d737238c162f34d69f5becf01f15897d4bbeb2c4b2c51d41526ec6343621",
+    });
+    expect(pythonManifest).toContain(`fingerprint="${EXACT_V10_SCHEMA_MANIFEST.fingerprint}",`);
+    expect(EXACT_V10_SCHEMA_MANIFEST).toEqual({
+      version: SUPPORTED_SCHEMA_VERSION,
+      objectCount: 274,
+      tableCount: 118,
+      fingerprint: "d5c1676fff6e81c987055bf4db6d725c582c74b834f4bf92c9eef3f5980f3641",
     });
   });
 

--- a/apps/api/test/score-correction-v7.test.ts
+++ b/apps/api/test/score-correction-v7.test.ts
@@ -15,7 +15,7 @@ vi.mock("../src/read-model.js", async (importOriginal) => ({
   getJobDetail,
 }));
 
-import { hasExactV9SchemaManifest } from "../src/schema-manifest.js";
+import { hasExactV10SchemaManifest } from "../src/schema-manifest.js";
 import { buildApp } from "../src/server.js";
 import { initializeExactV7Database } from "./v7-schema.js";
 
@@ -104,7 +104,7 @@ describe("score correction exact-v7 identity", () => {
             event_type: "ScoreCorrected",
           }),
         ]);
-        expect(hasExactV9SchemaManifest(db)).toBe(true);
+        expect(hasExactV10SchemaManifest(db)).toBe(true);
       } finally {
         db.close();
       }
@@ -136,7 +136,7 @@ describe("score correction exact-v7 identity", () => {
           identity_version: 1,
           event_type: "ScoreRescoreRequested",
         }));
-        expect(hasExactV9SchemaManifest(resetDb)).toBe(true);
+        expect(hasExactV10SchemaManifest(resetDb)).toBe(true);
       } finally {
         resetDb.close();
       }

--- a/apps/api/test/seed-enrichment.ts
+++ b/apps/api/test/seed-enrichment.ts
@@ -1,0 +1,10 @@
+import type Database from "better-sqlite3";
+
+/** Seed a target without claiming successful enrichment. */
+export function seedApplicationUrl(db: Database.Database, tenantId: string, jobId: string, applicationUrl: string | null): void {
+  db.prepare(`INSERT INTO job_enrichments (tenant_id, job_id, current_status, application_url, updated_at)
+    VALUES (?, ?, 'pending', ?, '2026-08-01T00:00:00Z')
+    ON CONFLICT (tenant_id, job_id) DO UPDATE SET application_url = excluded.application_url`).run(
+    tenantId, jobId, applicationUrl,
+  );
+}

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -1,3 +1,4 @@
+import { seedApplicationUrl } from "./seed-enrichment.js";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
@@ -7692,7 +7693,7 @@ describe("local TypeScript API", () => {
       `INSERT INTO job_enrichments (
          tenant_id, job_id, current_status, full_description, application_url,
          enriched_at, extraction_tier, attempts_json, updated_at
-       ) VALUES ('local', ?, 'pending', NULL, NULL, NULL, NULL, '[]', ?)`,
+       ) VALUES ('local', ?, 'pending', NULL, NULL, NULL, NULL, '[]', ?) ON CONFLICT (tenant_id, job_id) DO UPDATE SET application_url = NULL`,
     ).run(jobIdFor(pendingEnrichUrl), "2026-08-05T23:15:00.000Z");
     insertJob(seedDb, {
       url: pendingScoreUrl,
@@ -8034,7 +8035,11 @@ describe("local TypeScript API", () => {
          job_id, tenant_id, current_status, full_description,
          application_url, enriched_at, extraction_tier,
          attempts_json, updated_at
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (tenant_id, job_id) DO UPDATE SET current_status = excluded.current_status,
+         full_description = excluded.full_description, application_url = excluded.application_url,
+         enriched_at = excluded.enriched_at, extraction_tier = excluded.extraction_tier,
+         attempts_json = excluded.attempts_json, updated_at = excluded.updated_at`,
     ).run(
       jobIdFor("https://example.com/jobs/failed-score"),
       "local",
@@ -8117,6 +8122,10 @@ describe("local TypeScript API", () => {
   });
 
   it("retry-enrich is a no-op when no job_enrichments row exists", async () => {
+    const seedDb = new Database(options.dbPath);
+    seedDb.prepare("DELETE FROM job_enrichments WHERE tenant_id = 'local' AND job_id = ?")
+      .run(jobIdFor("https://example.com/jobs/blocked-tailor"));
+    seedDb.close();
     // Confirm ``resetEnrichmentAggregate`` doesn't crash when the
     // aggregate row was never written. Exact-v7 reset is a 0-row aggregate
     // update and never falls back to retired wide job columns.
@@ -12209,8 +12218,8 @@ function seedExactV7CompensationDatabase(
   if (job) {
     db.prepare(
       `INSERT INTO jobs (
-        tenant_id, job_id, url, title, site, strategy, location, discovered_at, application_url
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        tenant_id, job_id, url, title, site, strategy, location, discovered_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       "local",
       job.jobId,
@@ -12220,8 +12229,8 @@ function seedExactV7CompensationDatabase(
       "test",
       "Remote",
       "2026-04-29T10:00:00+00:00",
-      `${job.postingUrl}/apply`,
     );
+    seedApplicationUrl(db, "local", job.jobId, `${job.postingUrl}/apply`);
   }
   db.close();
 }
@@ -12655,10 +12664,10 @@ function insertJob(
 ): void {
   db.prepare(
     `INSERT INTO jobs (
-      tenant_id, job_id, url, title, site, company, strategy, location, salary, discovered_at, application_url,
+      tenant_id, job_id, url, title, site, company, strategy, location, salary, discovered_at,
       description, full_description, detail_scraped_at, fit_score, score_reasoning,
       scored_at, tailored_resume_path, tailored_at
-    ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     jobIdFor(job.url),
     job.url,
@@ -12669,7 +12678,6 @@ function insertJob(
     "Remote",
     "",
     "2026-04-29T10:00:00+00:00",
-    job.url,
     job.description ?? "Short description",
     job.fullDescription ?? "Long description",
     "2026-04-29T10:01:00+00:00",
@@ -12679,6 +12687,7 @@ function insertJob(
     job.tailoredPath ?? null,
     job.tailoredPath ? "2026-04-29T10:03:00+00:00" : null,
   );
+  seedApplicationUrl(db, "local", jobIdFor(job.url), job.url);
 }
 
 function jobIdFor(jobUrl: string): string {
@@ -12695,7 +12704,8 @@ function insertEnrichment(
     `INSERT INTO job_enrichments (
        tenant_id, job_id, current_status, full_description, application_url,
        enriched_at, extraction_tier, attempts_json, updated_at
-     ) VALUES ('local', ?, 'enriched', ?, ?, ?, 'css_selectors', '[]', ?)`,
+     ) VALUES ('local', ?, 'enriched', ?, ?, ?, 'css_selectors', '[]', ?)
+     ON CONFLICT (tenant_id, job_id) DO UPDATE SET current_status = excluded.current_status, full_description = excluded.full_description, application_url = excluded.application_url, enriched_at = excluded.enriched_at, extraction_tier = excluded.extraction_tier, updated_at = excluded.updated_at`,
   ).run(
     jobIdFor(jobUrl),
     fullDescription,

--- a/apps/api/test/support/reopen-exact-v10.ts
+++ b/apps/api/test/support/reopen-exact-v10.ts
@@ -2,12 +2,19 @@ import { openDatabase, openReadOnlyDatabase } from "../../src/db.js";
 
 const databasePath = process.argv[2];
 if (!databasePath) {
-  throw new Error("exact-v9 reopen probe requires a database path");
+  throw new Error("exact-v10 reopen probe requires a database path");
 }
 
 for (const open of [openDatabase, openReadOnlyDatabase]) {
   const database = open(databasePath);
   try {
+    if (database.pragma("user_version", { simple: true }) !== 10) {
+      throw new Error("TypeScript API did not reopen schema v10");
+    }
+    const columns = database.prepare("PRAGMA table_info(jobs)").all() as Array<{ name: string }>;
+    if (columns.some((column) => column.name === "application_url")) {
+      throw new Error("TypeScript API admitted the removed jobs.application_url column");
+    }
     const row = database
       .prepare("SELECT job_id, url FROM jobs ORDER BY tenant_id, job_id LIMIT 1")
       .get() as { job_id?: unknown; url?: unknown } | undefined;

--- a/apps/api/test/v7-schema.ts
+++ b/apps/api/test/v7-schema.ts
@@ -26,7 +26,14 @@ const v9SchemaPath = fileURLToPath(
   ),
 );
 
-// The frozen v7 schema plus additive v8/v9 DDL form the exact runtime schema. The
+const v10SchemaPath = fileURLToPath(
+  new URL(
+    "../../../workers/automation/src/jobctrl/infrastructure/migrations/schema_v10.sql",
+    import.meta.url,
+  ),
+);
+
+// The frozen v7 schema plus v8/v9/v10 DDL form the exact runtime schema. The
 // seeding hooks across this suite call this helper once per test, so build it
 // once per worker process and copy the closed single-file database instead.
 let templatePath: string | undefined;
@@ -35,12 +42,13 @@ function schemaTemplate(): string {
   if (templatePath !== undefined) {
     return templatePath;
   }
-  const templateDir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-v9-schema-"));
-  const template = path.join(templateDir, "schema-v9.db");
+  const templateDir = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-v10-schema-"));
+  const template = path.join(templateDir, "schema-v10.db");
   const db = new Database(template);
   db.exec(fs.readFileSync(path.resolve(v7SchemaPath), "utf8"));
   db.exec(fs.readFileSync(path.resolve(v8SchemaPath), "utf8"));
   db.exec(fs.readFileSync(path.resolve(v9SchemaPath), "utf8"));
+  db.exec(fs.readFileSync(path.resolve(v10SchemaPath), "utf8"));
   db.pragma(`user_version = ${SUPPORTED_SCHEMA_VERSION}`);
   db.close();
   process.on("exit", () => {

--- a/apps/api/test/write-model-cancel.test.ts
+++ b/apps/api/test/write-model-cancel.test.ts
@@ -25,14 +25,14 @@ describe("cancelJobAction", () => {
     db = new Database(dbPath);
     db.prepare(
       `INSERT INTO jobs (
-         tenant_id, job_id, url, application_url,
+         tenant_id, job_id, url,
          detail_scraped_at, detail_error,
          fit_score, score_reasoning, scored_at,
          tailored_resume_path, tailored_at, tailor_attempts,
          cover_letter_path, cover_letter_at, cover_attempts,
          applied_at, apply_status, apply_error, apply_attempts,
          agent_id, apply_task_id
-       ) VALUES (?, ?, ?, ?, ?, 'retired-detail-error', 10, 'retired-score', ?,
+       ) VALUES (?, ?, ?, ?, 'retired-detail-error', 10, 'retired-score', ?,
                  '/tmp/retired-resume.txt', ?, 4,
                  '/tmp/retired-cover.txt', ?, 3,
                  ?, 'retired-status', 'retired-apply-error', 2,
@@ -41,7 +41,6 @@ describe("cancelJobAction", () => {
       TENANT_ID,
       JOB_ID,
       JOB_URL,
-      `${JOB_URL}/apply`,
       RETIRED_AT,
       RETIRED_AT,
       RETIRED_AT,

--- a/apps/web/e2e/tests/outreach.spec.ts
+++ b/apps/web/e2e/tests/outreach.spec.ts
@@ -22,6 +22,24 @@ const SENSITIVE_VALUES = [
   "Hi Casey, I saw the platform role and wanted to introduce myself.",
 ];
 
+test.afterEach(() => {
+  const db = new Database(loadE2eDbPath());
+  try {
+    db.transaction(() => {
+      db.prepare(
+        "DELETE FROM application_outcomes WHERE tenant_id = 'local' AND outcome_id = 'outcome-e2e-outreach' AND job_id = ?",
+      ).run(QA_PLATFORM_JOB_ID);
+      // A later canonical metadata refresh must not inherit this fixture's
+      // applied status. Rebuild through the normal API from remaining facts.
+      db.prepare(
+        "DELETE FROM job_list_projections WHERE tenant_id = 'local' AND job_id = ?",
+      ).run(QA_PLATFORM_JOB_ID);
+    })();
+  } finally {
+    db.close();
+  }
+});
+
 function tableExists(db: Database.Database, table: string): boolean {
   const row = db
     .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")

--- a/apps/web/e2e/tests/repeat-application.spec.ts
+++ b/apps/web/e2e/tests/repeat-application.spec.ts
@@ -133,7 +133,6 @@ test("repeat application block and reasoned override reach only the simulated su
       ...target,
       job_id: PRIOR_JOB_ID,
       url: PRIOR,
-      application_url: `${PRIOR}/apply`,
       company: "GitLab",
       apply_status: "applied",
       applied_at: CONFIRMED_AT,
@@ -143,6 +142,9 @@ test("repeat application block and reasoned override reach only the simulated su
       `INSERT OR REPLACE INTO jobs (${columns.map((column) => `"${column}"`).join(", ")})
        VALUES (${columns.map(() => "?").join(", ")})`,
     ).run(...columns.map((column) => prior[column]));
+    db.prepare(`INSERT INTO job_enrichments (
+      tenant_id, job_id, current_status, application_url, updated_at
+    ) VALUES ('local', ?, 'pending', ?, ?)`).run(PRIOR_JOB_ID, `${PRIOR}/apply`, CONFIRMED_AT);
     db.prepare(
       `INSERT INTO job_events
        (tenant_id, job_id, identity_version, stage, event_type, level, message, occurred_at, payload_json)
@@ -394,6 +396,7 @@ print(job["url"])
     db.prepare("DELETE FROM job_list_projections WHERE tenant_id = 'local' AND job_id = ?").run(
       PRIOR_JOB_ID,
     );
+    db.prepare("DELETE FROM job_enrichments WHERE tenant_id = 'local' AND job_id = ?").run(PRIOR_JOB_ID);
     db.prepare("DELETE FROM jobs WHERE tenant_id = 'local' AND job_id = ?").run(PRIOR_JOB_ID);
     if (originalTargetJob) {
       db.prepare(

--- a/docs/architecture/application-url-authority.md
+++ b/docs/architecture/application-url-authority.md
@@ -1,0 +1,41 @@
+# Application URL authority inventory
+
+The exact-v10 boundary removes the `jobs.application_url` column. Application
+URLs remain valid domain values; removing the legacy storage authority does not
+remove canonical targets, approval snapshots, event evidence, or API fields.
+
+| Reader or writer | Current source and behavior |
+| --- | --- |
+| TypeScript and Python list/detail/dashboard projection builders | Read `job_enrichments.application_url` only. They never restore a cleared target from an alias. |
+| API job detail lookup and write-model action/reset/delete lookup | Resolve tenant-scoped canonical/posting identity first, then a unique enrichment or application alias. Shared application endpoints fail closed. |
+| Python administrative stage reset | Uses the same tenant-scoped unique locator semantics. |
+| TypeScript and Python repeat-application identity | Read canonical enrichment target, then the existing posting URL fallback. Historical aliases are not target authority. |
+| API application review and approval validation | Bind the canonical enrichment target, retaining the existing posting URL fallback when no target is available. Saved review/run URLs remain immutable evidence. |
+| API resume-template privacy guard | Checks canonical enrichment and retained historical URL aliases for the selected tenant, so migrated private facts cannot leak into reusable templates. |
+| Python job loaders and stage readers | Join canonical enrichment and expose its `application_url` in the existing job DTO. Apply, browser navigation, scoring, tailoring, and prompt consumers use that DTO. |
+| Detail enrichment discovery-description fallback | Reads the existing discovery description with the canonical enrichment URL; no legacy target fallback. |
+| Enrichment repository | Writes only canonical enrichment and retains a lookup alias; no legacy job-column write. |
+| JobSpy and Workday discovery metadata refresh | Fills an absent canonical URL with a pending enrichment and retains observed aliases. It leaves a nonempty canonical target unchanged. |
+| Gmail application anchors | Join canonical enrichment by tenant and JobId. Feedback scan persistence uses canonical identities and exact runtime admission. |
+| Permanent job purge | Captures canonical and historical aliases for existing reference cleanup; the job foreign key removes owned aliases without touching another tenant/job. |
+| API, browser QA, and worker current-runtime fixtures | Seed enrichment URLs directly against the exact current schema. Migration fixtures alone seed the historical column. |
+
+`job_application_locators` is a lookup relation, separate from posting locators:
+several jobs can share one application form without weakening posting identity
+uniqueness. Migration retains both values when canonical and legacy URLs differ.
+A null/empty canonical value receives the nonempty legacy value; other enrichment
+state is preserved. Alias rows never drive submission, projections, or approval
+binding after migration.
+
+The frozen `schema_v7.sql`, historical v6 preparation helpers (including the
+wide-column registry and v6 enrichment backfill), and v6/v7/v8/v9 migration
+executors still describe the old column. They are isolated compatibility inputs
+to the stopped-runtime candidate chain. They are not invoked by exact-v10 runtime
+admission. Historical tests intentionally retain those definitions. The new
+v9-to-v10 transfer is the final reader of legacy values before column removal.
+
+Verification combines an exact migration preservation matrix, tenant/ambiguity
+lookup regressions, a shared cross-runtime migration/projection fixture,
+canonical application review tests, discovery/enrichment tests, and native
+paired-backup/recovery tests. All migration and recovery fixtures use owned
+synthetic databases; they do not establish migration of a real installation.

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -107,13 +107,13 @@ locking; selector resolution holds a shared selection lock through supervisor
 readiness. Before a candidate is promoted, the old process tree is quiesced
 with the registry's PID/PGID identity checks and both `JOBCTRL_DIR/jobctrl.db`
 and `JOBCTRL_DIR/temporal.db` receive online, hash-verified paired backups.
-The current runtime admits only exact schema v9. A stopped v6 database uses the
-existing Temporal quiescence proof and private v7/v8 intermediates before v9;
-a stopped exact-v7 database starts with the private v8 step; and an exact-v8
-database receives only the additive optional position-summary column. An
-exact-v9 database needs no schema transition. Neither Python nor the TypeScript
-API runs against an intermediate schema, and recovery removes staged candidates
-before restoring the retained pair.
+The current runtime admits only exact schema v10. A stopped v6 database retains
+the Temporal quiescence proof and private v7/v8/v9 intermediates; exact v7 and v8
+start at their next intermediate. Exact v9 transfers application URL authority
+to enrichment and retains historical lookup aliases before removing the legacy
+job column. Exact v10 needs no schema transition. Neither Python nor the
+TypeScript API runs against an intermediate schema. Recovery removes all staged
+candidates and their sidecars before restoring the retained database pair.
 Policy finalization happens only after the candidate has passed readiness and
 the paired backup is durable, so a failed health gate cannot revoke the only
 runnable release. A pre-finalization failure restores the full pair and

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -87,33 +87,51 @@ licensed-feed coverage policy. Public Levels.fyi Markdown needs no credential.
 Credentials, feed paths/URLs, feed contents, and provider payloads do not belong
 in the settings file.
 
-### Exact v9 runtime and compatible cutovers
+### Exact v10 runtime and compatible cutovers
 
-Schema v9 is the exact runtime contract. The native lifecycle upgrades admitted
-v6, exact-v7, and exact-v8 installations only while the application is stopped.
-It creates a paired backup of `jobctrl.db` and Temporal state before building an
-isolated candidate. A v6 source first runs the existing identity rewrite into
-an owner-private exact-v7 intermediate and then applies v8; an exact-v7 source
-starts at the private v8 step. Both paths then add v9, while an exact-v8 source
-receives only the additive optional `summary` column on Candidate Profile
-experience rows. Intermediates are deleted and never become live. The v6 path
-retains the Temporal quiescence proof required before URL-rooted job rows and
-foreign references are mapped to stable tenant-scoped JobIds.
+Schema v10 is the exact runtime contract. The native lifecycle upgrades admitted
+v6, exact-v7, exact-v8, and exact-v9 installations only while the application is
+stopped. It first creates a paired backup of `jobctrl.db` and Temporal state.
+A v6 source retains the Temporal quiescence proof and identity rewrite through
+private exact-v7/v8/v9 intermediates; newer sources start at their next schema
+step. Only the final exact-v10 candidate can become live. Intermediate databases
+and their sidecars are removed after success and during failure recovery.
 
-Activation happens only after exact-manifest, row/reference, foreign-key,
-integrity, source-preservation, file-permission, digest, and paired-state
-verification succeeds. The verified v9 candidate replaces the live database
-atomically. Any failed build, verification, activation, or readiness check
-restores the paired backup and leaves the previous version runnable. There is
-no mixed-version runtime, rolling deployment, dual-write path, or permanent
-compatibility layer: the TypeScript API and Python worker accept exact v9 and
-reject direct v6/v7/v8 operation. Runtime projections read registered persisted
-artifacts only and do not reconstruct legacy URL-shaped fallback rows.
+V10 removes `jobs.application_url`. `job_enrichments.application_url` is the
+canonical application target. A nonempty canonical value wins; otherwise the
+migration promotes a nonempty legacy value. A missing enrichment receives a
+pending row, without claiming that enrichment succeeded. Other enrichment fields,
+lifecycle state, tenant/job identities, dependent rows, and sequences stay intact.
+Null and empty values are absent; retained strings keep their exact bytes.
 
-SQLite repository and projection constructors do not initialize schema or
-commit caller work. Exact-v9 creation/admission owns that boundary before runtime
-refresh begins; each refresh owns only its derived writes and consumer cursor
-inside a transaction or the caller's savepoint.
+`job_application_locators` retains the union of nonempty legacy and canonical
+URLs under a tenant/job/URL key. These aliases support historical lookup only;
+clearing the canonical target does not make projections or approval validation
+read an old alias. New enrichment saves retain their application URL as an alias.
+Discovery can fill an absent canonical target and retain an observed alias, but
+cannot replace a nonempty canonical enrichment URL. Posting locator uniqueness
+remains unchanged. Application endpoints may be shared, so application lookup
+returns a job only when exactly one job in the requested tenant matches. Posting
+identity takes priority over an application alias. Deleting a job cascades only
+its own aliases.
+
+Activation requires exact-manifest, retained-data, exact URL-transfer,
+foreign-key, integrity, source-preservation, permissions, digest, and paired-state
+verification. The receipt's comparable data digests cover every retained cell and
+sequence; the complete changed enrichment rows and alias set are verified
+separately before sealing. Any failed build, verification, activation, or readiness
+check restores the paired backup and leaves the previous version runnable.
+The TypeScript API and Python worker accept exact v10 and reject direct v6/v7/v8/v9
+operation; runtime constructors do not migrate schema or commit caller work.
+Each projection refresh owns only derived writes and its consumer cursor inside a
+transaction or the caller's savepoint. Refresh compares existing projected targets
+with canonical enrichment even without a new event, so preserved projection rows
+and watermarks cannot hide a URL promoted during migration.
+
+The remaining URL consumers are classified in the
+[application URL authority inventory](application-url-authority.md). Historical
+v6 preparation and v7/v8/v9 schema/executor definitions remain frozen to admit
+previous installations, and do not provide a current-runtime fallback.
 
 V9 adds one optional per-position summary to normalized Candidate Profile
 experience rows. Existing rows receive the empty-string default; empty values

--- a/launcher/internal/launcher/homebrew_bootstrap_test.go
+++ b/launcher/internal/launcher/homebrew_bootstrap_test.go
@@ -546,7 +546,7 @@ func preseedUnsignedHomebrewRelease(t *testing.T, home string, fixture homebrewB
 func seedHomebrewSQLitePair(t *testing.T, python, state string) {
 	t.Helper()
 	for _, name := range []string{"jobctrl.db", "temporal.db"} {
-		code := "import pathlib,sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute('create table t(v)'); c.execute('insert into t values (1)'); c.execute('PRAGMA user_version=9') if pathlib.Path(sys.argv[1]).name == 'jobctrl.db' else None; c.commit()"
+		code := "import pathlib,sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute('create table t(v)'); c.execute('insert into t values (1)'); c.execute('PRAGMA user_version=10') if pathlib.Path(sys.argv[1]).name == 'jobctrl.db' else None; c.commit()"
 		if output, err := exec.Command(python, "-c", code, filepath.Join(state, name)).CombinedOutput(); err != nil {
 			t.Fatalf("seed %s: %v %s", name, err, output)
 		}

--- a/launcher/internal/launcher/lifecycle.go
+++ b/launcher/internal/launcher/lifecycle.go
@@ -936,6 +936,7 @@ func recoverInterruptedTransition(ctx launchContext, store *release.Store) (bool
 	}
 	cleanupV7Candidate(ctx.Instance.StateDir, journal.ID)
 	cleanupV9Candidate(ctx.Instance.StateDir, journal.ID)
+	cleanupV10Candidate(ctx.Instance.StateDir, journal.ID)
 	if journal.BackupID != "" {
 		var pair databasePair
 		if err := decodeStrictRegular(filepath.Join(ctx.Instance.StateDir, "backups", journal.BackupID, "pair.json"), &pair); err != nil {
@@ -1121,14 +1122,16 @@ func promoteExisting(ctx launchContext, store *release.Store, active release.Act
 	switch databaseVersion {
 	case legacyJobCtrlSchemaVersion:
 		if err := temporalQuiescenceProof(activeRuntime, candidateRuntime); err != nil {
-			return restartBeforeBackup(fmt.Errorf("v6-to-v9 upgrade blocked before backup: %w", err))
+			return restartBeforeBackup(fmt.Errorf("v6-to-v10 upgrade blocked before backup: %w", err))
 		}
 	case exactJobCtrlSchemaVersion:
 		// Exact v7 upgrades retain the private v8 step before the additive v9 step.
 	case previousJobCtrlSchemaVersion:
-		// Exact v8 upgrades add v9 only after the stopped-runtime paired backup.
+		// Exact v8 upgrades pass through private v9 before v10.
+	case v9JobCtrlSchemaVersion:
+		// Exact v9 upgrades transfer URL authority after the paired backup.
 	case currentJobCtrlSchemaVersion:
-		// Ordinary exact-v9 release promotion uses the paired lifecycle unchanged.
+		// Ordinary exact-v10 release promotion uses the paired lifecycle unchanged.
 	default:
 		return restartBeforeBackup(fmt.Errorf("unsupported stopped JobCtrl schema version %d", databaseVersion))
 	}
@@ -1157,6 +1160,7 @@ func promoteExisting(ctx launchContext, store *release.Store, active release.Act
 		_ = store.Advance(&journal, release.RollbackRestoring, cause)
 		cleanupV7Candidate(ctx.Instance.StateDir, journal.ID)
 		cleanupV9Candidate(ctx.Instance.StateDir, journal.ID)
+		cleanupV10Candidate(ctx.Instance.StateDir, journal.ID)
 		if stopErr := stop(ctx); stopErr != nil { // Candidate records share the canonical state identity.
 			return fmt.Errorf("%v; refusing paired rollback restore while the candidate could not be quiesced: %w", cause, stopErr)
 		}
@@ -1178,13 +1182,13 @@ func promoteExisting(ctx launchContext, store *release.Store, active release.Act
 	if databaseVersion != currentJobCtrlSchemaVersion {
 		candidatePath, err := sealedV7CandidateBuilder(candidateRuntime, pair, journal.ID)
 		if err != nil {
-			return rollbackFailure(fmt.Errorf("build exact-v9 migration candidate: %w", err))
+			return rollbackFailure(fmt.Errorf("build exact-v10 migration candidate: %w", err))
 		}
 		if err := advance(store, &journal, release.MigrationCandidateReady); err != nil {
 			return rollbackFailure(err)
 		}
 		if err := sealedV7CandidateInstaller(candidateRuntime, candidatePath); err != nil {
-			return rollbackFailure(fmt.Errorf("activate exact-v9 database: %w", err))
+			return rollbackFailure(fmt.Errorf("activate exact-v10 database: %w", err))
 		}
 		if err := advance(store, &journal, release.MigrationActivated); err != nil {
 			return rollbackFailure(err)

--- a/launcher/internal/launcher/lifecycle_test.go
+++ b/launcher/internal/launcher/lifecycle_test.go
@@ -927,7 +927,7 @@ func installLifecycleRelease(t *testing.T, runtime, build string, sequence uint6
 func seedLifecycleSQLitePair(t *testing.T, python, state, marker string) {
 	t.Helper()
 	for _, name := range []string{"jobctrl.db", "temporal.db"} {
-		code := "import pathlib,sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute('create table t(v)'); c.execute('insert into t values (?)',(sys.argv[2],)); c.execute('PRAGMA user_version=9') if pathlib.Path(sys.argv[1]).name == 'jobctrl.db' else None; c.commit()"
+		code := "import pathlib,sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute('create table t(v)'); c.execute('insert into t values (?)',(sys.argv[2],)); c.execute('PRAGMA user_version=10') if pathlib.Path(sys.argv[1]).name == 'jobctrl.db' else None; c.commit()"
 		if output, err := exec.Command(python, "-c", code, filepath.Join(state, name), marker+name).CombinedOutput(); err != nil {
 			t.Fatalf("seed %s: %v %s", name, err, output)
 		}

--- a/launcher/internal/launcher/v10_migration.go
+++ b/launcher/internal/launcher/v10_migration.go
@@ -1,0 +1,154 @@
+package launcher
+
+// Native binding for exact-v10 candidates. Existing v6/v7 installations retain
+// their private identity/compensation migration path through exact v8; exact-v9
+// sources preserve canonical application targets and their lookup aliases.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+type sealedV10CandidateReceipt struct {
+	CandidateDataDigest string `json:"candidate_data_digest"`
+	CandidateSHA256     string `json:"candidate_sha256"`
+	JobCount            int    `json:"job_count"`
+	SchemaVersion       int    `json:"schema_version"`
+	SourceDataDigest    string `json:"source_data_digest"`
+	Status              string `json:"status"`
+	TableCount          int    `json:"table_count"`
+	UserVersion         int64  `json:"user_version"`
+}
+
+func buildSealedV10Candidate(candidate launchContext, pair databasePair, journalID string) (string, error) {
+	sourceVersion, err := pairedV10SourceSchemaVersion(pair)
+	if err != nil {
+		return "", err
+	}
+	source, err := pairedDatabasePath(candidate.Instance.StateDir, pair, "jobctrl.db", sourceVersion)
+	if err != nil {
+		return "", err
+	}
+	path := v10CandidatePath(candidate.Instance.StateDir, journalID)
+	if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+		return "", errors.New("v10 migration candidate path already exists")
+	}
+	python := filepath.Join(candidate.PayloadRoot, "python", "bin", "python3")
+	module := ""
+	arguments := []string{"-I", "-B", "-m"}
+	switch sourceVersion {
+	case legacyJobCtrlSchemaVersion, exactJobCtrlSchemaVersion, previousJobCtrlSchemaVersion:
+		module = "jobctrl.infrastructure.migrations.legacy_to_v10_execute"
+	case v9JobCtrlSchemaVersion:
+		module = "jobctrl.infrastructure.migrations.v9_to_v10_execute"
+	default:
+		return "", errors.New("unsupported source schema for exact-v10 migration")
+	}
+	arguments = append(arguments, module, "--source", source, "--candidate", path)
+	if sourceVersion < v9JobCtrlSchemaVersion {
+		arguments = append(arguments, "--source-version", strconv.FormatInt(sourceVersion, 10))
+	}
+	if sourceVersion == legacyJobCtrlSchemaVersion {
+		arguments = append(arguments, "--migration-at", time.Now().UTC().Format(time.RFC3339Nano))
+	}
+	command := exec.Command(python, arguments...)
+	command.Env = candidate.Environment
+	command.Dir = candidate.Instance.StateDir
+	output, err := command.Output()
+	if err != nil || len(output) > 4096 {
+		cleanupV10Candidate(candidate.Instance.StateDir, journalID)
+		return "", errors.New("sealed exact-v10 candidate execution failed")
+	}
+	var receipt sealedV10CandidateReceipt
+	if err := decodeSingleJSON(output, &receipt); err != nil ||
+		receipt.SchemaVersion != 1 || receipt.Status != "ready" ||
+		receipt.UserVersion != currentJobCtrlSchemaVersion || receipt.JobCount < 0 || receipt.TableCount < 1 ||
+		!validSHA256(receipt.SourceDataDigest) || !validSHA256(receipt.CandidateDataDigest) ||
+		receipt.SourceDataDigest != receipt.CandidateDataDigest || !validSHA256(receipt.CandidateSHA256) {
+		cleanupV10Candidate(candidate.Instance.StateDir, journalID)
+		return "", errors.New("sealed exact-v10 candidate receipt is invalid")
+	}
+	info, statErr := os.Lstat(path)
+	if statErr != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {
+		cleanupV10Candidate(candidate.Instance.StateDir, journalID)
+		return "", errors.New("sealed v10 candidate is not an owner-private regular file")
+	}
+	digest, digestErr := sha256Path(path)
+	if digestErr != nil || digest != receipt.CandidateSHA256 {
+		cleanupV10Candidate(candidate.Instance.StateDir, journalID)
+		return "", errors.New("sealed v10 candidate digest verification failed")
+	}
+	version, versionErr := sqliteUserVersion(python, path)
+	if versionErr != nil || version != currentJobCtrlSchemaVersion {
+		cleanupV10Candidate(candidate.Instance.StateDir, journalID)
+		return "", errors.New("sealed v10 candidate schema verification failed")
+	}
+	return path, nil
+}
+
+func pairedV10SourceSchemaVersion(pair databasePair) (int64, error) {
+	if pair.SchemaVersion != 1 || pair.ID == "" || len(pair.Files) != 2 {
+		return 0, errors.New("migration requires a complete paired backup")
+	}
+	for _, file := range pair.Files {
+		if file.Name != "jobctrl.db" {
+			continue
+		}
+		switch file.SQLiteUserVer {
+		case legacyJobCtrlSchemaVersion, exactJobCtrlSchemaVersion, previousJobCtrlSchemaVersion, v9JobCtrlSchemaVersion:
+			return file.SQLiteUserVer, nil
+		default:
+			return 0, errors.New("paired backup has an unsupported JobCtrl schema version")
+		}
+	}
+	return 0, errors.New("paired backup does not contain jobctrl.db")
+}
+
+func installSealedV10Candidate(candidate launchContext, candidatePath string) error {
+	info, err := os.Lstat(candidatePath)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {
+		return errors.New("v10 activation candidate is not an owner-private regular file")
+	}
+	live := filepath.Join(candidate.Instance.StateDir, "jobctrl.db")
+	liveInfo, err := os.Lstat(live)
+	if err != nil || !liveInfo.Mode().IsRegular() || liveInfo.Mode()&os.ModeSymlink != 0 {
+		return errors.New("live database is not a regular file")
+	}
+	if err := os.Rename(candidatePath, live); err != nil {
+		return errors.New("atomically install exact-v10 database")
+	}
+	if err := cleanupSQLiteSidecars(candidate.Instance.StateDir, "jobctrl.db"); err != nil {
+		return err
+	}
+	python := filepath.Join(candidate.PayloadRoot, "python", "bin", "python3")
+	if version, err := sqliteUserVersion(python, live); err != nil || version != currentJobCtrlSchemaVersion {
+		return errors.New("installed v10 database did not reopen at the exact schema version")
+	}
+	return nil
+}
+
+func v10CandidatePath(stateDir, journalID string) string {
+	digest := sha256.Sum256([]byte(journalID))
+	return filepath.Join(stateDir, ".jobctrl-v10-candidate-"+hex.EncodeToString(digest[:])[:24]+".db")
+}
+
+func vLegacyToV10IntermediatePath(candidatePath string) string {
+	return candidatePath + ".exact-v9-intermediate"
+}
+
+func cleanupV10Candidate(stateDir, journalID string) {
+	candidate := v10CandidatePath(stateDir, journalID)
+	intermediate := vLegacyToV10IntermediatePath(candidate)
+	for _, path := range []string{candidate, intermediate, intermediate + ".exact-v8-intermediate", intermediate + ".exact-v8-intermediate.exact-v7-intermediate"} {
+		_ = os.Remove(path)
+		for _, suffix := range []string{"-journal", "-shm", "-wal"} {
+			_ = os.Remove(path + suffix)
+		}
+	}
+}

--- a/launcher/internal/launcher/v10_migration_test.go
+++ b/launcher/internal/launcher/v10_migration_test.go
@@ -1,0 +1,557 @@
+package launcher
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ebarti/jobctrl/launcher/internal/release"
+)
+
+func fakeV10BuilderContext(t *testing.T, sourceVersion int64) (launchContext, databasePair, string, string) {
+	t.Helper()
+	state, payload := t.TempDir(), t.TempDir()
+	pairID := "pair-v10-builder"
+	pairDir := filepath.Join(state, "backups", pairID)
+	if err := os.MkdirAll(pairDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	jobPath := filepath.Join(pairDir, "jobctrl.db")
+	temporalPath := filepath.Join(pairDir, "temporal.db")
+	if err := os.WriteFile(jobPath, []byte("sealed source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(temporalPath, []byte("temporal source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	jobFile, err := describeDatabase(jobPath, "jobctrl.db", sourceVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	temporalFile, err := describeDatabase(temporalPath, "temporal.db", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pair := databasePair{SchemaVersion: 1, ID: pairID, Files: []databaseFile{jobFile, temporalFile}}
+
+	python := filepath.Join(payload, "python", "bin", "python3")
+	if err := os.MkdirAll(filepath.Dir(python), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	script := `#!/bin/sh
+set -eu
+if [ "$3" = "-m" ]; then
+  [ "$4" = "$JOBCTRL_TEST_EXPECTED_MODULE" ] || exit 41
+  printf '%s\n' "$@" > "$JOBCTRL_TEST_ARGUMENTS"
+  candidate=""
+  previous=""
+  for argument in "$@"; do
+    if [ "$previous" = "--candidate" ]; then candidate="$argument"; fi
+    previous="$argument"
+  done
+  [ -n "$candidate" ] || exit 42
+  umask 077
+  printf '%s' "$JOBCTRL_TEST_CANDIDATE" > "$candidate"
+  printf '%s\n' "$JOBCTRL_TEST_RECEIPT"
+  exit 0
+fi
+if [ "$3" = "-c" ]; then
+  printf '10\n'
+  exit 0
+fi
+exit 43
+`
+	if err := os.WriteFile(python, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	candidateBytes := "sealed exact-v10 candidate"
+	digest := sha256.Sum256([]byte(candidateBytes))
+	receipt, err := json.Marshal(sealedV10CandidateReceipt{
+		CandidateDataDigest: strings.Repeat("a", 64),
+		CandidateSHA256:     hex.EncodeToString(digest[:]),
+		JobCount:            1,
+		SchemaVersion:       1,
+		SourceDataDigest:    strings.Repeat("a", 64),
+		Status:              "ready",
+		TableCount:          118,
+		UserVersion:         currentJobCtrlSchemaVersion,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	module := "jobctrl.infrastructure.migrations.v9_to_v10_execute"
+	if sourceVersion < v9JobCtrlSchemaVersion {
+		module = "jobctrl.infrastructure.migrations.legacy_to_v10_execute"
+	}
+	argumentsPath := filepath.Join(state, "migration-arguments.txt")
+	ctx := launchContext{
+		PayloadRoot: payload,
+		Instance:    instance{StateDir: state},
+		Environment: []string{
+			"JOBCTRL_TEST_EXPECTED_MODULE=" + module,
+			"JOBCTRL_TEST_ARGUMENTS=" + argumentsPath,
+			"JOBCTRL_TEST_CANDIDATE=" + candidateBytes,
+			"JOBCTRL_TEST_RECEIPT=" + string(receipt),
+		},
+	}
+	return ctx, pair, "journal-v10-builder", argumentsPath
+}
+
+func TestBuildSealedV10CandidateDispatchesByPairedSourceVersion(t *testing.T) {
+	for _, sourceVersion := range []int64{
+		legacyJobCtrlSchemaVersion,
+		exactJobCtrlSchemaVersion,
+		previousJobCtrlSchemaVersion,
+		v9JobCtrlSchemaVersion,
+	} {
+		t.Run("source-v"+strconv.FormatInt(sourceVersion, 10), func(t *testing.T) {
+			ctx, pair, journalID, argumentsPath := fakeV10BuilderContext(t, sourceVersion)
+
+			candidate, err := buildSealedV10Candidate(ctx, pair, journalID)
+			if err != nil {
+				t.Fatalf("build exact-v10 candidate: %v", err)
+			}
+			if candidate != v10CandidatePath(ctx.Instance.StateDir, journalID) {
+				t.Fatalf("candidate path = %q", candidate)
+			}
+			arguments, err := os.ReadFile(argumentsPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			hasSourceVersion := strings.Contains(string(arguments), "--source-version")
+			if hasSourceVersion != (sourceVersion < v9JobCtrlSchemaVersion) {
+				t.Fatalf("source-version presence from v%d = %v", sourceVersion, hasSourceVersion)
+			}
+			hasMigrationAt := strings.Contains(string(arguments), "--migration-at")
+			if hasMigrationAt != (sourceVersion == legacyJobCtrlSchemaVersion) {
+				t.Fatalf("migration-at presence from v%d = %v", sourceVersion, hasMigrationAt)
+			}
+			info, err := os.Stat(candidate)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.Mode().Perm()&0o077 != 0 {
+				t.Fatalf("candidate permissions = %#o", info.Mode().Perm())
+			}
+		})
+	}
+}
+
+func TestBuildSealedV10CandidateRejectsUnknownReceiptFieldsAndCleansFile(t *testing.T) {
+	ctx, pair, journalID, _ := fakeV10BuilderContext(t, previousJobCtrlSchemaVersion)
+	for index, value := range ctx.Environment {
+		if strings.HasPrefix(value, "JOBCTRL_TEST_RECEIPT=") {
+			ctx.Environment[index] = `JOBCTRL_TEST_RECEIPT={"candidate_data_digest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","candidate_sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","job_count":1,"schema_version":1,"source_data_digest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","status":"ready","table_count":117,"user_version":10,"unexpected":true}`
+		}
+	}
+
+	if _, err := buildSealedV10Candidate(ctx, pair, journalID); err == nil || !strings.Contains(err.Error(), "receipt is invalid") {
+		t.Fatalf("unbounded receipt passed: %v", err)
+	}
+	if _, err := os.Lstat(v10CandidatePath(ctx.Instance.StateDir, journalID)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("invalid receipt left candidate behind: %v", err)
+	}
+}
+
+func v10CandidateArtifactPaths(stateDir, journalID string) []string {
+	candidate := v10CandidatePath(stateDir, journalID)
+	intermediate := vLegacyToV10IntermediatePath(candidate)
+	basePaths := []string{candidate, intermediate, intermediate + ".exact-v8-intermediate", intermediate + ".exact-v8-intermediate.exact-v7-intermediate"}
+	paths := make([]string, 0, len(basePaths)*4)
+	for _, path := range basePaths {
+		paths = append(paths, path)
+		for _, suffix := range []string{"-journal", "-shm", "-wal"} {
+			paths = append(paths, path+suffix)
+		}
+	}
+	return paths
+}
+
+func TestInterruptedV10MigrationRecoveryRemovesCandidatesIntermediatesAndSidecars(t *testing.T) {
+	for _, stage := range []release.State{release.PolicyPending, release.MigrationCandidateReady, release.MigrationActivated} {
+		t.Run(string(stage), func(t *testing.T) {
+			preserveMigrationSeams(t)
+			fixture := newV6ActivationFixture(t)
+			pair, err := snapshotPair(fixture.ctx, fixture.old)
+			if err != nil {
+				t.Fatal(err)
+			}
+			journal, err := fixture.store.Begin("update", &fixture.old, &fixture.candidate, fixture.candidate.DescriptorSHA256)
+			if err != nil {
+				t.Fatal(err)
+			}
+			journal.BackupID = pair.ID
+			if err := fixture.store.Advance(&journal, stage, nil); err != nil {
+				t.Fatal(err)
+			}
+			artifactPaths := v10CandidateArtifactPaths(fixture.state, journal.ID)
+			for _, path := range artifactPaths {
+				if err := os.WriteFile(path, []byte("owner-private migration artifact"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			oldStarts := 0
+			startReleaseCommand = func(_ launchContext, receipt release.Receipt, journalID string) error {
+				if receipt != fixture.old || journalID != journal.ID {
+					t.Fatalf("interrupted recovery executed unexpected release %#v journal=%q", receipt, journalID)
+				}
+				oldStarts++
+				return nil
+			}
+
+			recovered, err := recoverInterruptedTransition(fixture.ctx, fixture.store)
+			if !recovered || err != nil {
+				t.Fatalf("recover interrupted %s = recovered:%v err:%v", stage, recovered, err)
+			}
+			if oldStarts != 1 {
+				t.Fatalf("interrupted %s old starts = %d", stage, oldStarts)
+			}
+			for _, path := range artifactPaths {
+				if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+					t.Errorf("interrupted %s left migration artifact %q behind: %v", stage, path, err)
+				}
+			}
+			loaded, err := fixture.store.ReadJournal()
+			if err != nil || loaded.State != release.RolledBack || loaded.Resumable() {
+				t.Fatalf("interrupted %s journal = %#v, %v", stage, loaded, err)
+			}
+		})
+	}
+}
+
+func syntheticV10CandidateBuilder(t *testing.T, python string, expectedSourceVersion int64) func(launchContext, databasePair, string) (string, error) {
+	t.Helper()
+	return func(candidate launchContext, pair databasePair, journalID string) (string, error) {
+		source, err := pairedDatabasePath(candidate.Instance.StateDir, pair, "jobctrl.db", expectedSourceVersion)
+		if err != nil {
+			return "", err
+		}
+		path := v10CandidatePath(candidate.Instance.StateDir, journalID)
+		if _, err := sqliteOnlineBackup(python, source, path); err != nil {
+			return "", err
+		}
+		if err := os.Chmod(path, 0o600); err != nil {
+			return "", err
+		}
+		code := "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute('PRAGMA user_version=10'); c.commit(); c.close()"
+		if output, err := exec.Command(python, "-c", code, path).CombinedOutput(); err != nil {
+			return "", errors.New(strings.TrimSpace(string(output)))
+		}
+		return path, nil
+	}
+}
+
+func TestLifecycleMigratesV6V7V8AndV9ToV10AndRestoresExactSourceOnRollback(t *testing.T) {
+	for _, sourceVersion := range []int64{
+		legacyJobCtrlSchemaVersion,
+		exactJobCtrlSchemaVersion,
+		previousJobCtrlSchemaVersion,
+		v9JobCtrlSchemaVersion,
+	} {
+		t.Run("source-v"+strconv.FormatInt(sourceVersion, 10), func(t *testing.T) {
+			preserveMigrationSeams(t)
+			fixture := newV6ActivationFixture(t)
+			setJobCtrlUserVersion(t, fixture.python, fixture.state, sourceVersion)
+			proofs := 0
+			temporalQuiescenceProof = func(_, _ launchContext) error {
+				proofs++
+				return nil
+			}
+			sealedV7CandidateBuilder = syntheticV10CandidateBuilder(t, fixture.python, sourceVersion)
+			sealedV7CandidateInstaller = installSealedV10Candidate
+			candidateStarts, oldStarts := 0, 0
+			startReleaseCommand = func(_ launchContext, receipt release.Receipt, journalID string) error {
+				if journalID == "" {
+					t.Fatal("release start is not bound to a journal")
+				}
+				switch receipt.BuildID {
+				case fixture.candidate.BuildID:
+					candidateStarts++
+					version, err := sqliteUserVersion(fixture.python, filepath.Join(fixture.state, "jobctrl.db"))
+					if err != nil || version != currentJobCtrlSchemaVersion {
+						t.Fatalf("candidate opened schema v%d, err=%v", version, err)
+					}
+				case fixture.old.BuildID:
+					oldStarts++
+				default:
+					t.Fatalf("unexpected release start %#v", receipt)
+				}
+				return nil
+			}
+
+			if err := promoteExisting(fixture.ctx, fixture.store, fixture.active, fixture.candidate.BuildID, "update", io.Discard); err != nil {
+				t.Fatalf("promote v%d to v10: %v", sourceVersion, err)
+			}
+			if candidateStarts != 1 || oldStarts != 0 {
+				t.Fatalf("promotion starts candidate=%d old=%d", candidateStarts, oldStarts)
+			}
+			expectedProofs := 0
+			if sourceVersion == legacyJobCtrlSchemaVersion {
+				expectedProofs = 1
+			}
+			if proofs != expectedProofs {
+				t.Fatalf("v%d Temporal proofs = %d", sourceVersion, proofs)
+			}
+			active, err := fixture.store.ReadActive()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := rollbackExisting(fixture.ctx, fixture.store, active, fixture.old.BuildID, io.Discard); err != nil {
+				t.Fatalf("rollback to v%d: %v", sourceVersion, err)
+			}
+			version, err := sqliteUserVersion(fixture.python, filepath.Join(fixture.state, "jobctrl.db"))
+			if err != nil || version != sourceVersion {
+				t.Fatalf("rollback restored v%d, err=%v; expected v%d", version, err, sourceVersion)
+			}
+		})
+	}
+}
+
+// Cross the production Go/Python boundary using exact, populated source schemas.
+// Startup is intercepted, but admission still runs in both shipped runtimes.
+func TestV10NativeExactSourcesRestorePairedState(t *testing.T) {
+	for _, scenario := range []struct {
+		version       int64
+		failReadiness bool
+	}{{7, false}, {8, false}, {9, false}, {9, true}} {
+		name := "source-v" + strconv.FormatInt(scenario.version, 10)
+		if scenario.failReadiness {
+			name += "-readiness-failure"
+		}
+		t.Run(name, func(t *testing.T) {
+			preserveMigrationSeams(t)
+			python := migrationIntegrationPython(t)
+			fixture := newV6ActivationFixtureWithPython(t, python)
+			database := filepath.Join(fixture.state, "jobctrl.db")
+			if err := os.Remove(database); err != nil {
+				t.Fatal(err)
+			}
+			code := `import importlib,sqlite3,sys
+v=int(sys.argv[2]); c=sqlite3.connect(sys.argv[1])
+m=importlib.import_module('jobctrl.infrastructure.migrations.schema_v'+str(v))
+getattr(m,'create_exact_v'+str(v)+'_schema')(c)
+c.execute("INSERT INTO jobs(tenant_id,job_id,url,title,application_url) VALUES('local','019ed290-3340-7000-8000-000000000891','https://jobs.example/shipped-v6','Preserved title','https://apply.example/legacy')")
+c.execute("INSERT INTO job_enrichments(tenant_id,job_id,current_status,application_url,attempts_json,updated_at) VALUES('local','019ed290-3340-7000-8000-000000000891','completed','https://apply.example/canonical','[]','preserved-time')")
+c.commit(); c.close()`
+			if output, err := exec.Command(python, "-I", "-B", "-c", code, database, strconv.FormatInt(scenario.version, 10)).CombinedOutput(); err != nil {
+				t.Fatalf("seed exact source: %v %s", err, output)
+			}
+			sealedV7CandidateBuilder = buildSealedV10Candidate
+			sealedV7CandidateInstaller = installSealedV10Candidate
+			temporalQuiescenceProof = func(_, _ launchContext) error { t.Fatal("v7+ requested v6 Temporal identity proof"); return nil }
+			assertRestored := func() {
+				t.Helper()
+				pair, err := retainedPairForReceipt(fixture.state, fixture.old)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, expected := range pair.Files {
+					actual, err := sha256Path(filepath.Join(fixture.state, expected.Name))
+					if err != nil || actual != expected.SHA256 {
+						t.Fatalf("restored %s differs from paired backup: %s / %s, %v", expected.Name, actual, expected.SHA256, err)
+					}
+				}
+				code := `import sqlite3,sys
+from jobctrl.infrastructure.migrations import schema_manifest
+c=sqlite3.connect('file:'+sys.argv[1]+'?mode=ro',uri=True)
+v=int(sys.argv[2])
+assert c.execute('PRAGMA user_version').fetchone()[0] == v
+schema_manifest.assert_exact_manifest(c,getattr(schema_manifest,'EXACT_V'+str(v)+'_MANIFEST'))
+assert c.execute('SELECT application_url FROM jobs').fetchone() == ('https://apply.example/legacy',)
+c.close()`
+				if output, err := exec.Command(python, "-I", "-B", "-c", code, database, strconv.FormatInt(scenario.version, 10)).CombinedOutput(); err != nil {
+					t.Fatalf("reopen restored schema: %v %s", err, output)
+				}
+			}
+			candidateStarts, oldStarts := 0, 0
+			startReleaseCommand = func(_ launchContext, receipt release.Receipt, journalID string) error {
+				if journalID == "" {
+					t.Fatal("startup has no journal binding")
+				}
+				if receipt == fixture.old {
+					oldStarts++
+					assertRestored()
+					return nil
+				}
+				if receipt != fixture.candidate {
+					t.Fatalf("unexpected startup %#v", receipt)
+				}
+				candidateStarts++
+				code := `import sys
+from jobctrl.database import open_exact_v10_database,close_connection
+c=open_exact_v10_database(sys.argv[1])
+assert c.execute('PRAGMA user_version').fetchone()[0] == 10
+assert 'application_url' not in {r[1] for r in c.execute('PRAGMA table_info(jobs)')}
+assert tuple(c.execute('SELECT title FROM jobs').fetchone()) == ('Preserved title',)
+assert tuple(c.execute('SELECT application_url,updated_at FROM job_enrichments').fetchone()) == ('https://apply.example/canonical','preserved-time')
+assert {r[0] for r in c.execute('SELECT application_url FROM job_application_locators')} == {'https://apply.example/legacy','https://apply.example/canonical'}
+assert not c.execute('PRAGMA foreign_key_check').fetchall()
+close_connection(sys.argv[1])`
+				if output, err := exec.Command(python, "-I", "-B", "-c", code, database).CombinedOutput(); err != nil {
+					t.Fatalf("native v10 admission/transfer: %v %s", err, output)
+				}
+				if err := reopenMigratedV10WithTypeScriptAPI(database); err != nil {
+					t.Fatal(err)
+				}
+				// Make Temporal restoration observable rather than relying on an unchanged file.
+				code = "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute(\"UPDATE t SET v='candidate-temporal'\"); c.commit(); c.close()"
+				if output, err := exec.Command(python, "-I", "-B", "-c", code, filepath.Join(fixture.state, "temporal.db")).CombinedOutput(); err != nil {
+					t.Fatalf("write owned Temporal marker: %v %s", err, output)
+				}
+				if scenario.failReadiness {
+					return errors.New("synthetic v10 readiness failure")
+				}
+				return nil
+			}
+			err := promoteExisting(fixture.ctx, fixture.store, fixture.active, fixture.candidate.BuildID, "update", io.Discard)
+			journal, journalErr := fixture.store.ReadJournal()
+			if journalErr != nil {
+				t.Fatal(journalErr)
+			}
+			migrationJournalID := journal.ID
+			if scenario.failReadiness {
+				if err == nil || !strings.Contains(err.Error(), "synthetic v10 readiness failure") {
+					t.Fatalf("readiness failure result: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("native promotion: %v", err)
+				}
+				active, err := fixture.store.ReadActive()
+				if err != nil || active.Receipt != fixture.candidate {
+					t.Fatalf("candidate pointer: %#v %v", active, err)
+				}
+				if err := rollbackExisting(fixture.ctx, fixture.store, active, fixture.old.BuildID, io.Discard); err != nil {
+					t.Fatalf("explicit rollback: %v", err)
+				}
+			}
+			active, err := fixture.store.ReadActive()
+			if err != nil || active.Receipt != fixture.old || candidateStarts != 1 || oldStarts != 1 {
+				t.Fatalf("final pointer=%#v candidate=%d old=%d err=%v", active, candidateStarts, oldStarts, err)
+			}
+			assertRestored()
+			for _, path := range v10CandidateArtifactPaths(fixture.state, migrationJournalID) {
+				if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+					t.Errorf("left migration artifact %s: %v", path, err)
+				}
+			}
+		})
+	}
+}
+
+func TestV10FreshRuntimePromotesWithoutMigration(t *testing.T) {
+	preserveMigrationSeams(t)
+	python := migrationIntegrationPython(t)
+	fixture := newV6ActivationFixtureWithPython(t, python)
+	database := filepath.Join(fixture.state, "jobctrl.db")
+	if err := os.Remove(database); err != nil {
+		t.Fatal(err)
+	}
+	code := `import sys
+from jobctrl.database import create_exact_v10_database,close_connection
+c=create_exact_v10_database(sys.argv[1])
+assert c.execute('PRAGMA user_version').fetchone()[0] == 10
+assert 'application_url' not in {r[1] for r in c.execute('PRAGMA table_info(jobs)')}
+close_connection(sys.argv[1])`
+	if output, err := exec.Command(python, "-I", "-B", "-c", code, database).CombinedOutput(); err != nil {
+		t.Fatalf("fresh v10 creation: %v %s", err, output)
+	}
+	sealedV7CandidateBuilder = func(_ launchContext, _ databasePair, _ string) (string, error) {
+		t.Fatal("fresh v10 attempted migration")
+		return "", nil
+	}
+	starts := 0
+	startReleaseCommand = func(_ launchContext, receipt release.Receipt, _ string) error {
+		if receipt != fixture.candidate {
+			t.Fatalf("unexpected fresh startup %#v", receipt)
+		}
+		starts++
+		code := "import sys; from jobctrl.database import open_exact_v10_database,close_connection; open_exact_v10_database(sys.argv[1]); close_connection(sys.argv[1])"
+		if output, err := exec.Command(python, "-I", "-B", "-c", code, database).CombinedOutput(); err != nil {
+			t.Fatalf("fresh v10 admission: %v %s", err, output)
+		}
+		return nil
+	}
+	if err := promoteExisting(fixture.ctx, fixture.store, fixture.active, fixture.candidate.BuildID, "update", io.Discard); err != nil || starts != 1 {
+		t.Fatalf("fresh promotion: starts=%d err=%v", starts, err)
+	}
+}
+
+func TestBuildSealedV10CandidateRejectsBrokenSeal(t *testing.T) {
+	for _, field := range []string{"source_data_digest", "candidate_sha256", "user_version", "oversized"} {
+		t.Run(field, func(t *testing.T) {
+			ctx, pair, journalID, _ := fakeV10BuilderContext(t, v9JobCtrlSchemaVersion)
+			for index, value := range ctx.Environment {
+				if !strings.HasPrefix(value, "JOBCTRL_TEST_RECEIPT=") {
+					continue
+				}
+				var receipt map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimPrefix(value, "JOBCTRL_TEST_RECEIPT=")), &receipt); err != nil {
+					t.Fatal(err)
+				}
+				if field == "user_version" {
+					receipt[field] = 9
+				} else {
+					receipt[field] = strings.Repeat("b", 64)
+				}
+				encoded, err := json.Marshal(receipt)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if field == "oversized" {
+					encoded = []byte(strings.Repeat(" ", 4097) + string(encoded))
+				}
+				ctx.Environment[index] = "JOBCTRL_TEST_RECEIPT=" + string(encoded)
+			}
+			if _, err := buildSealedV10Candidate(ctx, pair, journalID); err == nil {
+				t.Fatal("invalid seal accepted")
+			}
+			if _, err := os.Lstat(v10CandidatePath(ctx.Instance.StateDir, journalID)); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("invalid seal left candidate: %v", err)
+			}
+		})
+	}
+}
+
+func TestV10NativeExecutorRejectsMerelyStampedV9WithoutChangingPair(t *testing.T) {
+	python := migrationIntegrationPython(t)
+	fixture := newV6ActivationFixtureWithPython(t, python)
+	// The generic fixture contains only t(v), deliberately not the exact v9 shape.
+	setJobCtrlUserVersion(t, python, fixture.state, 9)
+	pair, err := snapshotPair(fixture.ctx, fixture.old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := lifecycleDatabaseDigests(t, fixture.state)
+	candidate := fixture.ctx
+	candidate.PayloadRoot = filepath.Join(fixture.runtime, "releases", fixture.candidate.BuildID, "payload")
+	journalID := "reject-malformed-v9"
+	if _, err := buildSealedV10Candidate(candidate, pair, journalID); err == nil {
+		t.Fatal("merely stamped v9 source was admitted")
+	}
+	for name, expected := range before {
+		actual, err := sha256Path(filepath.Join(fixture.state, name))
+		if err != nil || actual != expected {
+			t.Fatalf("rejected migration changed live %s: %s / %s, %v", name, actual, expected, err)
+		}
+	}
+	for _, expected := range pair.Files {
+		actual, err := sha256Path(filepath.Join(fixture.state, "backups", pair.ID, expected.Name))
+		if err != nil || actual != expected.SHA256 {
+			t.Fatalf("rejected migration changed paired %s: %s / %s, %v", expected.Name, actual, expected.SHA256, err)
+		}
+	}
+	for _, path := range v10CandidateArtifactPaths(fixture.state, journalID) {
+		if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("rejected source left artifact %s: %v", path, err)
+		}
+	}
+}

--- a/launcher/internal/launcher/v6_migration.go
+++ b/launcher/internal/launcher/v6_migration.go
@@ -26,15 +26,16 @@ const (
 	legacyJobCtrlSchemaVersion   = int64(6)
 	exactJobCtrlSchemaVersion    = int64(7)
 	previousJobCtrlSchemaVersion = int64(8)
-	currentJobCtrlSchemaVersion  = int64(9)
+	v9JobCtrlSchemaVersion       = int64(9)
+	currentJobCtrlSchemaVersion  = int64(10)
 )
 
 var (
 	temporalQuiescenceProof = proveStoppedTemporalQuiescence
 	// These seam names are retained for the existing lifecycle fault-injection
-	// matrix. Production builds and installs the current exact-v9 candidate.
-	sealedV7CandidateBuilder   = buildSealedV9Candidate
-	sealedV7CandidateInstaller = installSealedV9Candidate
+	// matrix. Production builds and installs the current exact-v10 candidate.
+	sealedV7CandidateBuilder   = buildSealedV10Candidate
+	sealedV7CandidateInstaller = installSealedV10Candidate
 )
 
 type temporalQuiescenceReceipt struct {

--- a/launcher/internal/launcher/v6_migration_test.go
+++ b/launcher/internal/launcher/v6_migration_test.go
@@ -86,7 +86,7 @@ func migrationIntegrationPython(t *testing.T) string {
 			t.Skip("python3 unavailable for the native migration integration test")
 		}
 	}
-	probe := exec.Command(python, "-I", "-B", "-c", "import jobctrl.infrastructure.migrations.legacy_to_v9_execute")
+	probe := exec.Command(python, "-I", "-B", "-c", "import jobctrl.infrastructure.migrations.legacy_to_v10_execute")
 	if output, err := probe.CombinedOutput(); err != nil {
 		if os.Getenv("CI") != "" || os.Getenv("JOBCTRL_MIGRATION_TEST_PYTHON") != "" {
 			t.Fatalf("native migration integration Python is not provisioned: %v %s", err, output)
@@ -112,12 +112,12 @@ create_shipped_v6_database(pathlib.Path(sys.argv[2]))`
 	}
 }
 
-func reopenMigratedV9WithCandidateRuntime(ctx launchContext, database string) error {
+func reopenMigratedV10WithCandidateRuntime(ctx launchContext, database string) error {
 	python := filepath.Join(ctx.PayloadRoot, "python", "bin", "python3")
 	code := `import sys
-from jobctrl.database import close_connection, open_exact_v9_database
+from jobctrl.database import close_connection, open_exact_v10_database
 path=sys.argv[1]
-connection=open_exact_v9_database(path)
+connection=open_exact_v10_database(path)
 try:
     row=connection.execute("SELECT job_id,url FROM jobs").fetchone()
     if row is None or not row[0] or row[0] == row[1] or row[1] != "https://jobs.example/shipped-v6":
@@ -127,12 +127,12 @@ finally:
 	command := exec.Command(python, "-I", "-B", "-c", code, database)
 	command.Env = ctx.Environment
 	if output, err := command.CombinedOutput(); err != nil {
-		return fmt.Errorf("candidate runtime failed to reopen exact v9: %w: %s", err, output)
+		return fmt.Errorf("candidate runtime failed to reopen exact v10: %w: %s", err, output)
 	}
 	return nil
 }
 
-func reopenMigratedV9WithTypeScriptAPI(database string) error {
+func reopenMigratedV10WithTypeScriptAPI(database string) error {
 	apiRoot, err := filepath.Abs(filepath.Join("..", "..", "..", "apps", "api"))
 	if err != nil {
 		return err
@@ -145,11 +145,11 @@ func reopenMigratedV9WithTypeScriptAPI(database string) error {
 			return fmt.Errorf("locate Node.js for TypeScript API reopen probe: %w", err)
 		}
 	}
-	probe := filepath.Join(apiRoot, "test", "support", "reopen-exact-v9.ts")
+	probe := filepath.Join(apiRoot, "test", "support", "reopen-exact-v10.ts")
 	command := exec.Command(runner, "--import", "tsx", probe, database)
 	command.Dir = apiRoot
 	if output, err := command.CombinedOutput(); err != nil {
-		return fmt.Errorf("TypeScript API failed to reopen exact v9: %w: %s", err, output)
+		return fmt.Errorf("TypeScript API failed to reopen exact v10: %w: %s", err, output)
 	}
 	return nil
 }
@@ -375,7 +375,7 @@ func TestV6ToV7ActivationMigratesAndExplicitRollbackReopensV6Pair(t *testing.T) 
 	}
 }
 
-func TestV6ToV9NativePrivateExecutorMigratesAndRollsBackRealSchema(t *testing.T) {
+func TestV6ToV10NativePrivateExecutorMigratesAndRollsBackRealSchema(t *testing.T) {
 	preserveMigrationSeams(t)
 	python := migrationIntegrationPython(t)
 	fixture := newV6ActivationFixtureWithPython(t, python)
@@ -384,19 +384,19 @@ func TestV6ToV9NativePrivateExecutorMigratesAndRollsBackRealSchema(t *testing.T)
 		t.Fatal(err)
 	}
 	createShippedV6Fixture(t, python, database)
-	next := installLifecycleRelease(t, fixture.runtime, "local-v9-next-build-0003", 3, python)
+	next := installLifecycleRelease(t, fixture.runtime, "local-v10-next-build-0003", 3, python)
 
 	// Temporal quiescence has its own real gated-process regression below. This
 	// test keeps that network boundary closed while crossing the production Go
-	// v9 candidate builder, private Python module, atomic install, runtime reopen,
+	// v10 candidate builder, private Python module, atomic install, runtime reopen,
 	// retained-pair rollback, and prior-runtime reopen in one transaction.
 	temporalQuiescenceProof = func(_, _ launchContext) error { return nil }
 	migrationBuilds := 0
 	sealedV7CandidateBuilder = func(candidate launchContext, pair databasePair, journalID string) (string, error) {
 		migrationBuilds++
-		return buildSealedV9Candidate(candidate, pair, journalID)
+		return buildSealedV10Candidate(candidate, pair, journalID)
 	}
-	sealedV7CandidateInstaller = installSealedV9Candidate
+	sealedV7CandidateInstaller = installSealedV10Candidate
 	candidateStarts, oldStarts := 0, 0
 	startReleaseCommand = func(base launchContext, receipt release.Receipt, journalID string) error {
 		if journalID == "" {
@@ -410,10 +410,10 @@ func TestV6ToV9NativePrivateExecutorMigratesAndRollsBackRealSchema(t *testing.T)
 		switch receipt.BuildID {
 		case fixture.candidate.BuildID, next.BuildID:
 			candidateStarts++
-			if err := reopenMigratedV9WithCandidateRuntime(runtimeContext, database); err != nil {
+			if err := reopenMigratedV10WithCandidateRuntime(runtimeContext, database); err != nil {
 				return err
 			}
-			return reopenMigratedV9WithTypeScriptAPI(database)
+			return reopenMigratedV10WithTypeScriptAPI(database)
 		case fixture.old.BuildID:
 			oldStarts++
 			return reopenRestoredV6WithPriorRuntime(runtimeContext, database)
@@ -424,11 +424,11 @@ func TestV6ToV9NativePrivateExecutorMigratesAndRollsBackRealSchema(t *testing.T)
 
 	var output bytes.Buffer
 	if err := promoteExisting(fixture.ctx, fixture.store, fixture.active, fixture.candidate.BuildID, "update", &output); err != nil {
-		t.Fatalf("native v6-to-v9 activation: %v", err)
+		t.Fatalf("native v6-to-v10 activation: %v", err)
 	}
 	active, err := fixture.store.ReadActive()
 	if err != nil || active.Receipt != fixture.candidate || candidateStarts != 1 || oldStarts != 0 || migrationBuilds != 1 {
-		t.Fatalf("native v9 activation = active:%#v candidate starts:%d old starts:%d migration builds:%d err:%v", active, candidateStarts, oldStarts, migrationBuilds, err)
+		t.Fatalf("native v10 activation = active:%#v candidate starts:%d old starts:%d migration builds:%d err:%v", active, candidateStarts, oldStarts, migrationBuilds, err)
 	}
 	pair, err := retainedPairForReceipt(fixture.state, fixture.old)
 	if err != nil {
@@ -450,11 +450,11 @@ func TestV6ToV9NativePrivateExecutorMigratesAndRollsBackRealSchema(t *testing.T)
 		t.Fatalf("paired backup did not preserve the shipped v6 source: %v", err)
 	}
 	if err := promoteExisting(fixture.ctx, fixture.store, active, next.BuildID, "update", &output); err != nil {
-		t.Fatalf("native exact-v9 promotion: %v", err)
+		t.Fatalf("native exact-v10 promotion: %v", err)
 	}
 	active, err = fixture.store.ReadActive()
 	if err != nil || active.Receipt != next || candidateStarts != 2 || oldStarts != 0 || migrationBuilds != 1 {
-		t.Fatalf("native exact-v9 promotion = active:%#v candidate starts:%d old starts:%d migration builds:%d err:%v", active, candidateStarts, oldStarts, migrationBuilds, err)
+		t.Fatalf("native exact-v10 promotion = active:%#v candidate starts:%d old starts:%d migration builds:%d err:%v", active, candidateStarts, oldStarts, migrationBuilds, err)
 	}
 
 	if err := rollbackExisting(fixture.ctx, fixture.store, active, fixture.old.BuildID, &output); err != nil {
@@ -469,7 +469,7 @@ func TestV6ToV9NativePrivateExecutorMigratesAndRollsBackRealSchema(t *testing.T)
 	}
 }
 
-func TestV6ToV9NativeVerificationFailureRestoresAndReopensV6(t *testing.T) {
+func TestV6ToV10NativeVerificationFailureRestoresAndReopensV6(t *testing.T) {
 	preserveMigrationSeams(t)
 	python := migrationIntegrationPython(t)
 	fixture := newV6ActivationFixtureWithPython(t, python)
@@ -481,7 +481,7 @@ func TestV6ToV9NativeVerificationFailureRestoresAndReopensV6(t *testing.T) {
 
 	temporalQuiescenceProof = func(_, _ launchContext) error { return nil }
 	sealedV7CandidateBuilder = postStampFailureCandidateBuilder()
-	sealedV7CandidateInstaller = installSealedV9Candidate
+	sealedV7CandidateInstaller = installSealedV10Candidate
 	candidateStarts, oldStarts := 0, 0
 	startReleaseCommand = func(base launchContext, receipt release.Receipt, journalID string) error {
 		if journalID == "" {
@@ -498,10 +498,10 @@ func TestV6ToV9NativeVerificationFailureRestoresAndReopensV6(t *testing.T) {
 			return reopenRestoredV6WithPriorRuntime(runtimeContext, database)
 		case fixture.candidate.BuildID:
 			candidateStarts++
-			if err := reopenMigratedV9WithCandidateRuntime(runtimeContext, database); err != nil {
+			if err := reopenMigratedV10WithCandidateRuntime(runtimeContext, database); err != nil {
 				return err
 			}
-			return reopenMigratedV9WithTypeScriptAPI(database)
+			return reopenMigratedV10WithTypeScriptAPI(database)
 		default:
 			return fmt.Errorf("unexpected release start %s", receipt.BuildID)
 		}
@@ -531,7 +531,7 @@ func TestV6ToV9NativeVerificationFailureRestoresAndReopensV6(t *testing.T) {
 		t.Fatalf("post-stamp rollback did not restore exact v6 bytes: backup=%s restored=%s err=%v", backupDigest, restoredDigest, err)
 	}
 
-	sealedV7CandidateBuilder = buildSealedV9Candidate
+	sealedV7CandidateBuilder = buildSealedV10Candidate
 	if err := promoteExisting(fixture.ctx, fixture.store, active, fixture.candidate.BuildID, "update", &output); err != nil {
 		t.Fatalf("native retry after post-stamp failure: %v", err)
 	}

--- a/launcher/internal/launcher/v9_migration.go
+++ b/launcher/internal/launcher/v9_migration.go
@@ -68,7 +68,7 @@ func buildSealedV9Candidate(candidate launchContext, pair databasePair, journalI
 	var receipt sealedV9CandidateReceipt
 	if err := decodeSingleJSON(output, &receipt); err != nil ||
 		receipt.SchemaVersion != 1 || receipt.Status != "ready" ||
-		receipt.UserVersion != currentJobCtrlSchemaVersion || receipt.JobCount < 0 || receipt.TableCount < 1 ||
+		receipt.UserVersion != v9JobCtrlSchemaVersion || receipt.JobCount < 0 || receipt.TableCount < 1 ||
 		!validSHA256(receipt.SourceDataDigest) || !validSHA256(receipt.CandidateDataDigest) ||
 		receipt.SourceDataDigest != receipt.CandidateDataDigest || !validSHA256(receipt.CandidateSHA256) {
 		cleanupV9Candidate(candidate.Instance.StateDir, journalID)
@@ -85,7 +85,7 @@ func buildSealedV9Candidate(candidate launchContext, pair databasePair, journalI
 		return "", errors.New("sealed v9 candidate digest verification failed")
 	}
 	version, versionErr := sqliteUserVersion(python, path)
-	if versionErr != nil || version != currentJobCtrlSchemaVersion {
+	if versionErr != nil || version != v9JobCtrlSchemaVersion {
 		cleanupV9Candidate(candidate.Instance.StateDir, journalID)
 		return "", errors.New("sealed v9 candidate schema verification failed")
 	}
@@ -127,7 +127,7 @@ func installSealedV9Candidate(candidate launchContext, candidatePath string) err
 		return err
 	}
 	python := filepath.Join(candidate.PayloadRoot, "python", "bin", "python3")
-	if version, err := sqliteUserVersion(python, live); err != nil || version != currentJobCtrlSchemaVersion {
+	if version, err := sqliteUserVersion(python, live); err != nil || version != v9JobCtrlSchemaVersion {
 		return errors.New("installed v9 database did not reopen at the exact schema version")
 	}
 	return nil

--- a/launcher/internal/launcher/v9_migration_test.go
+++ b/launcher/internal/launcher/v9_migration_test.go
@@ -82,7 +82,7 @@ exit 43
 		SourceDataDigest:    strings.Repeat("a", 64),
 		Status:              "ready",
 		TableCount:          117,
-		UserVersion:         currentJobCtrlSchemaVersion,
+		UserVersion:         v9JobCtrlSchemaVersion,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -274,7 +274,7 @@ func TestLifecycleMigratesV6V7AndV8ToV9AndRestoresExactSourceOnRollback(t *testi
 				case fixture.candidate.BuildID:
 					candidateStarts++
 					version, err := sqliteUserVersion(fixture.python, filepath.Join(fixture.state, "jobctrl.db"))
-					if err != nil || version != currentJobCtrlSchemaVersion {
+					if err != nil || version != v9JobCtrlSchemaVersion {
 						t.Fatalf("candidate opened schema v%d, err=%v", version, err)
 					}
 				case fixture.old.BuildID:

--- a/packages/domain-types/test/fixtures/application_url_authority.json
+++ b/packages/domain-types/test/fixtures/application_url_authority.json
@@ -1,0 +1,68 @@
+{
+  "cases": [
+    {
+      "name": "legacy-only",
+      "jobId": "89100000-0000-4000-8000-000000000001",
+      "legacy": "https://apply.example.test/legacy",
+      "enrichment": null,
+      "expected": "https://apply.example.test/legacy"
+    },
+    {
+      "name": "canonical-wins",
+      "jobId": "89100000-0000-4000-8000-000000000002",
+      "legacy": "https://apply.example.test/retained-alias",
+      "enrichment": {
+        "applicationUrl": "https://apply.example.test/canonical",
+        "status": "enriched"
+      },
+      "expected": "https://apply.example.test/canonical"
+    },
+    {
+      "name": "empty-canonical",
+      "jobId": "89100000-0000-4000-8000-000000000003",
+      "legacy": "https://apply.example.test/promoted",
+      "enrichment": {
+        "applicationUrl": "",
+        "status": "failed"
+      },
+      "expected": "https://apply.example.test/promoted"
+    },
+    {
+      "name": "missing-target",
+      "jobId": "89100000-0000-4000-8000-000000000004",
+      "legacy": null,
+      "enrichment": null,
+      "expected": null
+    },
+    {
+      "name": "canonical-only",
+      "jobId": "89100000-0000-4000-8000-000000000005",
+      "legacy": "",
+      "enrichment": {
+        "applicationUrl": "https://apply.example.test/only-canonical",
+        "status": "enriched"
+      },
+      "expected": "https://apply.example.test/only-canonical"
+    },
+    {
+      "name": "verbatim-url",
+      "jobId": "89100000-0000-4000-8000-000000000006",
+      "legacy": "https://apply.example.test/Case?token=A%2FB&x=1#form",
+      "enrichment": {
+        "applicationUrl": null,
+        "status": "pending"
+      },
+      "expected": "https://apply.example.test/Case?token=A%2FB&x=1#form"
+    },
+    {
+      "name": "empty-target",
+      "jobId": "89100000-0000-4000-8000-000000000007",
+      "legacy": null,
+      "enrichment": {
+        "applicationUrl": "",
+        "status": "pending"
+      },
+      "expected": null
+    }
+  ]
+}

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from jobctrl.config import DB_PATH, DEFAULTS
 from jobctrl.infrastructure.migrations.schema_manifest import (
-    EXACT_V9_MANIFEST,
+    EXACT_V10_MANIFEST,
     SchemaManifestError,
     assert_exact_manifest,
     schema_dump,
@@ -32,8 +32,8 @@ from jobctrl.scoring.eligibility_sql import (
 # Schema version stamped into the SQLite ``user_version`` header. Runtime opens
 # only this exact schema and refuses databases written by newer code. The only
 # supported upgrades are explicit stopped-runtime cutovers. Older v6/v7
-# databases retain their identity-to-v8 path before the additive v9 step; exact
-# v8 databases receive only the optional position-summary column.
+# databases retain their identity-to-v8 path before the additive v9 step; v10
+# preserves application URL aliases and removes the legacy jobs URL column.
 #
 # v2 (Contact & Outreach): generic ``entity_kind``/``entity_ref`` columns on
 # ``job_events`` so contact-only events carry honest identity without
@@ -52,7 +52,7 @@ from jobctrl.scoring.eligibility_sql import (
 # without changing any v7 table. v9 adds the optional per-position summary to
 # Candidate Profile experience rows. Posting URLs remain unique locators,
 # never aggregate identity.
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -187,24 +187,24 @@ def _assert_schema_version_supported(
     return current
 
 
-def create_exact_v9_database(
+def create_exact_v10_database(
     db_path: Path | str | None = None,
 ) -> sqlite3.Connection:
-    """Create a brand-new database directly from the exact v9 schema."""
+    """Create a brand-new database directly from the exact v10 schema."""
     path = Path(db_path or DB_PATH)
     if path.exists():
         raise FileExistsError(
-            f"exact v9 creation requires a missing database path, found {path}"
+            f"exact v10 creation requires a missing database path, found {path}"
         )
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = get_connection(path)
     try:
         if schema_dump(conn):
-            raise SchemaManifestError("fresh v9 creation found pre-existing schema")
+            raise SchemaManifestError("fresh v10 creation found pre-existing schema")
 
-        from jobctrl.infrastructure.migrations.schema_v9 import create_exact_v9_schema
+        from jobctrl.infrastructure.migrations.schema_v10 import create_exact_v10_schema
 
-        create_exact_v9_schema(conn)
+        create_exact_v10_schema(conn)
         conn.commit()
         return conn
     except BaseException:
@@ -219,36 +219,36 @@ def create_exact_v9_database(
         raise
 
 
-def open_exact_v9_database(
+def open_exact_v10_database(
     db_path: Path | str | None = None,
 ) -> sqlite3.Connection:
-    """Open an existing exact-v9 database without performing any writes."""
+    """Open an existing exact-v10 database without performing any writes."""
     path = Path(db_path or DB_PATH)
     if not path.exists():
         raise FileNotFoundError(f"No database to open at {path}")
     conn = get_connection(path, enable_wal=False)
     current_version = _assert_schema_version_supported(conn)
-    if current_version in (6, 7, 8):
+    if current_version in (6, 7, 8, 9):
         raise SchemaMigrationRequiredError(
             f"JobCtrl database is schema v{current_version}. Run `jobctrl update` so "
             "the native lifecycle can stop JobCtrl, create the paired backup, "
-            "and activate schema v9 before starting the runtime."
+            "and activate schema v10 before starting the runtime."
         )
     if current_version != SCHEMA_VERSION:
         raise SchemaMigrationRequiredError(
-            "JobCtrl can only open the exact schema v9 at runtime; "
+            "JobCtrl can only open the exact schema v10 at runtime; "
             f"found schema version {current_version}."
         )
-    assert_exact_manifest(conn, EXACT_V9_MANIFEST)
+    assert_exact_manifest(conn, EXACT_V10_MANIFEST)
     return conn
 
 
 def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
-    """Create a missing v9 database or read-only validate an existing one."""
+    """Create a missing v10 database or read-only validate an existing one."""
     path = Path(db_path or DB_PATH)
     if not path.exists():
-        return create_exact_v9_database(path)
-    return open_exact_v9_database(path)
+        return create_exact_v10_database(path)
+    return open_exact_v10_database(path)
 
 
 def ensure_projection_tables_in_db(conn: sqlite3.Connection | None = None) -> list[str]:
@@ -256,7 +256,7 @@ def ensure_projection_tables_in_db(conn: sqlite3.Connection | None = None) -> li
 
     Defers to ``infrastructure.projections.sqlite_projection_store`` so the
     compatibility schema helper stays next to its adapter. Runtime ``init_db``
-    creates or admits the exact v9 manifest instead; this helper is for explicit
+    creates or admits the exact v10 manifest instead; this helper is for explicit
     legacy-schema preparation. The import is local to keep
     ``database.py`` free of infrastructure imports at module-load time.
     """

--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -621,7 +621,6 @@ def _refresh_existing_jobspy_job(
             site = COALESCE(NULLIF(?, ''), site),
             strategy = COALESCE(NULLIF(?, ''), strategy),
             full_description = COALESCE(NULLIF(?, ''), full_description),
-            application_url = COALESCE(NULLIF(?, ''), application_url),
             detail_scraped_at = COALESCE(?, detail_scraped_at)
         WHERE tenant_id = ? AND job_id = ?
         """,
@@ -634,12 +633,28 @@ def _refresh_existing_jobspy_job(
             site,
             strategy,
             full_description,
-            application_url,
             detail_scraped_at,
             str(LOCAL_TENANT),
             str(identity.job_id),
         ),
     )
+    if application_url:
+        # A discovery lead can fill an absent target without replacing accepted
+        # enrichment. Retain every observed endpoint for tenant-scoped lookup.
+        conn.execute(
+            """INSERT INTO job_enrichments (
+                 tenant_id, job_id, current_status, application_url, updated_at
+               ) VALUES (?, ?, 'pending', ?, ?)
+               ON CONFLICT (tenant_id, job_id) DO UPDATE SET
+                 application_url = COALESCE(NULLIF(job_enrichments.application_url, ''), excluded.application_url)
+            """,
+            (str(LOCAL_TENANT), str(identity.job_id), application_url, updated_at),
+        )
+        conn.execute(
+            """INSERT INTO job_application_locators (tenant_id, job_id, application_url)
+               VALUES (?, ?, ?) ON CONFLICT DO NOTHING""",
+            (str(LOCAL_TENANT), str(identity.job_id), application_url),
+        )
     if cursor.rowcount:
         from jobctrl.state import record_job_event
 

--- a/workers/automation/src/jobctrl/discovery/workday.py
+++ b/workers/automation/src/jobctrl/discovery/workday.py
@@ -501,18 +501,31 @@ def _update_detail_columns(conn: sqlite3.Connection, job: dict, url: str, now: s
         """
         UPDATE jobs
         SET full_description = COALESCE(?, full_description),
-            application_url = COALESCE(?, application_url),
             detail_scraped_at = COALESCE(?, detail_scraped_at),
             detail_error = COALESCE(?, detail_error)
-        WHERE url = ?
+        WHERE tenant_id = ? AND url = ?
         """,
         (
             full_description,
-            url,
             now if full_description else None,
             job.get("detail_error"),
+            str(LOCAL_TENANT),
             url,
         ),
+    )
+    conn.execute(
+        """INSERT INTO job_enrichments (tenant_id, job_id, current_status, application_url, updated_at)
+           SELECT tenant_id, job_id, 'pending', ?, ? FROM jobs WHERE tenant_id = ? AND url = ?
+           ON CONFLICT (tenant_id, job_id) DO UPDATE SET
+             application_url = COALESCE(NULLIF(job_enrichments.application_url, ''), excluded.application_url)
+        """,
+        (url, now, str(LOCAL_TENANT), url),
+    )
+    conn.execute(
+        """INSERT INTO job_application_locators (tenant_id, job_id, application_url)
+           SELECT tenant_id, job_id, ? FROM jobs WHERE tenant_id = ? AND url = ?
+           ON CONFLICT DO NOTHING""",
+        (url, str(LOCAL_TENANT), url),
     )
 
 

--- a/workers/automation/src/jobctrl/domain/apply/repeat_application.py
+++ b/workers/automation/src/jobctrl/domain/apply/repeat_application.py
@@ -362,7 +362,6 @@ def _job_identity(
                     FROM job_enrichments je
                    WHERE je.tenant_id = ? AND je.job_id = j.job_id
                    ORDER BY je.updated_at DESC LIMIT 1),
-                 j.application_url,
                  j.url
                ) AS application_url
          FROM jobs j

--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -314,9 +314,8 @@ def resolve_all_urls(conn: sqlite3.Connection) -> dict:
         else:
             failed += 1
 
-    # Note: legacy ``jobs.application_url`` is NO LONGER updated here.
-    # New enrichment writes target ``job_enrichments.application_url``;
-    # the legacy column is read-only fallback for un-backfilled rows.
+    # Application targets belong to ``job_enrichments.application_url``;
+    # changing a posting locator does not rewrite the application target.
     conn.commit()
     return {
         "resolved": resolved,
@@ -742,9 +741,10 @@ def _discovery_description_fallback(
     """Return discovery-owned content that is usable as enrichment fallback."""
     row = conn.execute(
         """
-        SELECT full_description, description, application_url
-        FROM jobs
-        WHERE tenant_id = ? AND job_id = ?
+        SELECT j.full_description, j.description, e.application_url
+        FROM jobs j LEFT JOIN job_enrichments e
+          ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id
+        WHERE j.tenant_id = ? AND j.job_id = ?
         """,
         (str(tenant_id), str(job_id)),
     ).fetchone()

--- a/workers/automation/src/jobctrl/infrastructure/enrichment/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/enrichment/sqlite_repository.py
@@ -173,6 +173,14 @@ class SqliteEnrichmentRepository:
                 enrichment.updated_at,
             ),
         )
+        if enrichment.application_url is not None:
+            self._conn.execute(
+                """
+                INSERT INTO job_application_locators (tenant_id, job_id, application_url)
+                VALUES (?, ?, ?) ON CONFLICT DO NOTHING
+                """,
+                (str(enrichment.tenant_id), str(job_id), enrichment.application_url.value),
+            )
         if commit:
             self._conn.commit()
 

--- a/workers/automation/src/jobctrl/infrastructure/gmail/feedback.py
+++ b/workers/automation/src/jobctrl/infrastructure/gmail/feedback.py
@@ -15,7 +15,9 @@ from pathlib import Path
 from typing import Any, Protocol
 from urllib.parse import urlparse
 
+from jobctrl.database import close_connection, open_exact_v10_database
 from jobctrl.infrastructure.gmail.client import GmailClient
+from jobctrl.infrastructure.migrations.schema_manifest import EXACT_V10_MANIFEST, SchemaManifestError, assert_exact_manifest
 
 TENANT_ID = "local"
 PROVIDER = "gmail"
@@ -123,8 +125,7 @@ def scan_gmail_feedback(
         default=DEFAULT_WINDOW_DAYS,
     )
 
-    conn = sqlite3.connect(str(db_path))
-    conn.row_factory = sqlite3.Row
+    conn = open_exact_v10_database(db_path)
     conn.execute("PRAGMA busy_timeout=10000")
     gmail = client or GmailClient()
     try:
@@ -241,108 +242,14 @@ def scan_gmail_feedback(
 
         return summary
     finally:
-        conn.close()
+        close_connection(db_path)
 
 
 def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
-    """Create the feedback tables with the TypeScript API's table shape."""
-
-    conn.executescript(
-        """
-        CREATE TABLE IF NOT EXISTS application_review_decisions (
-          tenant_id    TEXT NOT NULL DEFAULT 'local',
-          decision_id  TEXT NOT NULL,
-          job_key      TEXT NOT NULL,
-          decision     TEXT NOT NULL,
-          reason       TEXT,
-          decided_by   TEXT NOT NULL DEFAULT 'user',
-          decided_at   TEXT NOT NULL,
-          materials_generation INTEGER,
-          profile_version INTEGER,
-          application_url TEXT,
-          partial_override_run_id TEXT,
-          email_recipient TEXT,
-          email_attachment_artifact_id TEXT,
-          PRIMARY KEY (tenant_id, decision_id)
-        );
-        CREATE INDEX IF NOT EXISTS idx_application_review_decisions_job
-          ON application_review_decisions(tenant_id, job_key, decided_at DESC);
-
-        CREATE TABLE IF NOT EXISTS application_outcomes (
-          tenant_id     TEXT NOT NULL DEFAULT 'local',
-          outcome_id    TEXT NOT NULL,
-          job_key       TEXT NOT NULL,
-          kind          TEXT NOT NULL,
-          source        TEXT NOT NULL,
-          note          TEXT,
-          occurred_at   TEXT NOT NULL,
-          recorded_at   TEXT NOT NULL,
-          suggestion_id TEXT,
-          evidence_id   TEXT,
-          created_by    TEXT NOT NULL DEFAULT 'user',
-          PRIMARY KEY (tenant_id, outcome_id)
-        );
-        CREATE INDEX IF NOT EXISTS idx_application_outcomes_job
-          ON application_outcomes(tenant_id, job_key, occurred_at DESC, recorded_at DESC);
-
-        CREATE TABLE IF NOT EXISTS application_email_evidence (
-          tenant_id            TEXT NOT NULL DEFAULT 'local',
-          evidence_id          TEXT NOT NULL,
-          job_key              TEXT NOT NULL,
-          provider             TEXT NOT NULL DEFAULT 'gmail',
-          provider_message_id  TEXT NOT NULL,
-          provider_thread_id   TEXT,
-          from_address         TEXT,
-          to_addresses_json    TEXT NOT NULL DEFAULT '[]',
-          subject              TEXT,
-          snippet              TEXT,
-          received_at          TEXT,
-          linked_at            TEXT NOT NULL,
-          link_confidence      REAL NOT NULL DEFAULT 0,
-          link_signals_json    TEXT NOT NULL DEFAULT '[]',
-          body_text            TEXT,
-          body_sha256          TEXT,
-          body_stored_at       TEXT,
-          PRIMARY KEY (tenant_id, evidence_id),
-          UNIQUE (tenant_id, provider, provider_message_id)
-        );
-        CREATE INDEX IF NOT EXISTS idx_application_email_evidence_job
-          ON application_email_evidence(tenant_id, job_key, received_at DESC);
-
-        CREATE TABLE IF NOT EXISTS application_outcome_suggestions (
-          tenant_id          TEXT NOT NULL DEFAULT 'local',
-          suggestion_id      TEXT NOT NULL,
-          job_key            TEXT NOT NULL,
-          evidence_id        TEXT,
-          suggested_kind     TEXT NOT NULL,
-          confidence         REAL NOT NULL DEFAULT 0,
-          rationale          TEXT NOT NULL DEFAULT '',
-          status             TEXT NOT NULL DEFAULT 'pending',
-          created_at         TEXT NOT NULL,
-          decided_at         TEXT,
-          decision           TEXT,
-          decision_reason    TEXT,
-          decided_outcome_id TEXT,
-          PRIMARY KEY (tenant_id, suggestion_id)
-        );
-        CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_job
-          ON application_outcome_suggestions(tenant_id, job_key, status, created_at DESC);
-        CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_status
-          ON application_outcome_suggestions(tenant_id, status, created_at DESC);
-        """
-    )
-    _ensure_columns(
-        conn,
-        "application_review_decisions",
-        {
-            "materials_generation": "INTEGER",
-            "profile_version": "INTEGER",
-            "application_url": "TEXT",
-            "partial_override_run_id": "TEXT",
-            "email_recipient": "TEXT",
-            "email_attachment_artifact_id": "TEXT",
-        },
-    )
+    """Validate the current feedback owner without creating or altering schema."""
+    if conn.execute("PRAGMA user_version").fetchone()[0] != EXACT_V10_MANIFEST.version:
+        raise SchemaManifestError("Gmail feedback requires the exact current database schema")
+    assert_exact_manifest(conn, EXACT_V10_MANIFEST)
 
 
 def classify_outcome(*, subject: str, snippet: str, body_text: str) -> Classification:
@@ -439,7 +346,7 @@ def _store_linked_message(
     conn.execute(
         """
         INSERT INTO application_email_evidence (
-            tenant_id, evidence_id, job_key, provider, provider_message_id,
+            tenant_id, evidence_id, job_id, provider, provider_message_id,
             provider_thread_id, from_address, to_addresses_json, subject, snippet,
             received_at, linked_at, link_confidence, link_signals_json,
             body_text, body_sha256, body_stored_at
@@ -489,7 +396,7 @@ def _store_suggestion(
     cursor = conn.execute(
         """
         INSERT OR IGNORE INTO application_outcome_suggestions (
-            tenant_id, suggestion_id, job_key, evidence_id, suggested_kind,
+            tenant_id, suggestion_id, job_id, evidence_id, suggested_kind,
             confidence, rationale, status, created_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
@@ -519,12 +426,9 @@ def _record_safe_event(
     signals: tuple[str, ...],
     occurred_at: datetime,
 ) -> None:
-    if not _table_exists(conn, "job_events"):
-        return
-    columns = _columns(conn, "job_events")
     payload = {
         "tenantId": TENANT_ID,
-        "jobKey": job_key,
+        "jobId": job_key,
         "evidenceId": evidence_id,
         "suggestionId": suggestion_id,
         "provider": PROVIDER,
@@ -534,7 +438,9 @@ def _record_safe_event(
         "linkSignals": list(signals),
     }
     values: dict[str, Any] = {
-        "job_url": job_key,
+        "tenant_id": TENANT_ID,
+        "job_id": job_key,
+        "identity_version": 1,
         "stage": "apply",
         "event_type": "ApplicationEmailFeedbackIngested",
         "level": "info",
@@ -542,9 +448,7 @@ def _record_safe_event(
         "occurred_at": _iso(occurred_at),
         "payload_json": json.dumps(payload, sort_keys=True),
     }
-    names = [name for name in values if name in columns]
-    if not names:
-        return
+    names = list(values)
     conn.execute(
         f"INSERT INTO job_events ({', '.join(names)}) VALUES ({', '.join('?' for _ in names)})",
         tuple(values[name] for name in names),
@@ -617,41 +521,32 @@ def _load_application_anchors(conn: sqlite3.Connection, *, limit: int) -> list[A
 
 
 def _job_anchors(conn: sqlite3.Connection) -> list[ApplicationAnchor]:
-    if not _table_exists(conn, "jobs"):
-        return []
-    columns = _columns(conn, "jobs")
-    title_expr = _column_expr(columns, "title")
-    company_expr = _first_column_expr(columns, ["company", "site", "employer"])
-    application_url_expr = _column_expr(columns, "application_url")
-    applied_at_expr = _column_expr(columns, "applied_at")
-    discovered_at_expr = _column_expr(columns, "discovered_at")
-    apply_status_expr = _column_expr(columns, "apply_status")
     rows = conn.execute(
-        f"""
-        SELECT url AS job_key, {title_expr} AS title, {company_expr} AS company,
-               {application_url_expr} AS application_url,
-               COALESCE(NULLIF({applied_at_expr}, ''), NULLIF({discovered_at_expr}, '')) AS anchor_at
-        FROM jobs
-        WHERE NULLIF({applied_at_expr}, '') IS NOT NULL
-           OR lower(COALESCE({apply_status_expr}, '')) = 'applied'
         """
+        SELECT j.job_id AS job_key, COALESCE(j.title, '') AS title,
+               COALESCE(j.company, j.site, '') AS company,
+               COALESCE(e.application_url, '') AS application_url,
+               COALESCE(NULLIF(j.applied_at, ''), NULLIF(j.discovered_at, '')) AS anchor_at
+        FROM jobs j
+        LEFT JOIN job_enrichments e ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id
+        WHERE j.tenant_id = ? AND (
+            NULLIF(j.applied_at, '') IS NOT NULL OR lower(COALESCE(j.apply_status, '')) = 'applied'
+        )
+        """,
+        (TENANT_ID,),
     ).fetchall()
     return [_anchor_from_row(row) for row in rows if _anchor_from_row(row) is not None]
 
 
 def _outcome_anchors(conn: sqlite3.Connection) -> list[ApplicationAnchor]:
-    if not _table_exists(conn, "application_outcomes") or not _table_exists(conn, "jobs"):
-        return []
-    columns = _columns(conn, "jobs")
-    title_expr = _column_expr(columns, "title", prefix="j")
-    company_expr = _first_column_expr(columns, ["company", "site", "employer"], prefix="j")
-    application_url_expr = _column_expr(columns, "application_url", prefix="j")
     rows = conn.execute(
-        f"""
-        SELECT o.job_key AS job_key, {title_expr} AS title, {company_expr} AS company,
-               {application_url_expr} AS application_url, o.occurred_at AS anchor_at
+        """
+        SELECT o.job_id AS job_key, COALESCE(j.title, '') AS title,
+               COALESCE(j.company, j.site, '') AS company,
+               COALESCE(e.application_url, '') AS application_url, o.occurred_at AS anchor_at
         FROM application_outcomes o
-        LEFT JOIN jobs j ON j.url = o.job_key
+        JOIN jobs j ON j.tenant_id = o.tenant_id AND j.job_id = o.job_id
+        LEFT JOIN job_enrichments e ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id
         WHERE o.tenant_id = ?
           AND o.kind IN (
             'applied_confirmation', 'recruiter_reply', 'interview',
@@ -664,26 +559,23 @@ def _outcome_anchors(conn: sqlite3.Connection) -> list[ApplicationAnchor]:
 
 
 def _apply_run_anchors(conn: sqlite3.Connection) -> list[ApplicationAnchor]:
-    if not _table_exists(conn, "apply_run_projections") or not _table_exists(conn, "jobs"):
-        return []
-    columns = _columns(conn, "jobs")
-    title_expr = _column_expr(columns, "title", prefix="j")
-    company_expr = _first_column_expr(columns, ["company", "site", "employer"], prefix="j")
-    application_url_expr = _column_expr(columns, "application_url", prefix="j")
     rows = conn.execute(
-        f"""
-        SELECT a.job_id AS job_key, {title_expr} AS title, {company_expr} AS company,
-               {application_url_expr} AS application_url,
+        """
+        SELECT a.job_id AS job_key, COALESCE(j.title, '') AS title,
+               COALESCE(j.company, j.site, '') AS company,
+               COALESCE(e.application_url, '') AS application_url,
                COALESCE(NULLIF(a.finished_at, ''), NULLIF(a.started_at, '')) AS anchor_at
         FROM apply_run_projections a
-        LEFT JOIN jobs j ON j.url = a.job_id
-        WHERE COALESCE(a.dry_run, 0) = 0
+        JOIN jobs j ON j.tenant_id = a.tenant_id AND j.job_id = a.job_id
+        LEFT JOIN job_enrichments e ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id
+        WHERE a.tenant_id = ? AND COALESCE(a.dry_run, 0) = 0
           AND (
             lower(COALESCE(a.status, '')) IN ('succeeded', 'success', 'complete', 'completed')
             OR lower(COALESCE(a.result, '')) LIKE '%applied%'
             OR lower(COALESCE(a.result, '')) LIKE '%submitted%'
           )
-        """
+        """,
+        (TENANT_ID,),
     ).fetchall()
     return [_anchor_from_row(row) for row in rows if _anchor_from_row(row) is not None]
 
@@ -860,40 +752,6 @@ def _columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
         row["name"] if isinstance(row, sqlite3.Row) else row[1]
         for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()
     }
-
-
-def _ensure_columns(
-    conn: sqlite3.Connection,
-    table_name: str,
-    additions: dict[str, str],
-) -> None:
-    columns = _columns(conn, table_name)
-    for column, definition in additions.items():
-        if column not in columns:
-            conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column} {definition}")
-
-
-def _column_expr(columns: set[str], column: str, *, prefix: str | None = None) -> str:
-    if column not in columns:
-        return "''"
-    qualified = f"{prefix}.{column}" if prefix else column
-    return f"COALESCE({qualified}, '')"
-
-
-def _first_column_expr(
-    columns: set[str],
-    names: list[str],
-    *,
-    prefix: str | None = None,
-) -> str:
-    available = [
-        f"{prefix}.{name}" if prefix else name
-        for name in names
-        if name in columns
-    ]
-    if not available:
-        return "''"
-    return "COALESCE(" + ", ".join(available + ["''"]) + ")"
 
 
 def _text(value: Any) -> str:

--- a/workers/automation/src/jobctrl/infrastructure/job_locators.py
+++ b/workers/automation/src/jobctrl/infrastructure/job_locators.py
@@ -1,0 +1,37 @@
+"""Tenant-scoped locator resolution without legacy job-column authority."""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def resolve_job_locator(
+    conn: sqlite3.Connection, tenant_id: str, locator: str,
+) -> tuple[str, str] | None:
+    """Prefer posting identity and refuse ambiguous application aliases."""
+    posting = conn.execute(
+        """
+        SELECT job_id, url FROM jobs j
+        WHERE tenant_id = ? AND (job_id = ? OR url = ? OR EXISTS (
+            SELECT 1 FROM job_locators l WHERE l.tenant_id = j.tenant_id
+              AND l.job_id = j.job_id AND l.locator_value = ?
+        )) LIMIT 2
+        """,
+        (tenant_id, locator, locator, locator),
+    ).fetchall()
+    if posting:
+        return (str(posting[0][0]), str(posting[0][1])) if len(posting) == 1 else None
+    application = conn.execute(
+        """
+        SELECT job_id, url FROM jobs j
+        WHERE tenant_id = ? AND (EXISTS (
+            SELECT 1 FROM job_enrichments e WHERE e.tenant_id = j.tenant_id
+              AND e.job_id = j.job_id AND e.application_url = ?
+        ) OR EXISTS (
+            SELECT 1 FROM job_application_locators l WHERE l.tenant_id = j.tenant_id
+              AND l.job_id = j.job_id AND l.application_url = ?
+        )) LIMIT 2
+        """,
+        (tenant_id, locator, locator),
+    ).fetchall()
+    return (str(application[0][0]), str(application[0][1])) if len(application) == 1 else None

--- a/workers/automation/src/jobctrl/infrastructure/migrations/legacy_to_v10_execute.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/legacy_to_v10_execute.py
@@ -1,0 +1,145 @@
+"""Private composite executor for stopped-runtime v6/v7/v8-to-v10 cutovers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import sys
+from collections.abc import Sequence
+from dataclasses import asdict
+from pathlib import Path
+from typing import Final
+
+from jobctrl.infrastructure.migrations.legacy_to_v9_execute import execute_legacy_to_v9_candidate
+from jobctrl.infrastructure.migrations.v7_to_v8_execute import (
+    CandidateExecutionResult,
+    _fsync_directory,
+)
+from jobctrl.infrastructure.migrations.v8_to_v9_execute import (
+    execute_v8_to_v9_candidate,
+)
+
+from jobctrl.infrastructure.migrations.v9_to_v10_execute import (
+    execute_v9_to_v10_candidate,
+    _remove_created_candidate,
+    _source_file_state,
+)
+
+_GENERIC_FAILURE: Final = "legacy-to-v10 candidate migration failed"
+
+
+class CandidateExecutionError(RuntimeError):
+    """Raised when an isolated v10 candidate cannot be built from v6, v7 or v8."""
+
+
+def execute_legacy_to_v10_candidate(
+    source_path: Path | str,
+    candidate_path: Path | str,
+    *,
+    source_version: int,
+    migration_at: str | None = None,
+) -> CandidateExecutionResult:
+    """Build exact v9 privately, then transfer URLs into v10 without installation."""
+
+    source = Path(source_path)
+    candidate = Path(candidate_path)
+    intermediate = _intermediate_candidate_path(candidate)
+    result: CandidateExecutionResult | None = None
+    intermediate_identity: tuple[int, int] | None = None
+    candidate_identity: tuple[int, int] | None = None
+    try:
+        _assert_candidate_path(candidate)
+        _assert_candidate_path(intermediate)
+        source_files = _source_file_state(source)
+        if source_version in (6, 7):
+            execute_legacy_to_v9_candidate(
+                source,
+                intermediate,
+                source_version=source_version,
+                migration_at=migration_at,
+            )
+        elif source_version == 8 and migration_at is None:
+            execute_v8_to_v9_candidate(source, intermediate)
+        else:
+            raise CandidateExecutionError(_GENERIC_FAILURE)
+        info = intermediate.lstat()
+        intermediate_identity = (info.st_dev, info.st_ino)
+        result = execute_v9_to_v10_candidate(intermediate, candidate)
+        info = candidate.lstat()
+        candidate_identity = (info.st_dev, info.st_ino)
+        _remove_created_candidate(intermediate, intermediate_identity)
+        if intermediate.exists() or _source_file_state(source) != source_files:
+            raise CandidateExecutionError(_GENERIC_FAILURE)
+        _fsync_directory(candidate.parent)
+        return result
+    except BaseException as error:
+        # A cleanup failure must not prevent removing the final candidate.
+        for path, identity in ((intermediate, intermediate_identity), (candidate, candidate_identity)):
+            if identity is not None:
+                try:
+                    _remove_created_candidate(path, identity)
+                except OSError:
+                    pass
+        if isinstance(error, Exception):
+            raise CandidateExecutionError(_GENERIC_FAILURE) from None
+        raise
+
+
+def _assert_candidate_path(candidate: Path) -> None:
+    try:
+        parent = candidate.parent.stat()
+    except OSError:
+        raise CandidateExecutionError(_GENERIC_FAILURE) from None
+    if not stat.S_ISDIR(parent.st_mode):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    if os.path.lexists(candidate) or any(
+        os.path.lexists(f"{candidate}{suffix}") for suffix in ("-journal", "-shm", "-wal")
+    ):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+
+
+def _intermediate_candidate_path(candidate: Path) -> Path:
+    return Path(f"{candidate}.exact-v9-intermediate")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the authenticated launcher's private composite migration."""
+
+    parser = _PrivateArgumentParser(add_help=False)
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--source-version", required=True, type=int, choices=(6, 7, 8))
+    parser.add_argument("--migration-at")
+    try:
+        arguments = parser.parse_args(argv)
+        result = execute_legacy_to_v10_candidate(
+            arguments.source,
+            arguments.candidate,
+            source_version=arguments.source_version,
+            migration_at=arguments.migration_at,
+        )
+    except CandidateExecutionError:
+        print(_GENERIC_FAILURE, file=sys.stderr)
+        return 1
+    print(json.dumps(asdict(result), sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+class _PrivateArgumentParser(argparse.ArgumentParser):
+    """Argument parser that never echoes private transition paths."""
+
+    def error(self, _message: str) -> None:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "CandidateExecutionError",
+    "execute_legacy_to_v10_candidate",
+    "main",
+]

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_manifest.py
@@ -45,6 +45,14 @@ EXACT_V9_MANIFEST = SchemaManifest(
 )
 
 
+EXACT_V10_MANIFEST = SchemaManifest(
+    version=10,
+    object_count=274,
+    table_count=118,
+    fingerprint="d5c1676fff6e81c987055bf4db6d725c582c74b834f4bf92c9eef3f5980f3641",
+)
+
+
 class SchemaManifestError(RuntimeError):
     """Raised before writes when a database is not an exact known schema."""
 

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v10.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v10.py
@@ -1,0 +1,122 @@
+"""Self-contained exact-v10 SQLite schema and exact-v9 URL ownership upgrade."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from importlib.resources import files
+
+from jobctrl.infrastructure.migrations.compensation_role_family_seed import (
+    seed_compensation_role_families,
+)
+from jobctrl.infrastructure.migrations.resume_template_seed import (
+    seed_builtin_resume_template,
+)
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V9_MANIFEST,
+    EXACT_V10_MANIFEST,
+    SchemaManifestError,
+    assert_exact_manifest,
+    schema_dump,
+)
+from jobctrl.infrastructure.migrations.schema_v9 import (
+    create_unstamped_exact_v9_candidate,
+)
+
+
+def _schema_statements() -> tuple[str, ...]:
+    statements: list[str] = []
+    buffered = ""
+    schema_text = files("jobctrl.infrastructure.migrations").joinpath("schema_v10.sql").read_text(encoding="utf-8")
+    for line in schema_text.splitlines():
+        buffered = f"{buffered}\n{line}" if buffered else line
+        if not sqlite3.complete_statement(buffered):
+            continue
+        statements.append(buffered.strip())
+        buffered = ""
+    if buffered.strip():
+        raise SchemaManifestError("the frozen v10 schema extension file is incomplete")
+    return tuple(statements)
+
+
+def create_exact_v10_schema(
+    conn: sqlite3.Connection,
+    *,
+    _execute: Callable[[str], object] | None = None,
+) -> None:
+    """Install the complete exact-v10 schema into an empty database."""
+
+    _create_empty_exact_v10_schema(conn, stamp_version=True, _execute=_execute)
+
+
+def create_unstamped_exact_v10_candidate(
+    conn: sqlite3.Connection,
+    *,
+    _execute: Callable[[str], object] | None = None,
+) -> None:
+    """Build an exact-v10 candidate without stamping its user version."""
+
+    _create_empty_exact_v10_schema(conn, stamp_version=False, _execute=_execute)
+
+
+def upgrade_exact_v9_schema_to_v10(
+    conn: sqlite3.Connection,
+    *,
+    _execute: Callable[[str], object] | None = None,
+) -> None:
+    """Transfer application URLs and drop the legacy column on an isolated candidate."""
+
+    if conn.in_transaction:
+        raise SchemaManifestError("exact v9-to-v10 upgrade requires no active transaction")
+    if int(conn.execute("PRAGMA user_version").fetchone()[0]) != EXACT_V9_MANIFEST.version:
+        raise SchemaManifestError("exact v9-to-v10 upgrade requires user_version 9")
+    assert_exact_manifest(conn, EXACT_V9_MANIFEST)
+
+    execute = _execute or conn.execute
+    conn.execute("SAVEPOINT exact_v9_to_v10_schema")
+    try:
+        for statement in _schema_statements():
+            execute(statement)
+        execute(f"PRAGMA user_version = {EXACT_V10_MANIFEST.version}")
+        assert_exact_manifest(conn, EXACT_V10_MANIFEST)
+        conn.execute("RELEASE SAVEPOINT exact_v9_to_v10_schema")
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT exact_v9_to_v10_schema")
+        conn.execute("RELEASE SAVEPOINT exact_v9_to_v10_schema")
+        raise
+
+
+def _create_empty_exact_v10_schema(
+    conn: sqlite3.Connection,
+    *,
+    stamp_version: bool,
+    _execute: Callable[[str], object] | None,
+) -> None:
+    if schema_dump(conn):
+        raise SchemaManifestError("exact v10 creation requires an empty schema")
+    if not stamp_version and conn.execute("PRAGMA user_version").fetchone()[0] != 0:
+        raise SchemaManifestError("unstamped exact v10 candidate creation requires user_version 0")
+
+    execute = _execute or conn.execute
+    conn.execute("SAVEPOINT exact_v10_schema")
+    try:
+        create_unstamped_exact_v9_candidate(conn, _execute=execute)
+        for statement in _schema_statements():
+            execute(statement)
+        if stamp_version:
+            seed_builtin_resume_template(conn)
+            seed_compensation_role_families(conn)
+            execute(f"PRAGMA user_version = {EXACT_V10_MANIFEST.version}")
+        assert_exact_manifest(conn, EXACT_V10_MANIFEST)
+        conn.execute("RELEASE SAVEPOINT exact_v10_schema")
+    except BaseException:
+        conn.execute("ROLLBACK TO SAVEPOINT exact_v10_schema")
+        conn.execute("RELEASE SAVEPOINT exact_v10_schema")
+        raise
+
+
+__all__ = [
+    "create_exact_v10_schema",
+    "create_unstamped_exact_v10_candidate",
+    "upgrade_exact_v9_schema_to_v10",
+]

--- a/workers/automation/src/jobctrl/infrastructure/migrations/schema_v10.sql
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/schema_v10.sql
@@ -1,0 +1,43 @@
+CREATE TABLE job_application_locators (
+    tenant_id TEXT NOT NULL,
+    job_id TEXT NOT NULL,
+    application_url TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, job_id, application_url),
+    FOREIGN KEY (tenant_id, job_id)
+        REFERENCES jobs(tenant_id, job_id) ON DELETE CASCADE
+);
+CREATE INDEX idx_job_application_locators_url
+    ON job_application_locators(tenant_id, application_url);
+INSERT INTO job_application_locators (tenant_id, job_id, application_url)
+    SELECT tenant_id, job_id, application_url FROM jobs
+        WHERE application_url IS NOT NULL AND application_url <> ''
+    UNION
+    SELECT tenant_id, job_id, application_url FROM job_enrichments
+        WHERE application_url IS NOT NULL AND application_url <> '';
+UPDATE job_enrichments
+    SET application_url = (
+        SELECT jobs.application_url FROM jobs
+        WHERE jobs.tenant_id = job_enrichments.tenant_id
+            AND jobs.job_id = job_enrichments.job_id
+    )
+    WHERE (application_url IS NULL OR application_url = '')
+        AND EXISTS (
+            SELECT 1 FROM jobs
+            WHERE jobs.tenant_id = job_enrichments.tenant_id
+                AND jobs.job_id = job_enrichments.job_id
+                AND jobs.application_url IS NOT NULL AND jobs.application_url <> ''
+        );
+INSERT INTO job_enrichments (
+    tenant_id, job_id, current_status, application_url, attempts_json, updated_at
+)
+    SELECT tenant_id, job_id, 'pending', application_url, '[]',
+        COALESCE(NULLIF(detail_scraped_at, ''), NULLIF(discovered_at, ''),
+            '1970-01-01T00:00:00+00:00')
+    FROM jobs
+    WHERE application_url IS NOT NULL AND application_url <> ''
+        AND NOT EXISTS (
+            SELECT 1 FROM job_enrichments
+            WHERE job_enrichments.tenant_id = jobs.tenant_id
+                AND job_enrichments.job_id = jobs.job_id
+        );
+ALTER TABLE jobs DROP COLUMN application_url;

--- a/workers/automation/src/jobctrl/infrastructure/migrations/v9_to_v10_execute.py
+++ b/workers/automation/src/jobctrl/infrastructure/migrations/v9_to_v10_execute.py
@@ -1,0 +1,331 @@
+"""Private file-to-file executor for the stopped-runtime v9-to-v10 cutover."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import asdict
+from pathlib import Path
+from typing import Final
+
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V9_MANIFEST,
+    EXACT_V10_MANIFEST,
+    assert_exact_manifest,
+)
+from jobctrl.infrastructure.migrations.schema_v10 import (
+    upgrade_exact_v9_schema_to_v10,
+)
+from jobctrl.infrastructure.migrations.v7_to_v8_execute import (
+    CandidateExecutionResult,
+    _assert_paths,
+    _digest_value,
+    _durable_table_names,
+    _fsync_directory,
+    _fsync_regular_file,
+    _quote_identifier,
+    _sequence_rows,
+    _sha256_file,
+)
+
+_GENERIC_FAILURE: Final = "v9-to-v10 candidate migration failed"
+_RESULT_SCHEMA_VERSION: Final = 1
+
+
+class CandidateExecutionError(RuntimeError):
+    """Raised when an isolated v10 candidate cannot be built and verified."""
+
+
+def execute_v9_to_v10_candidate(
+    source_path: Path | str,
+    candidate_path: Path | str,
+    *,
+    _after_stamp: Callable[[], None] | None = None,
+) -> CandidateExecutionResult:
+    """Copy exact v9, transfer application URLs, and seal a verified private file."""
+
+    source = Path(source_path)
+    candidate = Path(candidate_path)
+    source_connection: sqlite3.Connection | None = None
+    candidate_connection: sqlite3.Connection | None = None
+    created_identity: tuple[int, int] | None = None
+    try:
+        _assert_paths(source, candidate)
+        source_files = _source_file_state(source)
+        descriptor = os.open(candidate, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        try:
+            os.fchmod(descriptor, 0o600)
+            created = os.fstat(descriptor)
+            created_identity = (created.st_dev, created.st_ino)
+        finally:
+            os.close(descriptor)
+
+        source_connection = sqlite3.connect(
+            f"{source.resolve().as_uri()}?mode=ro",
+            uri=True,
+        )
+        source_connection.execute("PRAGMA foreign_keys = ON")
+        if int(source_connection.execute("PRAGMA user_version").fetchone()[0]) != EXACT_V9_MANIFEST.version:
+            raise CandidateExecutionError(_GENERIC_FAILURE)
+        assert_exact_manifest(source_connection, EXACT_V9_MANIFEST)
+        source_tables = _durable_table_names(source_connection)
+        source_columns = _table_columns(source_connection, source_tables)
+        full_source_digest = _table_data_digest(source_connection, source_tables, source_columns)
+        retained_columns = dict(source_columns)
+        for table in ("jobs", "job_enrichments"):
+            retained_columns[table] = tuple(c for c in source_columns[table] if c != "application_url")
+        enrichment_keys = frozenset(source_connection.execute("SELECT tenant_id, job_id FROM job_enrichments"))
+        source_digest = _preserved_data_digest(source_connection, source_tables, retained_columns, enrichment_keys)
+        expected_aliases, expected_enrichments = _expected_transfer(
+            source_connection, source_columns["job_enrichments"]
+        )
+
+        candidate_connection = sqlite3.connect(candidate)
+        candidate_connection.execute("PRAGMA foreign_keys = ON")
+        source_connection.backup(candidate_connection)
+        candidate_connection.commit()
+        assert_exact_manifest(candidate_connection, EXACT_V9_MANIFEST)
+        if _table_data_digest(candidate_connection, source_tables, source_columns) != full_source_digest:
+            raise CandidateExecutionError(_GENERIC_FAILURE)
+
+        upgrade_exact_v9_schema_to_v10(candidate_connection)
+        if _after_stamp is not None:
+            _after_stamp()
+        candidate_connection.commit()
+        _verify_candidate(
+            source_connection,
+            candidate_connection,
+            source_tables=source_tables,
+            source_columns=source_columns,
+            full_source_digest=full_source_digest,
+            retained_columns=retained_columns,
+            enrichment_keys=enrichment_keys,
+            expected_aliases=expected_aliases,
+            expected_enrichments=expected_enrichments,
+            source_digest=source_digest,
+        )
+        candidate_digest = _preserved_data_digest(
+            candidate_connection, source_tables, retained_columns, enrichment_keys
+        )
+        job_count = int(candidate_connection.execute("SELECT COUNT(*) FROM jobs").fetchone()[0])
+
+        candidate_connection.close()
+        candidate_connection = None
+        source_connection.close()
+        source_connection = None
+        if _source_file_state(source) != source_files:
+            raise CandidateExecutionError(_GENERIC_FAILURE)
+        current = candidate.lstat()
+        if (current.st_dev, current.st_ino) != created_identity or current.st_mode & 0o077:
+            raise CandidateExecutionError(_GENERIC_FAILURE)
+        _fsync_regular_file(candidate)
+        _fsync_directory(candidate.parent)
+        return CandidateExecutionResult(
+            schema_version=_RESULT_SCHEMA_VERSION,
+            status="ready",
+            user_version=EXACT_V10_MANIFEST.version,
+            source_data_digest=source_digest,
+            candidate_data_digest=candidate_digest,
+            candidate_sha256=_sha256_file(candidate),
+            job_count=job_count,
+            table_count=EXACT_V10_MANIFEST.table_count,
+        )
+    except BaseException as error:
+        if candidate_connection is not None:
+            candidate_connection.close()
+        if source_connection is not None:
+            source_connection.close()
+        if created_identity is not None:
+            _remove_created_candidate(candidate, created_identity)
+        if isinstance(error, Exception):
+            raise CandidateExecutionError(_GENERIC_FAILURE) from None
+        raise
+
+
+def _verify_candidate(
+    source: sqlite3.Connection,
+    candidate: sqlite3.Connection,
+    *,
+    source_tables: tuple[str, ...],
+    source_columns: dict[str, tuple[str, ...]],
+    full_source_digest: str,
+    retained_columns: dict[str, tuple[str, ...]],
+    enrichment_keys: frozenset[tuple[str, str]],
+    expected_aliases: set[tuple[object, ...]],
+    expected_enrichments: dict[tuple[object, ...], tuple[object, ...]],
+    source_digest: str,
+) -> None:
+    if int(source.execute("PRAGMA user_version").fetchone()[0]) != EXACT_V9_MANIFEST.version:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    assert_exact_manifest(source, EXACT_V9_MANIFEST)
+    if _table_data_digest(source, source_tables, source_columns) != full_source_digest:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+
+    if int(candidate.execute("PRAGMA user_version").fetchone()[0]) != EXACT_V10_MANIFEST.version:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    assert_exact_manifest(candidate, EXACT_V10_MANIFEST)
+    if _preserved_data_digest(candidate, source_tables, retained_columns, enrichment_keys) != source_digest:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    if candidate.execute("PRAGMA foreign_key_check").fetchall():
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    if candidate.execute("PRAGMA integrity_check").fetchone() != ("ok",):
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+    aliases = set(candidate.execute("SELECT tenant_id, job_id, application_url FROM job_application_locators"))
+    columns = source_columns["job_enrichments"]
+    selected = ", ".join(_quote_identifier(c) for c in columns)
+    rows = candidate.execute(f"SELECT {selected} FROM job_enrichments")
+    enrichments = {(r[columns.index("tenant_id")], r[columns.index("job_id")]): tuple(r) for r in rows}
+    if aliases != expected_aliases or enrichments != expected_enrichments:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+
+
+def _table_columns(
+    conn: sqlite3.Connection,
+    tables: tuple[str, ...],
+) -> dict[str, tuple[str, ...]]:
+    return {
+        table: tuple(str(row[1]) for row in conn.execute(f"PRAGMA table_info({_quote_identifier(table)})"))
+        for table in tables
+    }
+
+
+def _table_data_digest(
+    conn: sqlite3.Connection,
+    tables: tuple[str, ...],
+    columns_by_table: dict[str, tuple[str, ...]],
+) -> str:
+    digest = hashlib.sha256()
+    for table in tables:
+        columns = columns_by_table[table]
+        _digest_value(digest, table)
+        _digest_value(digest, columns)
+        selected = ", ".join(_quote_identifier(column) for column in columns)
+        order_by = ", ".join(_quote_identifier(column) for column in columns)
+        rows = conn.execute(f"SELECT {selected} FROM {_quote_identifier(table)} ORDER BY {order_by}")
+        for row in rows:
+            _digest_value(digest, tuple(row))
+    _digest_value(digest, _sequence_rows(conn))
+    return digest.hexdigest()
+
+
+def _preserved_data_digest(
+    conn: sqlite3.Connection,
+    tables: tuple[str, ...],
+    columns_by_table: dict[str, tuple[str, ...]],
+    enrichment_keys: frozenset[tuple[str, str]],
+) -> str:
+    """Compare all retained cells; separately verify changed URLs and added rows.
+
+    Only the removed jobs URL, enrichment URLs, and newly required enrichment
+    rows are omitted. The exact complete enrichment transform is checked before
+    issuing a receipt, including every omitted cell and added row.
+    """
+    digest = hashlib.sha256()
+    for table in tables:
+        columns = columns_by_table[table]
+        _digest_value(digest, table)
+        _digest_value(digest, columns)
+        selected = ", ".join(_quote_identifier(c) for c in columns)
+        for row in conn.execute(f"SELECT {selected} FROM {_quote_identifier(table)} ORDER BY {selected}"):
+            if table == "job_enrichments":
+                key = (row[columns.index("tenant_id")], row[columns.index("job_id")])
+                if key not in enrichment_keys:
+                    continue
+            _digest_value(digest, tuple(row))
+    _digest_value(digest, _sequence_rows(conn))
+    return digest.hexdigest()
+
+
+def _expected_transfer(
+    source: sqlite3.Connection,
+    columns: tuple[str, ...],
+) -> tuple[set[tuple[object, ...]], dict[tuple[object, ...], tuple[object, ...]]]:
+    """Derive expected rows independently of the SQL migration implementation."""
+    selected = ", ".join(_quote_identifier(c) for c in columns)
+    rows = [dict(zip(columns, row, strict=True)) for row in source.execute(f"SELECT {selected} FROM job_enrichments")]
+    by_key = {(r["tenant_id"], r["job_id"]): r for r in rows}
+    aliases = {
+        (r["tenant_id"], r["job_id"], r["application_url"]) for r in rows if r["application_url"] not in (None, "")
+    }
+    for tenant, job, legacy, detail_at, discovered_at in source.execute(
+        "SELECT tenant_id, job_id, application_url, detail_scraped_at, discovered_at FROM jobs"
+    ):
+        if legacy in (None, ""):
+            continue
+        aliases.add((tenant, job, legacy))
+        key = (tenant, job)
+        if key not in by_key:
+            row = dict.fromkeys(columns)
+            row.update(
+                tenant_id=tenant,
+                job_id=job,
+                current_status="pending",
+                application_url=legacy,
+                attempts_json="[]",
+                updated_at=detail_at or discovered_at or "1970-01-01T00:00:00+00:00",
+            )
+            by_key[key] = row
+        elif by_key[key]["application_url"] in (None, ""):
+            by_key[key]["application_url"] = legacy
+    return aliases, {key: tuple(row[c] for c in columns) for key, row in by_key.items()}
+
+
+def _source_file_state(source: Path) -> tuple[tuple[object, ...], ...]:
+    """Include the legacy column and SQLite sidecar bytes in immutability proof."""
+    state: list[tuple[object, ...]] = []
+    for path in (source, *(Path(f"{source}{s}") for s in ("-journal", "-wal", "-shm"))):
+        if path.exists():
+            info = path.lstat()
+            state.append((str(path), info.st_dev, info.st_ino, info.st_mode, _sha256_file(path)))
+    return tuple(state)
+
+
+def _remove_created_candidate(candidate: Path, created_identity: tuple[int, int]) -> None:
+    try:
+        current = candidate.lstat()
+    except FileNotFoundError:
+        return
+    if (current.st_dev, current.st_ino) != created_identity:
+        return
+    candidate.unlink()
+    for suffix in ("-journal", "-shm", "-wal"):
+        Path(f"{candidate}{suffix}").unlink(missing_ok=True)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the authenticated launcher's private migration subprocess."""
+
+    parser = _PrivateArgumentParser(add_help=False)
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--candidate", required=True)
+    try:
+        arguments = parser.parse_args(argv)
+        result = execute_v9_to_v10_candidate(arguments.source, arguments.candidate)
+    except CandidateExecutionError:
+        print(_GENERIC_FAILURE, file=sys.stderr)
+        return 1
+    print(json.dumps(asdict(result), sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+class _PrivateArgumentParser(argparse.ArgumentParser):
+    """Argument parser that never echoes private transition paths."""
+
+    def error(self, _message: str) -> None:
+        raise CandidateExecutionError(_GENERIC_FAILURE)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "CandidateExecutionError",
+    "execute_v9_to_v10_candidate",
+    "main",
+]

--- a/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobctrl/infrastructure/projections/projection_builder.py
@@ -980,6 +980,7 @@ class ProjectionBuilder:
                 # ``jobs`` table not yet created (very-fresh DB) — nothing
                 # to backfill.
                 pass
+        dirty_job_ids.update(self._stale_application_url_projection_jobs())
         dirty_job_ids.update(self._stale_deleted_projection_jobs())
         dirty_job_ids.update(self._stale_artifact_projection_jobs())
         dirty_job_ids.update(self._stale_stage_projection_jobs())
@@ -1468,7 +1469,7 @@ class ProjectionBuilder:
 
         title = _row_str(job_row, "title")
         site = _row_str(job_row, "site")
-        application_url = enrichment.get("application_url") or _row_nullable_str(job_row, "application_url")
+        application_url = enrichment.get("application_url")
         employer = _canonical_employer(job_row)
 
         # currentStage/State: the list view exposes only product stages.
@@ -2701,6 +2702,18 @@ class ProjectionBuilder:
         if row is None:
             return None
         return _row_nullable_str(row, "deleted_at")
+
+    def _stale_application_url_projection_jobs(self) -> set[str]:
+        # Migration retains projection rows/cursors; canonical target changes
+        # must reconcile even without an event after the cutover.
+        rows = self._conn.execute(
+            """SELECT p.job_id FROM job_list_projections p
+               JOIN jobs j ON j.tenant_id = p.tenant_id AND j.job_id = p.job_id
+               LEFT JOIN job_enrichments e ON e.tenant_id = j.tenant_id AND e.job_id = j.job_id
+               WHERE p.tenant_id = ? AND p.application_url IS NOT NULLIF(e.application_url, '')""",
+            (str(self._tenant_id),),
+        ).fetchall()
+        return {str(row[0]) for row in rows}
 
     def _stale_deleted_projection_jobs(self) -> set[str]:
         try:

--- a/workers/automation/src/jobctrl/state.py
+++ b/workers/automation/src/jobctrl/state.py
@@ -1553,19 +1553,13 @@ def reset_job_stage(
     if stage not in (*STAGE_ORDER, "apply"):
         raise ValueError(f"unknown stage: {stage}")
 
-    row = conn.execute(
-        """
-        SELECT job_id, url
-        FROM jobs
-        WHERE tenant_id = ? AND (url = ? OR application_url = ?)
-        """,
-        (str(tenant_id), job_url_or_application_url, job_url_or_application_url),
-    ).fetchone()
-    if row is None:
-        raise ValueError(f"no matching job found: {job_url_or_application_url}")
+    from jobctrl.infrastructure.job_locators import resolve_job_locator
 
-    job_url = row["url"]
-    stable_job_id = canonical_job_id(str(row["job_id"]))
+    identity = resolve_job_locator(conn, str(tenant_id), job_url_or_application_url)
+    if identity is None:
+        raise ValueError(f"no unique matching job found: {job_url_or_application_url}")
+    stable_job_id = canonical_job_id(identity[0])
+    job_url = identity[1]
     # Reset only the canonical stage-owned aggregate. The retired projection
     # columns on ``jobs`` are historical migration facts, not write targets.
     if stage in ("tailor", "cover"):

--- a/workers/automation/tests/test_application_url_authority.py
+++ b/workers/automation/tests/test_application_url_authority.py
@@ -1,0 +1,91 @@
+"""Shared TS/Python URL authority fixture through the actual private migration."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+from pathlib import Path
+
+from jobctrl.infrastructure.job_locators import resolve_job_locator
+from jobctrl.infrastructure.migrations.schema_manifest import EXACT_V10_MANIFEST, assert_exact_manifest
+from jobctrl.infrastructure.migrations.schema_v9 import create_exact_v9_schema
+from jobctrl.infrastructure.migrations.v9_to_v10_execute import execute_v9_to_v10_candidate
+from jobctrl.infrastructure.projections.projection_builder import ProjectionBuilder
+
+_FIXTURE = Path(__file__).resolve().parents[3] / "packages/domain-types/test/fixtures/application_url_authority.json"
+
+
+@pytest.mark.parametrize("populated_projection", [False, True])
+def test_migrated_python_projection_matches_shared_canonical_url_fixture(
+    tmp_path: Path, populated_projection: bool
+) -> None:
+    cases = json.loads(_FIXTURE.read_text())["cases"]
+    source, candidate = tmp_path / "source-v9.db", tmp_path / "candidate-v10.db"
+    with sqlite3.connect(source) as conn:
+        create_exact_v9_schema(conn)
+        for tenant in ("local", "other"):
+            for case in cases:
+                conn.execute(
+                    "INSERT INTO jobs(tenant_id,job_id,url,application_url,title,discovered_at) VALUES(?,?,?,?,?,'2026-08-01T00:00:00Z')",
+                    (tenant, case["jobId"], f"https://jobs.example.test/{case['name']}", case["legacy"], case["name"]),
+                )
+                if populated_projection:
+                    conn.execute(
+                        "INSERT INTO job_list_projections(tenant_id,job_id,application_url) VALUES(?,?,?)",
+                        (tenant, case["jobId"], (case["enrichment"] or {}).get("applicationUrl")),
+                    )
+                if case["enrichment"] is not None:
+                    conn.execute(
+                        "INSERT INTO job_enrichments(tenant_id,job_id,current_status,application_url,updated_at) VALUES(?,?,?,?,'2026-08-01T00:00:00Z')",
+                        (tenant, case["jobId"], case["enrichment"]["status"], case["enrichment"]["applicationUrl"]),
+                    )
+    before = source.read_bytes()
+    receipt = execute_v9_to_v10_candidate(source, candidate)
+    assert receipt.source_data_digest == receipt.candidate_data_digest and source.read_bytes() == before
+    with sqlite3.connect(candidate) as conn:
+        conn.row_factory = sqlite3.Row
+        assert_exact_manifest(conn, EXACT_V10_MANIFEST)
+        other_before = [
+            tuple(row)
+            for row in conn.execute("SELECT * FROM job_list_projections WHERE tenant_id='other' ORDER BY job_id")
+        ]
+        builder = ProjectionBuilder(conn_factory=lambda: conn)
+        builder.refresh()
+        assert conn.execute("SELECT COUNT(*) FROM job_list_projections WHERE tenant_id='other'").fetchone()[0] == (
+            len(cases) if populated_projection else 0
+        )
+        for case in cases:
+            row = conn.execute(
+                "SELECT application_url FROM job_list_projections WHERE tenant_id='local' AND job_id=?",
+                (case["jobId"],),
+            ).fetchone()
+            assert row["application_url"] == case["expected"], case["name"]
+            for value in [case["legacy"], (case["enrichment"] or {}).get("applicationUrl")]:
+                if value:
+                    for tenant in ("local", "other"):
+                        assert resolve_job_locator(conn, tenant, value)[0] == case["jobId"]
+        conflict = cases[1]
+        conn.execute(
+            "UPDATE job_enrichments SET application_url=NULL WHERE tenant_id='local' AND job_id=?", (conflict["jobId"],)
+        )
+        assert conn.execute("SELECT COUNT(*) FROM job_events").fetchone()[0] == 0
+        conn.commit()
+        builder.refresh()
+        assert (
+            conn.execute(
+                "SELECT application_url FROM job_list_projections WHERE tenant_id='local' AND job_id=?",
+                (conflict["jobId"],),
+            ).fetchone()[0]
+            is None
+        )
+        assert resolve_job_locator(conn, "local", conflict["legacy"])[0] == conflict["jobId"]
+        assert [
+            tuple(row)
+            for row in conn.execute("SELECT * FROM job_list_projections WHERE tenant_id='other' ORDER BY job_id")
+        ] == other_before
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+        settled_changes = conn.total_changes
+        assert builder.refresh() == 0
+        assert conn.total_changes == settled_changes

--- a/workers/automation/tests/test_apply_regressions.py
+++ b/workers/automation/tests/test_apply_regressions.py
@@ -1111,8 +1111,7 @@ def test_acquire_job_promotes_prior_apply_run_into_row_dict(tmp_path, monkeypatc
 
 def test_acquire_job_finds_new_path_enriched_job(tmp_path, monkeypatch):
     """``acquire_job`` must find jobs whose ``application_url`` lives
-    only in ``job_enrichments`` (the new write path leaves
-    ``jobs.application_url`` NULL)."""
+    only in canonical ``job_enrichments`` on exact v10."""
     from jobctrl.domain.enrichment import (
         ApplicationUrl,
         ExtractionTier,
@@ -1141,11 +1140,7 @@ def test_acquire_job_finds_new_path_enriched_job(tmp_path, monkeypatch):
             finished_at="t1",
         )
     )
-    legacy = conn.execute(
-        "SELECT application_url FROM jobs WHERE tenant_id = ? AND job_id = ?",
-        (LOCAL_TENANT, job_id),
-    ).fetchone()
-    assert legacy["application_url"] is None
+    assert "application_url" not in {row["name"] for row in conn.execute("PRAGMA table_info(jobs)")}
 
     try:
         monkeypatch.setattr("jobctrl.apply.launcher.get_connection", lambda: get_connection(db_path))

--- a/workers/automation/tests/test_apply_runs_projection_from_events.py
+++ b/workers/automation/tests/test_apply_runs_projection_from_events.py
@@ -49,8 +49,8 @@ def _seed_job(
     conn.execute(
         """
         INSERT INTO jobs (tenant_id, job_id, url, title, site, strategy, location, salary,
-                          discovered_at, application_url, description)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                          discovered_at, description)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             str(tenant_id),
@@ -62,9 +62,13 @@ def _seed_job(
             "Remote",
             "",
             utc_now(),
-            url,
             "x",
         ),
+    )
+    conn.execute(
+        "INSERT INTO job_enrichments(tenant_id,job_id,current_status,application_url,updated_at) "
+        "VALUES (?,?,'pending',?,?)",
+        (str(tenant_id), str(job_id), url, utc_now()),
     )
 
 

--- a/workers/automation/tests/test_apply_runs_table_dropped.py
+++ b/workers/automation/tests/test_apply_runs_table_dropped.py
@@ -70,7 +70,7 @@ def test_init_db_rejects_legacy_apply_tables_without_mutating_them(
     pre.commit()
     pre.close()
 
-    with pytest.raises(SchemaMigrationRequiredError, match="exact schema v9"):
+    with pytest.raises(SchemaMigrationRequiredError, match="exact schema v10"):
         init_db(fresh_db)
 
     verified = sqlite3.connect(str(fresh_db))

--- a/workers/automation/tests/test_dashboard_projection.py
+++ b/workers/automation/tests/test_dashboard_projection.py
@@ -40,8 +40,8 @@ def _seed_job(conn: sqlite3.Connection, url: str, *, site: str = "ExampleCo") ->
         """
         INSERT INTO jobs (
             tenant_id, job_id, url, title, site, strategy, location, salary,
-            discovered_at, application_url, description
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            discovered_at, description
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             LOCAL_TENANT,
@@ -53,7 +53,6 @@ def _seed_job(conn: sqlite3.Connection, url: str, *, site: str = "ExampleCo") ->
             "Remote",
             "",
             now,
-            url,
             "desc",
         ),
     )
@@ -65,6 +64,11 @@ def _seed_job(conn: sqlite3.Connection, url: str, *, site: str = "ExampleCo") ->
         ) VALUES (?, ?, 'posting_url', ?, 1, ?, ?)
         """,
         (LOCAL_TENANT, job_id, url, now, now),
+    )
+    conn.execute(
+        "INSERT INTO job_enrichments(tenant_id,job_id,current_status,application_url,updated_at) "
+        "VALUES (?,?,'pending',?,?)",
+        (str(LOCAL_TENANT), str(job_id), url, now),
     )
     conn.commit()
     return job_id

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -1386,7 +1386,8 @@ def test_jobspy_ignores_missing_direct_url_for_source_learning(tmp_path):
         assert jobspy.store_jobspy_results(conn, frame, "Platform", limit=10) == (1, 0)
 
         job = conn.execute(
-            "SELECT application_url FROM jobs WHERE url = ?",
+            "SELECT e.application_url FROM jobs j LEFT JOIN job_enrichments e "
+            "ON e.tenant_id=j.tenant_id AND e.job_id=j.job_id WHERE j.url = ?",
             ("https://www.linkedin.com/jobs/view/10",),
         ).fetchone()
         assert job["application_url"] is None
@@ -1733,3 +1734,40 @@ def test_jobspy_missing_dependency_is_not_reported_as_empty_success(monkeypatch)
             {},
             limit=10,
         )
+
+
+def test_jobspy_refresh_preserves_canonical_target_and_retains_new_application_alias(tmp_path):
+    db_path = tmp_path / 'jobs.db'
+    conn = init_db(db_path)
+    posting = 'https://www.linkedin.com/jobs/view/canonical-authority'
+    try:
+        frame = _jobspy_frame([{'job_url':posting,'job_url_direct':'https://jobs.ashbyhq.com/example/first','title':'Platform Engineer','company':'Example','location':'Barcelona, Spain','site':'linkedin'}])
+        assert jobspy.store_jobspy_results(conn, frame, 'Platform', limit=10) == (1,0)
+        job_id = _stable_job_id(conn, posting)
+        conn.execute("UPDATE job_enrichments SET application_url='https://accepted.example/target',current_status='failed',attempts_json='[{\"retained\":true}]',updated_at='retained-time' WHERE tenant_id='local' AND job_id=?", (job_id,))
+        before = tuple(conn.execute("SELECT * FROM job_enrichments WHERE tenant_id='local' AND job_id=?", (job_id,)).fetchone())
+        frame.loc[0, 'job_url_direct'] = 'https://jobs.ashbyhq.com/example/second'
+        assert jobspy.store_jobspy_results(conn, frame, 'Platform', limit=10) == (0,1)
+        assert tuple(conn.execute("SELECT * FROM job_enrichments WHERE tenant_id='local' AND job_id=?", (job_id,)).fetchone()) == before
+        aliases = {row[0] for row in conn.execute("SELECT application_url FROM job_application_locators WHERE tenant_id='local' AND job_id=?", (job_id,))}
+        assert {'https://jobs.ashbyhq.com/example/first','https://jobs.ashbyhq.com/example/second'} <= aliases
+    finally:
+        close_connection(db_path)
+
+
+def test_workday_refresh_preserves_canonical_enrichment_and_other_tenant(tmp_path):
+    db_path = tmp_path / 'jobs.db'
+    conn = init_db(db_path)
+    posting = 'https://workday.example/careers/job/one'
+    try:
+        for tenant in ('local','other'):
+            conn.execute("INSERT INTO jobs(tenant_id,job_id,url,title,full_description) VALUES(?, '89100000-0000-4000-8000-000000000099', ?, ?, 'unchanged')", (tenant,posting,f'{tenant} title'))
+            conn.execute("INSERT INTO job_enrichments(tenant_id,job_id,current_status,application_url,updated_at,attempts_json) VALUES(?, '89100000-0000-4000-8000-000000000099','failed',?,'old-time','[{\"retained\":true}]')", (tenant,f'https://{tenant}.accepted/target'))
+        enrichment_before = [tuple(r) for r in conn.execute('SELECT * FROM job_enrichments ORDER BY tenant_id')]
+        other_before = tuple(conn.execute("SELECT * FROM jobs WHERE tenant_id='other'").fetchone())
+        workday._update_detail_columns(conn, {'full_description':'Updated description. ' * 30}, posting, 'new-time')
+        assert [tuple(r) for r in conn.execute('SELECT * FROM job_enrichments ORDER BY tenant_id')] == enrichment_before
+        assert tuple(conn.execute("SELECT * FROM jobs WHERE tenant_id='other'").fetchone()) == other_before
+        assert [tuple(r) for r in conn.execute('SELECT * FROM job_application_locators')] == [('local','89100000-0000-4000-8000-000000000099',posting)]
+    finally:
+        close_connection(db_path)

--- a/workers/automation/tests/test_discovery_search_units.py
+++ b/workers/automation/tests/test_discovery_search_units.py
@@ -275,7 +275,7 @@ def test_v4_search_unit_tables_require_an_explicit_v7_upgrade(
     conn.commit()
     close_connection(db_path)
 
-    with pytest.raises(SchemaMigrationRequiredError, match="exact schema v9"):
+    with pytest.raises(SchemaMigrationRequiredError, match="exact schema v10"):
         init_db(db_path)
 
 

--- a/workers/automation/tests/test_enrichment_detail_staleness.py
+++ b/workers/automation/tests/test_enrichment_detail_staleness.py
@@ -398,8 +398,8 @@ def test_scrape_site_batch_uses_discovery_description_when_detail_extracts_no_da
             """
             INSERT INTO jobs (
                 tenant_id, job_id, url, title, description, full_description,
-                location, site, strategy, discovered_at, application_url, company
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                location, site, strategy, discovered_at, company
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 tenant_id,
@@ -412,7 +412,6 @@ def test_scrape_site_batch_uses_discovery_description_when_detail_extracts_no_da
                 "linkedin",
                 "jobspy",
                 "2026-06-04T15:55:20+00:00",
-                None,
                 "Checkatrade",
             ),
         )

--- a/workers/automation/tests/test_enrichment_repository.py
+++ b/workers/automation/tests/test_enrichment_repository.py
@@ -367,3 +367,31 @@ def test_shared_url_never_crosses_tenant_job_identity_on_save_load_or_update(
     assert other.full_description is not None
     assert other.full_description.text == "other description"
     assert repo.load(LOCAL_TENANT, other_job_id) is None
+
+
+def test_save_keeps_old_application_aliases_shared_urls_and_transaction_boundaries(conn: sqlite3.Connection) -> None:
+    from dataclasses import replace
+
+    from jobctrl.infrastructure.job_locators import resolve_job_locator
+
+    first_id = _job_id(tenant_id=LOCAL_TENANT, url='https://post/first')
+    second_id = _job_id(tenant_id=LOCAL_TENANT, url='https://post/second')
+    for job_id, posting in [(first_id, 'https://post/first'), (second_id, 'https://post/second')]:
+        _insert_job(conn, tenant_id=LOCAL_TENANT, job_id=job_id, url=posting)
+    repo = SqliteEnrichmentRepository(conn)
+    original = _enriched(tenant_id=LOCAL_TENANT, job_id=first_id)
+    repo.save(original)
+    changed = replace(original, application_url=ApplicationUrl(value='https://canonical/new'))
+    repo.save(changed, commit=False)
+    assert resolve_job_locator(conn, 'local', 'https://canonical/new') == (str(first_id), 'https://post/first')
+    conn.rollback()
+    assert resolve_job_locator(conn, 'local', 'https://canonical/new') is None
+    repo.save(changed)
+    assert resolve_job_locator(conn, 'local', 'https://example.test/apply') == (str(first_id), 'https://post/first')
+    repo.save(_enriched(tenant_id=LOCAL_TENANT, job_id=second_id))
+    assert resolve_job_locator(conn, 'local', 'https://example.test/apply') is None
+    assert repo.load(LOCAL_TENANT, first_id).application_url.value == 'https://canonical/new'
+    assert repo.load(LOCAL_TENANT, second_id).application_url.value == 'https://example.test/apply'
+    conn.execute('DELETE FROM jobs WHERE tenant_id=? AND job_id=?', (str(LOCAL_TENANT), str(first_id)))
+    assert conn.execute('SELECT COUNT(*) FROM job_application_locators WHERE job_id=?', (str(first_id),)).fetchone()[0] == 0
+    assert resolve_job_locator(conn, 'local', 'https://example.test/apply') == (str(second_id), 'https://post/second')

--- a/workers/automation/tests/test_exact_v10_schema.py
+++ b/workers/automation/tests/test_exact_v10_schema.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V9_MANIFEST,
+    EXACT_V10_MANIFEST,
+    SchemaManifestError,
+    assert_exact_manifest,
+    schema_dump,
+)
+from jobctrl.infrastructure.migrations.schema_v9 import create_exact_v9_schema
+from jobctrl.infrastructure.migrations.schema_v10 import (
+    create_exact_v10_schema,
+    create_unstamped_exact_v10_candidate,
+    upgrade_exact_v9_schema_to_v10,
+)
+
+
+def test_fresh_upgraded_and_unstamped_v10_have_identical_exact_schema() -> None:
+    with (
+        sqlite3.connect(":memory:") as fresh,
+        sqlite3.connect(":memory:") as upgraded,
+        sqlite3.connect(":memory:") as candidate,
+    ):
+        create_exact_v10_schema(fresh)
+        create_exact_v9_schema(upgraded)
+        upgrade_exact_v9_schema_to_v10(upgraded)
+        create_unstamped_exact_v10_candidate(candidate)
+        assert schema_dump(fresh) == schema_dump(upgraded) == schema_dump(candidate)
+        for conn in (fresh, upgraded, candidate):
+            assert_exact_manifest(conn, EXACT_V10_MANIFEST)
+            assert "application_url" not in {r[1] for r in conn.execute("PRAGMA table_info(jobs)")}
+        assert fresh.execute("PRAGMA user_version").fetchone() == (10,)
+        assert candidate.execute("PRAGMA user_version").fetchone() == (0,)
+        assert fresh.execute("SELECT COUNT(*) FROM resume_templates").fetchone()[0] > 0
+
+
+def test_upgrade_rejects_active_transaction_and_malformed_schema_without_changes() -> None:
+    with sqlite3.connect(":memory:") as conn:
+        create_exact_v9_schema(conn)
+        conn.execute("BEGIN")
+        with pytest.raises(SchemaManifestError, match="active transaction"):
+            upgrade_exact_v9_schema_to_v10(conn)
+        conn.rollback()
+        conn.execute("CREATE TABLE unexpected(value TEXT)")
+        before = tuple(conn.iterdump())
+        with pytest.raises(SchemaManifestError, match="exact v9 manifest"):
+            upgrade_exact_v9_schema_to_v10(conn)
+        assert tuple(conn.iterdump()) == before
+
+
+def test_failed_schema_upgrade_rolls_back_url_transfer_and_ddl() -> None:
+    with sqlite3.connect(":memory:") as conn:
+        create_exact_v9_schema(conn)
+        conn.execute("INSERT INTO jobs(tenant_id,job_id,url,application_url) VALUES('local','j','p','a')")
+        conn.commit()
+        before = tuple(conn.iterdump())
+
+        def fail_after_drop(sql: str) -> object:
+            result = conn.execute(sql)
+            if sql.startswith("ALTER TABLE jobs"):
+                raise RuntimeError("synthetic failure after column removal")
+            return result
+
+        with pytest.raises(RuntimeError, match="synthetic failure"):
+            upgrade_exact_v9_schema_to_v10(conn, _execute=fail_after_drop)
+        assert tuple(conn.iterdump()) == before
+        assert_exact_manifest(conn, EXACT_V9_MANIFEST)

--- a/workers/automation/tests/test_exact_v7_schema.py
+++ b/workers/automation/tests/test_exact_v7_schema.py
@@ -13,10 +13,10 @@ from jobctrl.database import (
     close_connection,
     init_db,
 )
-from jobctrl.infrastructure.migrations import schema_v9
+from jobctrl.infrastructure.migrations import schema_v10
 from jobctrl.infrastructure.migrations.schema_manifest import (
     EXACT_V7_MANIFEST,
-    EXACT_V9_MANIFEST,
+    EXACT_V10_MANIFEST,
     SchemaManifestError,
     assert_exact_manifest,
     schema_dump,
@@ -104,8 +104,8 @@ def test_fresh_runtime_creation_matches_the_exact_v9_manifest(tmp_path: Path) ->
 
     conn = init_db(db_path)
 
-    assert conn.execute("PRAGMA user_version").fetchone()[0] == EXACT_V9_MANIFEST.version
-    assert_exact_manifest(conn, EXACT_V9_MANIFEST)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == EXACT_V10_MANIFEST.version
+    assert_exact_manifest(conn, EXACT_V10_MANIFEST)
     assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
     assert conn.execute(
         "SELECT name FROM sqlite_master WHERE name = 'job_identity_aliases'"
@@ -251,7 +251,7 @@ def test_worker_heartbeat_does_not_drift_the_exact_v9_schema(
 
     reopened = init_db(db_path)
     assert schema_dump(reopened) == before_schema
-    assert_exact_manifest(reopened, EXACT_V9_MANIFEST)
+    assert_exact_manifest(reopened, EXACT_V10_MANIFEST)
     close_connection(db_path)
 
 
@@ -1532,7 +1532,7 @@ def test_failed_fresh_init_removes_its_file_and_can_retry(
     tmp_path: Path,
 ) -> None:
     db_path = tmp_path / "jobctrl.db"
-    create_schema = schema_v9.create_exact_v9_schema
+    create_schema = schema_v10.create_exact_v10_schema
 
     def fail_after_partial_creation(conn: sqlite3.Connection) -> None:
         executed = 0
@@ -1546,7 +1546,7 @@ def test_failed_fresh_init_removes_its_file_and_can_retry(
 
         create_schema(conn, _execute=fail_second_statement)
 
-    monkeypatch.setattr(schema_v9, "create_exact_v9_schema", fail_after_partial_creation)
+    monkeypatch.setattr(schema_v10, "create_exact_v10_schema", fail_after_partial_creation)
     with pytest.raises(RuntimeError, match="fixture creation failure"):
         init_db(db_path)
 
@@ -1554,7 +1554,7 @@ def test_failed_fresh_init_removes_its_file_and_can_retry(
     assert not Path(f"{db_path}-wal").exists()
     assert not Path(f"{db_path}-shm").exists()
 
-    monkeypatch.setattr(schema_v9, "create_exact_v9_schema", create_schema)
+    monkeypatch.setattr(schema_v10, "create_exact_v10_schema", create_schema)
     conn = init_db(db_path)
-    assert_exact_manifest(conn, EXACT_V9_MANIFEST)
+    assert_exact_manifest(conn, EXACT_V10_MANIFEST)
     close_connection(db_path)

--- a/workers/automation/tests/test_exact_v7_selector_job_identity.py
+++ b/workers/automation/tests/test_exact_v7_selector_job_identity.py
@@ -293,7 +293,6 @@ def test_exact_v7_selectors_ignore_retired_wide_job_state(
         """
         UPDATE jobs
         SET full_description = 'retired description',
-            application_url = 'https://apply.example.test/retired',
             detail_scraped_at = ?, detail_error = 'retired detail error',
             fit_score = 10, tailored_resume_path = '/tmp/retired-resume.txt',
             cover_letter_path = '/tmp/retired-cover.txt',
@@ -319,6 +318,10 @@ def test_exact_v7_selectors_ignore_retired_wide_job_state(
         WHERE tenant_id = ? AND job_id = ?
         """,
         (LOCAL_TENANT, TAILOR_JOB_ID),
+    )
+    conn.execute(
+        "INSERT INTO job_application_locators(tenant_id,job_id,application_url) VALUES(?,?,?)",
+        (OTHER_TENANT, OTHER_JOB_ID, "https://apply.example.test/retired"),
     )
     conn.commit()
 

--- a/workers/automation/tests/test_gmail_feedback.py
+++ b/workers/automation/tests/test_gmail_feedback.py
@@ -18,6 +18,9 @@ from jobctrl.infrastructure.gmail.feedback import (
 )
 
 
+from jobctrl.infrastructure.migrations.schema_v10 import create_exact_v10_schema
+
+JOB_ID = "7e0cc2ae-5d36-41f6-a7da-555714dabcd7"
 RECIPIENT = "candidate@example.com"
 JOB_URL = "https://jobs.example.com/platform-engineer"
 APPLIED_AT = "2026-06-01T10:00:00+00:00"
@@ -181,7 +184,7 @@ def test_linked_body_is_ingested_and_suggested(tmp_path: Path) -> None:
         {
             "suggestionId": summary["suggestions"][0]["suggestionId"],
             "evidenceId": summary["evidence"][0]["evidenceId"],
-            "jobKey": JOB_URL,
+            "jobKey": JOB_ID,
             "kind": "applied_confirmation",
             "confidence": pytest.approx(0.9),
         }
@@ -387,65 +390,20 @@ def seed_feedback_db(tmp_path: Path) -> Path:
     db_path = tmp_path / "jobctrl.db"
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA journal_mode=WAL")
+    create_exact_v10_schema(conn)
     conn.execute(
-        """
-        CREATE TABLE jobs (
-            url TEXT PRIMARY KEY,
-            title TEXT,
-            company TEXT,
-            site TEXT,
-            application_url TEXT,
-            applied_at TEXT,
-            apply_status TEXT,
-            discovered_at TEXT
-        )
-        """
+        "INSERT INTO jobs(tenant_id,job_id,url,title,company,site,applied_at,apply_status,discovered_at) "
+        "VALUES('local',?,?, 'Principal Platform Engineer','ExampleCo','ExampleCo',?,'applied','2026-05-31T10:00:00+00:00')",
+        (JOB_ID, JOB_URL, APPLIED_AT),
     )
     conn.execute(
-        """
-        INSERT INTO jobs (
-            url, title, company, site, application_url, applied_at,
-            apply_status, discovered_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-        (
-            JOB_URL,
-            "Principal Platform Engineer",
-            "ExampleCo",
-            "ExampleCo",
-            "https://boards.greenhouse.io/exampleco/jobs/123",
-            APPLIED_AT,
-            "applied",
-            "2026-05-31T10:00:00+00:00",
-        ),
+        "INSERT INTO job_enrichments(tenant_id,job_id,current_status,application_url,updated_at) "
+        "VALUES('local',?,'pending','https://boards.greenhouse.io/exampleco/jobs/123',?)",
+        (JOB_ID, APPLIED_AT),
     )
     conn.execute(
-        """
-        CREATE TABLE candidate_profiles (
-            tenant_id TEXT NOT NULL DEFAULT 'local',
-            profile_id TEXT NOT NULL DEFAULT 'default',
-            personal_email TEXT NOT NULL DEFAULT '',
-            PRIMARY KEY (tenant_id, profile_id)
-        )
-        """
-    )
-    conn.execute(
-        "INSERT INTO candidate_profiles (tenant_id, profile_id, personal_email) VALUES (?, ?, ?)",
-        ("local", "default", RECIPIENT),
-    )
-    conn.execute(
-        """
-        CREATE TABLE job_events (
-            event_id INTEGER PRIMARY KEY AUTOINCREMENT,
-            job_url TEXT,
-            stage TEXT,
-            event_type TEXT NOT NULL DEFAULT '',
-            level TEXT NOT NULL DEFAULT 'info',
-            message TEXT,
-            occurred_at TEXT NOT NULL,
-            payload_json TEXT
-        )
-        """
+        "INSERT INTO candidate_profiles(tenant_id,profile_id,personal_email,updated_at) VALUES('local','default',?,?)",
+        (RECIPIENT, APPLIED_AT),
     )
     ensure_application_feedback_tables(conn)
     conn.commit()
@@ -459,7 +417,7 @@ def seed_existing_evidence(db_path: Path, *, provider_message_id: str) -> None:
     conn.execute(
         """
         INSERT INTO application_email_evidence (
-            tenant_id, evidence_id, job_key, provider, provider_message_id,
+            tenant_id, evidence_id, job_id, provider, provider_message_id,
             provider_thread_id, from_address, to_addresses_json, subject, snippet,
             received_at, linked_at, link_confidence, link_signals_json,
             body_text, body_sha256, body_stored_at
@@ -468,7 +426,7 @@ def seed_existing_evidence(db_path: Path, *, provider_message_id: str) -> None:
         (
             "local",
             "existing-evidence",
-            JOB_URL,
+            JOB_ID,
             "gmail",
             provider_message_id,
             "thread-dupe",
@@ -491,3 +449,49 @@ def seed_existing_evidence(db_path: Path, *, provider_message_id: str) -> None:
 
 def epoch_ms(value: str) -> int:
     return int(datetime.fromisoformat(value).timestamp() * 1000)
+
+
+def test_exact_scan_preserves_other_tenant_and_schema_and_writes_canonical_references(tmp_path: Path) -> None:
+    from jobctrl.infrastructure.migrations.schema_manifest import EXACT_V10_MANIFEST, assert_exact_manifest, schema_dump
+
+    db_path = seed_feedback_db(tmp_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("INSERT INTO jobs(tenant_id,job_id,url,title,company,applied_at) VALUES('other', ?, ?, 'Other title', 'Other tenant', ?)", (JOB_ID, JOB_URL, APPLIED_AT))
+        conn.execute("INSERT INTO job_enrichments(tenant_id,job_id,current_status,application_url,updated_at) VALUES('other',?,'pending','https://other.example/apply',?)", (JOB_ID, APPLIED_AT))
+        conn.execute("INSERT INTO application_outcomes(tenant_id,outcome_id,job_id,kind,source,occurred_at,recorded_at) VALUES('other','other-outcome',?,'offer','user',?,?)", (JOB_ID, APPLIED_AT, APPLIED_AT))
+        other_before = conn.execute("SELECT * FROM jobs WHERE tenant_id='other'").fetchall()
+        schema_before = schema_dump(conn)
+    metadata = {'id':'tenant-message','subject':'ExampleCo Platform application received','from':'recruiting@exampleco.com','to':RECIPIENT,'internalDate':str(epoch_ms('2026-06-01T11:00:00+00:00'))}
+    client = FakeGmailClient([metadata], {'tenant-message': dict(metadata, body_text='Thank you for applying.')})
+    summary = scan_gmail_feedback(db_path=db_path, client=client, recipient_email=RECIPIENT)
+    assert summary['scannedAnchorCount'] == 1 and summary['linkedEvidenceCount'] == 1
+    assert summary['evidence'][0]['jobKey'] == JOB_ID
+    with sqlite3.connect(db_path) as conn:
+        assert_exact_manifest(conn, EXACT_V10_MANIFEST)
+        assert schema_dump(conn) == schema_before
+        assert conn.execute("SELECT * FROM jobs WHERE tenant_id='other'").fetchall() == other_before
+        for table in ('application_email_evidence', 'application_outcome_suggestions'):
+            assert conn.execute(f'SELECT tenant_id,job_id FROM {table}').fetchall() == [('local',JOB_ID)]
+        event = conn.execute('SELECT tenant_id,job_id,identity_version,payload_json FROM job_events').fetchone()
+        assert event[:3] == ('local',JOB_ID,1)
+        assert json.loads(event[3])['jobId'] == JOB_ID
+        assert conn.execute('PRAGMA foreign_key_check').fetchall() == []
+        assert conn.execute('SELECT tenant_id,outcome_id FROM application_outcomes').fetchall() == [('other','other-outcome')]
+
+
+def test_feedback_rejects_old_schema_before_any_table_mutation(tmp_path: Path) -> None:
+    from jobctrl.database import SchemaMigrationRequiredError, close_connection
+    from jobctrl.infrastructure.migrations.schema_v9 import create_exact_v9_schema
+
+    db_path = tmp_path / 'old.db'
+    with sqlite3.connect(db_path) as conn:
+        create_exact_v9_schema(conn)
+    before = db_path.read_bytes()
+    client = FakeGmailClient([])
+    try:
+        with pytest.raises(SchemaMigrationRequiredError):
+            scan_gmail_feedback(db_path=db_path, client=client, recipient_email=RECIPIENT)
+        assert db_path.read_bytes() == before
+        assert not client.search_calls and not client.read_calls
+    finally:
+        close_connection(db_path)

--- a/workers/automation/tests/test_gmail_feedback_v10_anchors.py
+++ b/workers/automation/tests/test_gmail_feedback_v10_anchors.py
@@ -1,0 +1,46 @@
+"""Exact current-schema anchor lookup and tenant isolation regressions."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from jobctrl.infrastructure.gmail.feedback import _apply_run_anchors, _job_anchors, _outcome_anchors
+from jobctrl.infrastructure.migrations.schema_v10 import create_exact_v10_schema
+
+
+@pytest.mark.parametrize("reader", [_job_anchors, _outcome_anchors, _apply_run_anchors])
+def test_anchor_uses_canonical_enrichment_and_exact_tenant_job_identity(reader) -> None:
+    with sqlite3.connect(":memory:") as conn:
+        conn.row_factory = sqlite3.Row
+        create_exact_v10_schema(conn)
+        for tenant in ("local", "other"):
+            conn.execute(
+                "INSERT INTO jobs(tenant_id,job_id,url,title,company,applied_at) VALUES(?, 'same-job', 'https://post/shared', ?, ?, '2026-09-01T10:00:00+00:00')",
+                (tenant, f"{tenant} title", f"{tenant} company"),
+            )
+            conn.execute(
+                "INSERT INTO job_enrichments(tenant_id,job_id,current_status,application_url,updated_at) VALUES(?, 'same-job', 'pending', ?, '2026-09-01T09:00:00+00:00')",
+                (tenant, f"https://{tenant}.canonical/apply"),
+            )
+            conn.execute(
+                "INSERT INTO job_application_locators VALUES(?, 'same-job', ?)",
+                (tenant, f"https://{tenant}.historical/alias"),
+            )
+            conn.execute(
+                "INSERT INTO application_outcomes(tenant_id,outcome_id,job_id,kind,source,occurred_at,recorded_at) VALUES(?, ?, 'same-job', 'applied_confirmation', 'user', '2026-09-01T10:00:00+00:00', '2026-09-01T10:00:00+00:00')",
+                (tenant, f"{tenant}-outcome"),
+            )
+            conn.execute(
+                "INSERT INTO apply_run_projections(run_id,tenant_id,job_id,status,finished_at) VALUES(?, ?, 'same-job', 'succeeded', '2026-09-01T10:00:00+00:00')",
+                (f"{tenant}-run", tenant),
+            )
+        anchors = reader(conn)
+        assert len(anchors) == 1
+        assert anchors[0].job_key == "same-job"
+        assert anchors[0].title == "local title"
+        assert anchors[0].company == "local company"
+        assert anchors[0].application_url == "https://local.canonical/apply"
+        conn.execute("DELETE FROM job_enrichments WHERE tenant_id='local'")
+        assert reader(conn)[0].application_url == ""

--- a/workers/automation/tests/test_job_application_locators.py
+++ b/workers/automation/tests/test_job_application_locators.py
@@ -1,0 +1,35 @@
+"""Canonical application target and preserved alias resolution on exact v10."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from jobctrl.infrastructure.job_locators import resolve_job_locator
+from jobctrl.infrastructure.migrations.schema_v10 import create_exact_v10_schema
+
+
+def test_resolver_prefers_posting_and_rejects_shared_application_aliases() -> None:
+    with sqlite3.connect(":memory:") as conn:
+        create_exact_v10_schema(conn)
+        for tenant, job, posting in [
+            ("local", "one", "https://post/one"),
+            ("local", "two", "https://post/two"),
+            ("other", "one", "https://post/one"),
+        ]:
+            conn.execute("INSERT INTO jobs(tenant_id,job_id,url) VALUES(?,?,?)", (tenant, job, posting))
+            conn.execute(
+                "INSERT INTO job_enrichments(tenant_id,job_id,current_status,application_url,updated_at) VALUES(?,?,'pending',?,'now')",
+                (tenant, job, f"https://{tenant}/canonical/{job}"),
+            )
+            conn.execute(
+                "INSERT INTO job_application_locators VALUES(?,?,?)", (tenant, job, f"https://{tenant}/old/{job}")
+            )
+            conn.execute("INSERT INTO job_application_locators VALUES(?,?,'https://shared/apply')", (tenant, job))
+        assert resolve_job_locator(conn, "local", "https://local/canonical/one") == ("one", "https://post/one")
+        assert resolve_job_locator(conn, "local", "https://local/old/one") == ("one", "https://post/one")
+        assert resolve_job_locator(conn, "other", "https://shared/apply") == ("one", "https://post/one")
+        assert resolve_job_locator(conn, "local", "https://shared/apply") is None
+        assert resolve_job_locator(conn, "local", "https://other/canonical/one") is None
+        assert resolve_job_locator(conn, "missing", "one") is None
+        conn.execute("INSERT INTO job_application_locators VALUES('local','two','https://post/one')")
+        assert resolve_job_locator(conn, "local", "https://post/one") == ("one", "https://post/one")

--- a/workers/automation/tests/test_job_list_projection.py
+++ b/workers/automation/tests/test_job_list_projection.py
@@ -44,8 +44,8 @@ def _seed_job(
         """
         INSERT INTO jobs (
             tenant_id, job_id, url, title, site, strategy, location, salary,
-            discovered_at, application_url, description
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            discovered_at, description
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             str(LOCAL_TENANT),
@@ -57,9 +57,13 @@ def _seed_job(
             "Remote",
             "$$$",
             "2026-05-04T12:00:00+00:00",
-            url,
             "Short job description",
         ),
+    )
+    conn.execute(
+        "INSERT INTO job_enrichments(tenant_id,job_id,current_status,application_url,updated_at) "
+        "VALUES (?,?,'pending',?,?)",
+        (str(LOCAL_TENANT), str(job_id), url, "2026-05-04T12:00:00+00:00"),
     )
     conn.commit()
     return job_id

--- a/workers/automation/tests/test_legacy_to_v10_execute.py
+++ b/workers/automation/tests/test_legacy_to_v10_execute.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.migrations import legacy_to_v10_execute as migration
+from jobctrl.infrastructure.migrations.schema_manifest import EXACT_V10_MANIFEST, assert_exact_manifest
+from jobctrl.infrastructure.migrations.schema_v7 import create_exact_v7_schema
+from jobctrl.infrastructure.migrations.schema_v8 import create_exact_v8_schema
+from tests.v6_migration_fixture import create_shipped_v6_database
+
+
+def _source(path: Path, version: int) -> None:
+    if version == 6:
+        create_shipped_v6_database(path)
+        return
+    with sqlite3.connect(path) as conn:
+        (create_exact_v7_schema if version == 7 else create_exact_v8_schema)(conn)
+        conn.execute(
+            "INSERT INTO jobs(tenant_id,job_id,url,title,application_url) VALUES('local','11111111-1111-4111-8111-111111111111','https://post/legacy','Retained title','https://apply/shared')"
+        )
+
+
+@pytest.mark.parametrize("version", [6, 7, 8])
+def test_all_legacy_routes_make_exact_v10_and_remove_every_nested_intermediate(tmp_path: Path, version: int) -> None:
+    source, candidate = tmp_path / "source.db", tmp_path / "candidate.db"
+    _source(source, version)
+    before = source.read_bytes()
+    result = migration.execute_legacy_to_v10_candidate(
+        source,
+        candidate,
+        source_version=version,
+        migration_at="2026-08-20T00:00:00+00:00" if version == 6 else None,
+    )
+    assert result.user_version == 10 and result.source_data_digest == result.candidate_data_digest
+    assert source.read_bytes() == before
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["candidate.db", "source.db"]
+    with sqlite3.connect(candidate) as conn:
+        assert_exact_manifest(conn, EXACT_V10_MANIFEST)
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+        if version != 6:
+            assert conn.execute("SELECT title FROM jobs").fetchone() == ("Retained title",)
+            assert conn.execute("SELECT application_url,current_status FROM job_enrichments").fetchone() == (
+                "https://apply/shared",
+                "pending",
+            )
+
+
+@pytest.mark.parametrize("version", [6, 7, 8])
+def test_downstream_failure_removes_private_v9_and_all_nested_files(
+    tmp_path: Path, version: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, candidate = tmp_path / "source.db", tmp_path / "candidate.db"
+    _source(source, version)
+    before = source.read_bytes()
+
+    def fail(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("injected downstream failure")
+
+    monkeypatch.setattr(migration, "execute_v9_to_v10_candidate", fail)
+    with pytest.raises(migration.CandidateExecutionError):
+        migration.execute_legacy_to_v10_candidate(
+            source,
+            candidate,
+            source_version=version,
+            migration_at="2026-08-20T00:00:00+00:00" if version == 6 else None,
+        )
+    assert source.read_bytes() == before
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["source.db"]
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "",
+        ".exact-v9-intermediate",
+        ".exact-v9-intermediate.exact-v8-intermediate",
+        ".exact-v9-intermediate.exact-v8-intermediate.exact-v7-intermediate",
+    ],
+)
+def test_existing_destination_and_nested_intermediates_are_preserved(tmp_path: Path, suffix: str) -> None:
+    source, candidate = tmp_path / "source.db", tmp_path / "candidate.db"
+    _source(source, 6)
+    protected = Path(f"{candidate}{suffix}")
+    protected.write_bytes(b"preexisting owned data")
+    before = source.read_bytes()
+    with pytest.raises(migration.CandidateExecutionError):
+        migration.execute_legacy_to_v10_candidate(
+            source, candidate, source_version=6, migration_at="2026-08-20T00:00:00+00:00"
+        )
+    assert protected.read_bytes() == b"preexisting owned data"
+    assert source.read_bytes() == before
+    assert sorted(p.name for p in tmp_path.iterdir()) == sorted(["source.db", protected.name])
+
+
+def test_intermediate_cleanup_failure_never_publishes_final_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source, candidate = tmp_path / "source.db", tmp_path / "candidate.db"
+    _source(source, 8)
+    before = source.read_bytes()
+    original = migration._remove_created_candidate
+    attempts = 0
+
+    def fail_once(path: Path, identity: tuple[int, int]) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OSError("synthetic cleanup failure")
+        original(path, identity)
+
+    monkeypatch.setattr(migration, "_remove_created_candidate", fail_once)
+    with pytest.raises(migration.CandidateExecutionError):
+        migration.execute_legacy_to_v10_candidate(source, candidate, source_version=8)
+    assert source.read_bytes() == before
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["source.db"]

--- a/workers/automation/tests/test_materials_queue_selectors.py
+++ b/workers/automation/tests/test_materials_queue_selectors.py
@@ -362,7 +362,7 @@ def test_get_stats_ready_to_apply_reflects_materials_writes(conn: sqlite3.Connec
     """``ready_to_apply`` requires tailored text, resume PDF, and application_url."""
     job_id = _seed_selector_job(conn, "job")
     conn.execute(
-        "UPDATE jobs SET application_url = 'https://example.com/apply' "
+        "UPDATE job_enrichments SET application_url = 'https://example.com/apply' "
         "WHERE tenant_id = ? AND job_id = ?",
         (LOCAL_TENANT, job_id),
     )
@@ -391,7 +391,7 @@ def test_get_stats_ready_to_apply_excludes_text_only_tailored_materials(
 ) -> None:
     job_id = _seed_selector_job(conn, "text-only")
     conn.execute(
-        "UPDATE jobs SET application_url = 'https://example.com/apply' "
+        "UPDATE job_enrichments SET application_url = 'https://example.com/apply' "
         "WHERE tenant_id = ? AND job_id = ?",
         (LOCAL_TENANT, job_id),
     )

--- a/workers/automation/tests/test_projection_builder.py
+++ b/workers/automation/tests/test_projection_builder.py
@@ -51,8 +51,8 @@ def _seed_job(
         """
         INSERT INTO jobs (
             tenant_id, job_id, url, title, company, site, strategy, location,
-            salary, discovered_at, application_url, description
-        ) VALUES (?, ?, ?, ?, ?, ?, 'jobspy', ?, ?, ?, ?, ?)
+            salary, discovered_at, description
+        ) VALUES (?, ?, ?, ?, ?, ?, 'jobspy', ?, ?, ?, ?)
         """,
         (
             str(LOCAL_TENANT),
@@ -64,9 +64,13 @@ def _seed_job(
             location,
             salary,
             utc_now(),
-            url,
             description,
         ),
+    )
+    conn.execute(
+        "INSERT INTO job_enrichments(tenant_id,job_id,current_status,application_url,updated_at) "
+        "VALUES (?,?,'pending',?,?)",
+        (str(LOCAL_TENANT), str(job_id), url, utc_now()),
     )
     conn.commit()
     return job_id
@@ -1530,8 +1534,9 @@ def test_score_audit_backfill_runs_at_most_once(conn: sqlite3.Connection) -> Non
         correction_json=None,
     )
     conn.execute(
-        "INSERT INTO job_list_projections (tenant_id, job_id, title, fit_score) VALUES ('local', ?, 'Engineer', 6)",
-        (str(later_job_id),),
+        "INSERT INTO job_list_projections (tenant_id, job_id, title, fit_score, application_url) "
+        "VALUES ('local', ?, 'Engineer', 6, ?)",
+        (str(later_job_id), later),
     )
     record_job_event(conn, later_job_id, "score", "JobScored", payload=_INERT_CONTEXT)
     latest_event_id = conn.execute("SELECT MAX(event_id) FROM job_events").fetchone()[0]

--- a/workers/automation/tests/test_schema_v7_packaging.py
+++ b/workers/automation/tests/test_schema_v7_packaging.py
@@ -14,6 +14,7 @@ _SCHEMA_MEMBERS = {
     "jobctrl/infrastructure/migrations/schema_v7.sql",
     "jobctrl/infrastructure/migrations/schema_v8.sql",
     "jobctrl/infrastructure/migrations/schema_v9.sql",
+    "jobctrl/infrastructure/migrations/schema_v10.sql",
 }
 
 

--- a/workers/automation/tests/test_state_dashboard.py
+++ b/workers/automation/tests/test_state_dashboard.py
@@ -27,7 +27,6 @@ def _insert_job(conn, **overrides):
         "strategy": "test",
         "discovered_at": "2026-04-29T10:00:00+00:00",
         "full_description": None,
-        "application_url": None,
         "detail_error": None,
         "fit_score": None,
         "tailored_resume_path": None,
@@ -42,12 +41,12 @@ def _insert_job(conn, **overrides):
         """
         INSERT INTO jobs (
             tenant_id, job_id, url, title, site, strategy, discovered_at, full_description,
-            application_url, detail_error, fit_score, tailored_resume_path,
+            detail_error, fit_score, tailored_resume_path,
             tailor_attempts, cover_letter_path, cover_attempts, apply_status,
             applied_at
         ) VALUES (
             :tenant_id, :job_id, :url, :title, :site, :strategy, :discovered_at, :full_description,
-            :application_url, :detail_error, :fit_score, :tailored_resume_path,
+            :detail_error, :fit_score, :tailored_resume_path,
             :tailor_attempts, :cover_letter_path, :cover_attempts, :apply_status,
             :applied_at
         )

--- a/workers/automation/tests/test_v6_to_v7_feedback_copy.py
+++ b/workers/automation/tests/test_v6_to_v7_feedback_copy.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from jobctrl.infrastructure.gmail.feedback import ensure_application_feedback_tables
+from tests.v6_feedback_fixture import ensure_application_feedback_tables
 from jobctrl.infrastructure.migrations.schema_v7 import (
     create_unstamped_exact_v7_candidate,
 )

--- a/workers/automation/tests/test_v6_to_v7_preflight.py
+++ b/workers/automation/tests/test_v6_to_v7_preflight.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from jobctrl.infrastructure.gmail.feedback import (
+from tests.v6_feedback_fixture import (
     ensure_application_feedback_tables,
 )
 from jobctrl.infrastructure.migrations.v6_to_v7_preflight import (

--- a/workers/automation/tests/test_v9_to_v10_execute.py
+++ b/workers/automation/tests/test_v9_to_v10_execute.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jobctrl.infrastructure.migrations.schema_manifest import (
+    EXACT_V9_MANIFEST,
+    EXACT_V10_MANIFEST,
+    assert_exact_manifest,
+)
+from jobctrl.infrastructure.migrations.schema_v9 import create_exact_v9_schema
+from jobctrl.infrastructure.migrations.v9_to_v10_execute import (
+    CandidateExecutionError,
+    execute_v9_to_v10_candidate,
+    main,
+)
+
+# Missing row, NULL, empty, conflicting, equal, shared and verbatim whitespace URLs.
+_CASES = [
+    ("local", "legacy", "legacy-url", None, False, "detail-time", "discovered-time"),
+    ("local", "discovered", "other-url", None, False, "", "discovered-time"),
+    ("local", "epoch", "epoch-url", None, False, None, None),
+    ("local", "canonical", None, "canonical-url", True, None, None),
+    ("local", "conflict", "old-url", "canonical-url", True, None, None),
+    ("local", "null", "shared-url", None, True, None, None),
+    ("local", "empty", "shared-url", "", True, None, None),
+    ("local", "equal", "same-url", "same-url", True, None, None),
+    ("local", "none", None, None, False, None, None),
+    ("local", "blank", "", "", True, None, None),
+    ("other", "legacy", "shared-url", "other-canonical", True, None, None),
+    ("other", "verbatim", "  Mixed/%2f?b=2&a=1  ", None, False, None, None),
+]
+
+
+def _source(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        create_exact_v9_schema(conn)
+        conn.execute("PRAGMA foreign_keys=ON")
+        for tenant, job, legacy, canonical, has_row, detail_at, discovered_at in _CASES:
+            conn.execute(
+                "INSERT INTO jobs(tenant_id,job_id,url,title,application_url,detail_scraped_at,discovered_at,apply_status) VALUES(?,?,?,?,?,?,?,?)",
+                (tenant, job, f"https://post/{job}", "Synthetic title", legacy, detail_at, discovered_at, "pending"),
+            )
+            if has_row:
+                conn.execute(
+                    "INSERT INTO job_enrichments VALUES(?,?,'failed','retained body',?,'old-enriched','tier-original','[{\"error\":\"retained\"}]','updated-original')",
+                    (tenant, job, canonical),
+                )
+        conn.execute(
+            "INSERT INTO candidate_profiles(tenant_id,profile_id,updated_at,personal_full_name) VALUES('local','default','profile-time','Synthetic Person')"
+        )
+        conn.execute(
+            "INSERT INTO candidate_profile_experience_entries(tenant_id,profile_id,entry_id,position_index,title,company,summary) VALUES('local','default','role',0,'Title','Synthetic','Preserve summary')"
+        )
+        conn.execute(
+            "INSERT INTO job_events(event_id,tenant_id,job_id,identity_version,event_type,occurred_at,payload_json) VALUES(81,'local','legacy',7,'synthetic','event-time','{\"retained\":true}')"
+        )
+        conn.execute(
+            "INSERT INTO job_events(event_id,tenant_id,identity_version,event_type,occurred_at) VALUES(100,'local',7,'deleted','time')"
+        )
+        conn.execute("DELETE FROM job_events WHERE event_id=100")
+        conn.execute(
+            "INSERT INTO job_artifacts(artifact_id,tenant_id,job_id,stage,artifact_type,path,created_at,metadata_json) VALUES(22,'local','legacy','tailor','resume','synthetic/path','artifact-time','{\"retained\":1}')"
+        )
+        conn.execute(
+            "INSERT INTO job_list_projections(tenant_id,job_id,title,application_url,score_trace_json) VALUES('local','legacy','Projection title','historical-projection','{\"retain\":2}')"
+        )
+
+
+def test_full_transfer_preserves_all_other_columns_references_and_sequences(tmp_path: Path) -> None:
+    source, candidate = tmp_path / "source.db", tmp_path / "candidate.db"
+    _source(source)
+    before = source.read_bytes()
+    result = execute_v9_to_v10_candidate(source, candidate)
+    assert source.read_bytes() == before
+    assert result.user_version == 10 and result.status == "ready"
+    assert result.source_data_digest == result.candidate_data_digest
+    assert result.candidate_sha256 == hashlib.sha256(candidate.read_bytes()).hexdigest()
+    assert result.job_count == len(_CASES) and result.table_count == 118
+    assert candidate.stat().st_mode & 0o777 == 0o600
+    with sqlite3.connect(source) as old, sqlite3.connect(candidate) as new:
+        assert_exact_manifest(old, EXACT_V9_MANIFEST)
+        assert_exact_manifest(new, EXACT_V10_MANIFEST)
+        # Independent expected policy, including exact lifecycle and all unspecified defaults.
+        expected_aliases = set()
+        for tenant, job, legacy, canonical, has_row, detail_at, discovered_at in _CASES:
+            for value in (legacy, canonical):
+                if value is not None and value != "":
+                    expected_aliases.add((tenant, job, value))
+            row = new.execute("SELECT * FROM job_enrichments WHERE tenant_id=? AND job_id=?", (tenant, job)).fetchone()
+            if has_row:
+                expected = list(
+                    old.execute(
+                        "SELECT * FROM job_enrichments WHERE tenant_id=? AND job_id=?", (tenant, job)
+                    ).fetchone()
+                )
+                if canonical in (None, "") and legacy not in (None, ""):
+                    expected[4] = legacy
+                assert row == tuple(expected)
+            elif legacy not in (None, ""):
+                assert row == (
+                    tenant,
+                    job,
+                    "pending",
+                    None,
+                    legacy,
+                    None,
+                    None,
+                    "[]",
+                    detail_at or discovered_at or "1970-01-01T00:00:00+00:00",
+                )
+            else:
+                assert row is None
+        assert set(new.execute("SELECT * FROM job_application_locators")) == expected_aliases
+        tables = [
+            r[0]
+            for r in old.execute("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_stat%'")
+        ]
+        for table in tables:
+            if table == "job_enrichments":
+                continue  # Every complete row checked above.
+            columns = [
+                r[1]
+                for r in old.execute(f'PRAGMA table_info("{table}")')
+                if not (table == "jobs" and r[1] == "application_url")
+            ]
+            selected = ",".join(f'"{c}"' for c in columns)
+            sql = f'SELECT {selected} FROM "{table}" ORDER BY {selected}'
+            assert old.execute(sql).fetchall() == new.execute(sql).fetchall(), table
+        assert new.execute("PRAGMA foreign_key_check").fetchall() == []
+        assert new.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+        new.execute("PRAGMA foreign_keys=ON")
+        new.execute("DELETE FROM jobs WHERE tenant_id='local' AND job_id='legacy'")
+        assert new.execute(
+            "SELECT COUNT(*) FROM job_application_locators WHERE tenant_id='local' AND job_id='legacy'"
+        ).fetchone() == (0,)
+        assert (
+            new.execute(
+                "SELECT COUNT(*) FROM job_application_locators WHERE tenant_id='other' AND job_id='legacy'"
+            ).fetchone()[0]
+            > 0
+        )
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "UPDATE jobs SET title='corruption' WHERE job_id='legacy'",
+        "DELETE FROM job_application_locators WHERE application_url='old-url'",
+        "INSERT INTO job_application_locators VALUES('local','legacy','invented-url')",
+        "UPDATE job_enrichments SET current_status='succeeded' WHERE job_id='epoch'",
+        "UPDATE job_enrichments SET application_url='wrong' WHERE job_id='conflict'",
+        "UPDATE job_enrichments SET attempts_json='[]' WHERE job_id='empty'",
+        "UPDATE job_artifacts SET path='corrupted'",
+        "UPDATE job_events SET payload_json='{}'",
+        "UPDATE candidate_profiles SET personal_full_name='corrupted'",
+        "UPDATE sqlite_sequence SET seq=999 WHERE name='job_events'",
+        "DELETE FROM job_list_projections",
+    ],
+)
+def test_expected_negative_corruption_is_rejected_and_owned_candidate_removed(tmp_path: Path, sql: str) -> None:
+    source, candidate = tmp_path / "source.db", tmp_path / "candidate.db"
+    _source(source)
+    before = source.read_bytes()
+
+    def corrupt() -> None:
+        with sqlite3.connect(candidate) as conn:
+            conn.execute(sql)
+
+    with pytest.raises(CandidateExecutionError, match="v9-to-v10 candidate migration failed"):
+        execute_v9_to_v10_candidate(source, candidate, _after_stamp=corrupt)
+    assert source.read_bytes() == before
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["source.db"]
+
+
+@pytest.mark.parametrize("suffix", ["", "-wal", "-shm", "-journal"])
+def test_existing_destination_or_sidecar_is_never_deleted(tmp_path: Path, suffix: str) -> None:
+    source, candidate = tmp_path / "source.db", tmp_path / "candidate.db"
+    _source(source)
+    protected = Path(f"{candidate}{suffix}")
+    protected.write_bytes(b"preexisting")
+    before = source.read_bytes()
+    with pytest.raises(CandidateExecutionError):
+        execute_v9_to_v10_candidate(source, candidate)
+    assert protected.read_bytes() == b"preexisting"
+    assert source.read_bytes() == before
+
+
+def test_symlink_destination_is_preserved(tmp_path: Path) -> None:
+    source, candidate = tmp_path / "source.db", tmp_path / "candidate.db"
+    _source(source)
+    candidate.symlink_to(source)
+    before = source.read_bytes()
+    with pytest.raises(CandidateExecutionError):
+        execute_v9_to_v10_candidate(source, candidate)
+    assert candidate.is_symlink() and source.read_bytes() == before
+
+
+def test_stamp_fault_and_malformed_source_fail_closed(tmp_path: Path) -> None:
+    source, candidate = tmp_path / "source.db", tmp_path / "candidate.db"
+    _source(source)
+    before = source.read_bytes()
+
+    def fail() -> None:
+        raise RuntimeError("synthetic crash")
+
+    with pytest.raises(CandidateExecutionError):
+        execute_v9_to_v10_candidate(source, candidate, _after_stamp=fail)
+    assert not candidate.exists() and source.read_bytes() == before
+    with sqlite3.connect(source) as conn:
+        conn.execute("CREATE TABLE injected(value TEXT)")
+    before = source.read_bytes()
+    with pytest.raises(CandidateExecutionError):
+        execute_v9_to_v10_candidate(source, candidate)
+    assert not candidate.exists() and source.read_bytes() == before
+
+
+def test_private_cli_has_bounded_receipt_and_generic_errors(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    source, candidate = tmp_path / "source.db", tmp_path / "candidate.db"
+    _source(source)
+    assert main(["--source", str(source), "--candidate", str(candidate)]) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["user_version"] == 10 and len(receipt) == 8
+    assert main(["--source", str(source), "--candidate", str(candidate)]) == 1
+    assert capsys.readouterr().err == "v9-to-v10 candidate migration failed\n"
+
+
+@pytest.mark.parametrize("operation", ["_fsync_regular_file", "_fsync_directory"])
+def test_fsync_failure_rejects_and_removes_candidate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    from jobctrl.infrastructure.migrations import v9_to_v10_execute as migration
+
+    source, candidate = tmp_path / "source.db", tmp_path / "candidate.db"
+    _source(source)
+    before = source.read_bytes()
+
+    def fail(_path: Path) -> None:
+        raise OSError("synthetic fsync failure")
+
+    monkeypatch.setattr(migration, operation, fail)
+    with pytest.raises(CandidateExecutionError):
+        execute_v9_to_v10_candidate(source, candidate)
+    assert source.read_bytes() == before
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["source.db"]
+
+
+def test_external_source_legacy_url_change_cannot_pass_retained_digest(tmp_path: Path) -> None:
+    source, candidate = tmp_path / "source.db", tmp_path / "candidate.db"
+    _source(source)
+
+    def mutate_source() -> None:
+        with sqlite3.connect(source) as conn:
+            conn.execute("UPDATE jobs SET application_url='external-change' WHERE job_id='legacy'")
+
+    with pytest.raises(CandidateExecutionError):
+        execute_v9_to_v10_candidate(source, candidate, _after_stamp=mutate_source)
+    assert not candidate.exists()
+    # Only the deliberately injected external mutation persists; v9 stays usable.
+    with sqlite3.connect(source) as conn:
+        assert_exact_manifest(conn, EXACT_V9_MANIFEST)
+        assert conn.execute(
+            "SELECT application_url FROM jobs WHERE tenant_id='local' AND job_id='legacy'"
+        ).fetchone() == ("external-change",)
+
+
+def test_replaced_candidate_and_its_sidecars_are_not_removed(tmp_path: Path) -> None:
+    source, candidate = tmp_path / "source.db", tmp_path / "candidate.db"
+    _source(source)
+    before = source.read_bytes()
+
+    def replace() -> None:
+        candidate.rename(tmp_path / "owned-displaced.db")
+        candidate.write_bytes(b"other owner")
+        Path(f"{candidate}-wal").write_bytes(b"other owner sidecar")
+
+    with pytest.raises(CandidateExecutionError):
+        execute_v9_to_v10_candidate(source, candidate, _after_stamp=replace)
+    assert source.read_bytes() == before
+    assert candidate.read_bytes() == b"other owner"
+    assert Path(f"{candidate}-wal").read_bytes() == b"other owner sidecar"

--- a/workers/automation/tests/v6_feedback_fixture.py
+++ b/workers/automation/tests/v6_feedback_fixture.py
@@ -1,0 +1,124 @@
+"""Frozen pre-v7 Gmail table owner for historical migration fixtures only."""
+from __future__ import annotations
+
+import sqlite3
+
+
+def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
+    """Create the feedback tables with the TypeScript API's table shape."""
+
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS application_review_decisions (
+          tenant_id    TEXT NOT NULL DEFAULT 'local',
+          decision_id  TEXT NOT NULL,
+          job_key      TEXT NOT NULL,
+          decision     TEXT NOT NULL,
+          reason       TEXT,
+          decided_by   TEXT NOT NULL DEFAULT 'user',
+          decided_at   TEXT NOT NULL,
+          materials_generation INTEGER,
+          profile_version INTEGER,
+          application_url TEXT,
+          partial_override_run_id TEXT,
+          email_recipient TEXT,
+          email_attachment_artifact_id TEXT,
+          PRIMARY KEY (tenant_id, decision_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_application_review_decisions_job
+          ON application_review_decisions(tenant_id, job_key, decided_at DESC);
+
+        CREATE TABLE IF NOT EXISTS application_outcomes (
+          tenant_id     TEXT NOT NULL DEFAULT 'local',
+          outcome_id    TEXT NOT NULL,
+          job_key       TEXT NOT NULL,
+          kind          TEXT NOT NULL,
+          source        TEXT NOT NULL,
+          note          TEXT,
+          occurred_at   TEXT NOT NULL,
+          recorded_at   TEXT NOT NULL,
+          suggestion_id TEXT,
+          evidence_id   TEXT,
+          created_by    TEXT NOT NULL DEFAULT 'user',
+          PRIMARY KEY (tenant_id, outcome_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_application_outcomes_job
+          ON application_outcomes(tenant_id, job_key, occurred_at DESC, recorded_at DESC);
+
+        CREATE TABLE IF NOT EXISTS application_email_evidence (
+          tenant_id            TEXT NOT NULL DEFAULT 'local',
+          evidence_id          TEXT NOT NULL,
+          job_key              TEXT NOT NULL,
+          provider             TEXT NOT NULL DEFAULT 'gmail',
+          provider_message_id  TEXT NOT NULL,
+          provider_thread_id   TEXT,
+          from_address         TEXT,
+          to_addresses_json    TEXT NOT NULL DEFAULT '[]',
+          subject              TEXT,
+          snippet              TEXT,
+          received_at          TEXT,
+          linked_at            TEXT NOT NULL,
+          link_confidence      REAL NOT NULL DEFAULT 0,
+          link_signals_json    TEXT NOT NULL DEFAULT '[]',
+          body_text            TEXT,
+          body_sha256          TEXT,
+          body_stored_at       TEXT,
+          PRIMARY KEY (tenant_id, evidence_id),
+          UNIQUE (tenant_id, provider, provider_message_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_application_email_evidence_job
+          ON application_email_evidence(tenant_id, job_key, received_at DESC);
+
+        CREATE TABLE IF NOT EXISTS application_outcome_suggestions (
+          tenant_id          TEXT NOT NULL DEFAULT 'local',
+          suggestion_id      TEXT NOT NULL,
+          job_key            TEXT NOT NULL,
+          evidence_id        TEXT,
+          suggested_kind     TEXT NOT NULL,
+          confidence         REAL NOT NULL DEFAULT 0,
+          rationale          TEXT NOT NULL DEFAULT '',
+          status             TEXT NOT NULL DEFAULT 'pending',
+          created_at         TEXT NOT NULL,
+          decided_at         TEXT,
+          decision           TEXT,
+          decision_reason    TEXT,
+          decided_outcome_id TEXT,
+          PRIMARY KEY (tenant_id, suggestion_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_job
+          ON application_outcome_suggestions(tenant_id, job_key, status, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_status
+          ON application_outcome_suggestions(tenant_id, status, created_at DESC);
+        """
+    )
+    _ensure_columns(
+        conn,
+        "application_review_decisions",
+        {
+            "materials_generation": "INTEGER",
+            "profile_version": "INTEGER",
+            "application_url": "TEXT",
+            "partial_override_run_id": "TEXT",
+            "email_recipient": "TEXT",
+            "email_attachment_artifact_id": "TEXT",
+        },
+    )
+
+
+
+def _columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
+    return {
+        row["name"] if isinstance(row, sqlite3.Row) else row[1]
+        for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+    }
+
+
+def _ensure_columns(
+    conn: sqlite3.Connection,
+    table_name: str,
+    additions: dict[str, str],
+) -> None:
+    columns = _columns(conn, table_name)
+    for column, definition in additions.items():
+        if column not in columns:
+            conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column} {definition}")


### PR DESCRIPTION
Application URLs still had two storage authorities: canonical enrichment and the legacy job column. Exact schema v10 transfers legacy-only values into enrichment, retains differing historical URLs as tenant-scoped lookup aliases, and removes `jobs.application_url`. Existing canonical targets win, shared application endpoints cannot select an arbitrary job, and both projection runtimes reconcile preserved caches without reviving retired targets.

The native stopped-runtime update supports exact v9 and the existing v6/v7/v8 upgrade chains, with paired JobCtrl/Temporal backups, exact transfer and reference verification, private candidate sealing, and rollback. Runtime readers/writers, approval validation, discovery, Gmail feedback, and current-schema fixtures now use canonical enrichment. The storage documentation includes the reader/writer inventory and migration contract.

Validation includes 886 API tests, 4,005 Python tests, full Go race tests, cross-runtime URL/projection fixtures, corruption and paired-recovery probes, and independent review/QA. The complete owned browser matrix passes 95 tests (10 opt-in skips), including the Jobs-to-Apply Review flow and fixture preservation; all migration and simulated application checks use synthetic data. No real installation was migrated or application submitted.

Fixes #891.
